### PR TITLE
fix(creator,player): pre-bundle ultimatedarktower so noble stays lazy

### DIFF
--- a/apps/creator/vite.config.ts
+++ b/apps/creator/vite.config.ts
@@ -20,7 +20,13 @@ export default defineConfig({
     dedupe: ['react', 'react-dom', 'three', 'gsap', '@dimforge/rapier3d-compat'],
   },
   optimizeDeps: {
-    include: ['@udtc/engine', '@udtc/schema', '@udtc/adapters'],
+    // `ultimatedarktower` must be pre-bundled explicitly (as apps/digital does). Without it, the
+    // CJS entry the alias above points at is processed by Vite's ESM pipeline, which hoists UDT's
+    // optional `require('@stoprocent/noble')` (Node-only BLE, guarded by a try/catch in
+    // NodeBluetoothAdapter) into an eager import — noble then runs `os.platform()` at module init
+    // and takes the whole app down with "os.platform is not a function". esbuild's dep optimizer
+    // keeps that require lazy. Pre-existing on a cold `.vite` cache; see PR notes.
+    include: ['@udtc/engine', '@udtc/schema', '@udtc/adapters', 'ultimatedarktower'],
   },
   server: {
     port: 5173,

--- a/apps/player/vite.config.ts
+++ b/apps/player/vite.config.ts
@@ -20,7 +20,13 @@ export default defineConfig({
     dedupe: ['react', 'react-dom', 'three', 'gsap', '@dimforge/rapier3d-compat'],
   },
   optimizeDeps: {
-    include: ['@udtc/engine', '@udtc/schema', '@udtc/adapters'],
+    // `ultimatedarktower` must be pre-bundled explicitly (as apps/digital does). Without it, the
+    // CJS entry the alias above points at is processed by Vite's ESM pipeline, which hoists UDT's
+    // optional `require('@stoprocent/noble')` (Node-only BLE, guarded by a try/catch in
+    // NodeBluetoothAdapter) into an eager import — noble then runs `os.platform()` at module init
+    // and takes the whole app down with "os.platform is not a function". esbuild's dep optimizer
+    // keeps that require lazy. Pre-existing on a cold `.vite` cache; see PR notes.
+    include: ['@udtc/engine', '@udtc/schema', '@udtc/adapters', 'ultimatedarktower'],
   },
   server: {
     port: 5174,


### PR DESCRIPTION
## The bug

`apps/creator` and `apps/player` fail to boot on a **cold `.vite` cache** — blank page, and one console error:

```
Uncaught TypeError: os.platform is not a function
```

Pre-existing on `main`; not introduced by any in-flight work.

## Cause

Both apps alias `ultimatedarktower` to its CJS entry (the ESM entry ships a Node-only `createRequire` banner that throws in the browser), but neither listed it in `optimizeDeps.include`. The un-pre-bundled CJS entry then goes through Vite's ESM pipeline, which **hoists** core's optional `require('@stoprocent/noble')` into an eager static import.

That hoist defeats *both* guards wrapping the require in `packages/core/src/adapters/NodeBluetoothAdapter.ts`:

```ts
let noble: Noble | undefined;
try {
  if (typeof process !== 'undefined' && process.versions?.node) {
    noble = require('@stoprocent/noble') as unknown as Noble;
  }
} catch {
  // not installed - will fail on adapter usage
}
```

A hoisted import runs before the `process.versions?.node` check can gate it, and outside the `try`/`catch` that would have swallowed it. noble initializes in the browser, calls `os.platform()` against Vite's `os` shim, and takes the page down.

esbuild's dep optimizer keeps that `require` lazy — which is why **`apps/digital` never hit this**: it has always pre-bundled UDT explicitly. This just mirrors digital.

## The fix

One line per app — add `'ultimatedarktower'` to `optimizeDeps.include`, plus a comment explaining why it must stay there.

## Verification

Done in a clean detached worktree at this commit (fresh `pnpm install` + full `pnpm build`), toggling *only* these lines with a cold cache each time:

| Config | Result |
| --- | --- |
| With fix — creator | Mounts fully; no `os.platform` error |
| With fix — player | Mounts fully; zero console errors |
| Fix reverted — creator | `TypeError: os.platform is not a function`; blank page |

The revert reproduces the failure in the same worktree, so these two lines are unambiguously what fix it.

`pnpm build`, Prettier, and ESLint all pass. No changeset — both apps are `private: true`.

## Note

Only reproduces on a **cold** `.vite` cache, so a warm dev server hides it. Worth knowing if this looks unreproducible locally.