### PR TITLE
feat(creator): custom game boards — author in Creator, play in Player

### DIFF
--- a/.changeset/curly-donuts-brake.md
+++ b/.changeset/curly-donuts-brake.md
@@ -1,0 +1,21 @@
+---
+'ultimatedarktowerboard': minor
+---
+
+Add `BoardDefinition` injection so hosts can render a board this package doesn't ship (custom
+game boards authored in the Creator app).
+
+- New `board?: BoardDefinition` option on `BoardMap2D`, `BoardReadout`, `Board3DPlugin` /
+  `attachBoard3D`, `createBoardTower3D`, `BoardRenderView`, `BoardStageView` and `mountBoardUI`,
+  plus `createDefaultBoardState(board?)`.
+- Exports `RTDT_BOARD_DEFINITION`, `resolveBoard`, `isBoardCalibrated`, `boardScaleFactor` and the
+  `BoardDefinition` / `BoardDefLocation` / `BoardDefImageInfo` / `ResolvedBoard` types.
+- Token geometry (tuned in image-space px against the 4096² board) now scales to a custom board's
+  image by `min(width, height) / 4096`.
+- 3D placement remaps a board's anchors onto the disc from its circle calibration; an uncalibrated
+  board is 2D-only (`setTowerEnabled(true)` warns and no-ops).
+
+Fully back-compatible: every new option is optional and defaults to the built-in Return to Dark
+Tower board, so existing consumers are unaffected — covered by an identity regression test
+(rendering with no `board` option is byte-identical to passing `RTDT_BOARD_DEFINITION`, and to a
+structural clone of it).

--- a/apps/creator/src/App.tsx
+++ b/apps/creator/src/App.tsx
@@ -4,6 +4,7 @@ import './App.css';
 import { CreatorCanvas } from './canvas';
 import { DeckBuilderView, DeckJsonPanel } from './decks';
 import { DungeonBuilderView, DungeonJsonPanel } from './dungeons';
+import { BoardBuilderView, BoardJsonPanel } from './boards';
 import { PalettePanel, InspectorPanel, ProblemsPanel, RecoveryDialog } from './editors';
 import { SimulatorPanel } from './simulator';
 import { useCreatorStore } from './store';
@@ -111,7 +112,7 @@ export default function App() {
           <PalettePanel />
         </div>
 
-        {/* Center: Canvas | Decks switcher */}
+        {/* Center: Canvas | Decks | Dungeons | Boards switcher */}
         <div className="creator-canvas">
           <div className="creator-center-tabs">
             <button
@@ -132,6 +133,12 @@ export default function App() {
             >
               Dungeons
             </button>
+            <button
+              className={`creator-bottom-tab ${centerView === 'boards' ? 'active' : ''}`}
+              onClick={() => setCenterView('boards')}
+            >
+              Boards
+            </button>
           </div>
           <div className="creator-center-content">
             {centerView === 'canvas' ? (
@@ -141,18 +148,22 @@ export default function App() {
               />
             ) : centerView === 'decks' ? (
               <DeckBuilderView />
+            ) : centerView === 'boards' ? (
+              <BoardBuilderView />
             ) : (
               <DungeonBuilderView />
             )}
           </div>
         </div>
 
-        {/* Right: Inspector (canvas) | Deck JSON (decks) | Dungeon JSON (dungeons) */}
+        {/* Right: Inspector (canvas) | Deck JSON (decks) | Dungeon JSON (dungeons) | Board JSON (boards) */}
         <div className="creator-inspector">
           {centerView === 'decks' ? (
             <DeckJsonPanel />
           ) : centerView === 'dungeons' ? (
             <DungeonJsonPanel />
+          ) : centerView === 'boards' ? (
+            <BoardJsonPanel />
           ) : (
             <InspectorPanel />
           )}

--- a/apps/creator/src/boards/BoardBuilderView.tsx
+++ b/apps/creator/src/boards/BoardBuilderView.tsx
@@ -1,0 +1,319 @@
+// BoardBuilderView — the first-class Board Designer (center 'Boards' view). 3-zone layout:
+// board list rail · map canvas · editor panel. Owns selection/mode and all edit→store wiring via
+// commitBoards + setActiveBoard.
+//
+// Supersedes packages/core/tools/location-marker for authoring CUSTOM boards; that standalone tool
+// remains the generator for the built-in RtDT board data (gen-board-data.mjs).
+
+import { useEffect, useState } from 'react';
+import type { CSSProperties } from 'react';
+import { useCreatorStore } from '../store';
+import { resizeAndEncode } from '../decks/imageUtils';
+import { ConfirmDialog } from '../components/ConfirmDialog';
+import { BoardListRail } from './BoardListRail';
+import { BoardMapCanvas } from './BoardMapCanvas';
+import type { BoardEditMode } from './BoardMapCanvas';
+import { BoardEditorPanel } from './BoardEditorPanel';
+import { buildRtdtPreset } from './presetRtdt';
+import {
+  BOARD_IMAGE_OPTS,
+  IMAGE_BUDGET_BYTES,
+  activeBoardId,
+  boardArtBytes,
+  boardImageKey,
+  boardsOf,
+  resolveImage,
+  smallBtn,
+  primaryBtn,
+  suggestAdjacency,
+  toggleAdjacency,
+} from './shared';
+import type { AnchorSlot, Board } from './shared';
+
+const MODES: Array<{ id: BoardEditMode; label: string }> = [
+  { id: 'locations', label: 'Locations' },
+  { id: 'anchors', label: 'Anchors' },
+  { id: 'adjacency', label: 'Adjacency' },
+  { id: 'calibrate', label: 'Calibrate' },
+];
+
+function emptyBoard(id: string): Board {
+  return {
+    id,
+    name: id,
+    imageInfo: { width: 2048, height: 2048 },
+    locations: [],
+    anchors: {},
+    adjacency: {},
+  };
+}
+
+/** True when setup.board holds a hand-authored inline boardState with real content. */
+function hasAuthoredBoardState(setup: Record<string, unknown> | undefined): boolean {
+  const board = setup?.board;
+  if (board === null || typeof board !== 'object' || Array.isArray(board)) return false;
+  const inline = (board as Record<string, unknown>).boardState;
+  if (inline === null || typeof inline !== 'object' || Array.isArray(inline)) return false;
+  const s = inline as Record<string, unknown>;
+  const home = s.home as Record<string, unknown> | undefined;
+  const buildings = s.buildings as unknown[] | undefined;
+  return Boolean(
+    (home && Object.keys(home).length > 0) || (Array.isArray(buildings) && buildings.length > 0),
+  );
+}
+
+export function BoardBuilderView() {
+  const schemaDoc = useCreatorStore((s) => s.schemaDoc);
+  const commitBoards = useCreatorStore((s) => s.commitBoards);
+  const setActiveBoard = useCreatorStore((s) => s.setActiveBoard);
+  const updateResourceImage = useCreatorStore((s) => s.updateResourceImage);
+  const setBoardSelection = useCreatorStore((s) => s.setBoardSelection);
+
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [mode, setMode] = useState<BoardEditMode>('locations');
+  const [activeSlot, setActiveSlot] = useState<AnchorSlot>('hero');
+  const [selectedLocation, setSelectedLocation] = useState<string | null>(null);
+  const [pendingDelete, setPendingDelete] = useState<string | null>(null);
+  const [pendingActivate, setPendingActivate] = useState<string | null>(null);
+
+  useEffect(() => {
+    setBoardSelection(selectedId);
+  }, [selectedId, setBoardSelection]);
+
+  if (!schemaDoc) {
+    return (
+      <div style={{ padding: 24, color: 'var(--c-text-muted)' }}>
+        Load a scenario to design boards.
+      </div>
+    );
+  }
+
+  const boards = boardsOf(schemaDoc);
+  const ids = Object.keys(boards);
+  const activeId = activeBoardId(schemaDoc);
+
+  // Keep selection valid & non-null whenever boards exist (adjust during render, as the
+  // dungeon/deck builders do).
+  const selectionValid = selectedId !== null && selectedId in boards;
+  if (!selectionValid) {
+    if (ids.length > 0) setSelectedId(ids[0]);
+    else if (selectedId !== null) setSelectedId(null);
+  }
+
+  const selected = selectedId ? boards[selectedId] : undefined;
+  const commit = (next: Board) => commitBoards({ ...boards, [next.id]: next });
+
+  const addBoard = (id: string, board: Board) => {
+    commitBoards({ ...boards, [id]: board });
+    setSelectedId(id);
+    setSelectedLocation(null);
+  };
+
+  const removeBoard = (id: string) => {
+    const next = { ...boards };
+    delete next[id];
+    // commitBoards restores the implicit RtDT board if this was the active one.
+    commitBoards(next);
+    updateResourceImage(boardImageKey(id), null);
+    setPendingDelete(null);
+    if (selectedId === id) setSelectedId(null);
+  };
+
+  const uploadArt = async (file: File) => {
+    if (!selected) return;
+    try {
+      const url = await resizeAndEncode(file, BOARD_IMAGE_OPTS);
+      const key = boardImageKey(selected.id);
+      // The stored art defines the image space the anchors are normalized against, so record
+      // its real dimensions — the renderer scales token geometry from them.
+      const dims = await imageDims(url);
+      updateResourceImage(key, url);
+      commit({
+        ...selected,
+        imageRef: key,
+        imageInfo: { ...selected.imageInfo, width: dims.width, height: dims.height },
+      });
+    } catch {
+      // upload failure is non-fatal; the board keeps its previous art
+    }
+  };
+
+  /** "Use in game" — guarded, because {boardRef} and an inline {boardState} are exclusive. */
+  const toggleActive = () => {
+    if (!selected) return;
+    if (activeId === selected.id) {
+      setActiveBoard(null);
+      return;
+    }
+    if (hasAuthoredBoardState(schemaDoc.setup as Record<string, unknown>)) {
+      setPendingActivate(selected.id);
+      return;
+    }
+    setActiveBoard(selected.id);
+  };
+
+  const artBytes = boardArtBytes(schemaDoc);
+  const overBudget = artBytes > IMAGE_BUDGET_BYTES * 0.8;
+  const artedBoards = ids.filter((id) => boards[id].imageRef).length;
+
+  return (
+    <div style={layout}>
+      <BoardListRail
+        ids={ids}
+        selectedId={selectedId}
+        activeId={activeId}
+        onSelect={(id) => {
+          setSelectedId(id);
+          setSelectedLocation(null);
+        }}
+        onAdd={(id) => addBoard(id, emptyBoard(id))}
+        onClonePreset={(id) => addBoard(id, buildRtdtPreset(id))}
+        onRemove={(id) => setPendingDelete(id)}
+      />
+
+      <div style={center}>
+        <div style={toolbar}>
+          {MODES.map((m) => (
+            <button
+              key={m.id}
+              style={m.id === mode ? primaryBtn : smallBtn}
+              onClick={() => setMode(m.id)}
+            >
+              {m.label}
+            </button>
+          ))}
+          <div style={{ flex: 1 }} />
+          {artedBoards > 1 && (
+            <span
+              style={{ fontSize: 11, color: overBudget ? '#f87171' : 'var(--c-text-muted)' }}
+              title="library.boards is a map — every board's art shares one ~5 MB draft budget"
+            >
+              board art {(artBytes / 1_000_000).toFixed(1)} MB /{' '}
+              {(IMAGE_BUDGET_BYTES / 1_000_000).toFixed(0)} MB
+              {overBudget ? ' — autosave may fail' : ''}
+            </span>
+          )}
+        </div>
+
+        {selected ? (
+          <BoardMapCanvas
+            board={selected}
+            imageUrl={resolveImage(schemaDoc, selected.imageRef)}
+            mode={mode}
+            selectedLocation={selectedLocation}
+            activeSlot={activeSlot}
+            adjacencyFrom={mode === 'adjacency' ? selectedLocation : null}
+            onSelectLocation={setSelectedLocation}
+            onPlaceAnchor={(name, slot, at) =>
+              commit({
+                ...selected,
+                anchors: {
+                  ...(selected.anchors ?? {}),
+                  [name]: { ...(selected.anchors?.[name] ?? {}), [slot]: at },
+                },
+              })
+            }
+            onToggleAdjacency={(a, b) =>
+              commit({ ...selected, adjacency: toggleAdjacency(selected, a, b) })
+            }
+            onCalibrate={(patch) =>
+              commit({ ...selected, imageInfo: { ...selected.imageInfo, ...patch } })
+            }
+          />
+        ) : (
+          <div style={{ padding: 24, color: 'var(--c-text-muted)', fontSize: 13 }}>
+            No board selected. Clone the RtDT preset to start from the built-in board, or add an
+            empty one.
+          </div>
+        )}
+      </div>
+
+      {selected && (
+        <BoardEditorPanel
+          board={selected}
+          isActive={activeId === selected.id}
+          mode={mode}
+          activeSlot={activeSlot}
+          selectedLocation={selectedLocation}
+          onChange={commit}
+          onSelectLocation={setSelectedLocation}
+          onActiveSlot={setActiveSlot}
+          onUploadArt={uploadArt}
+          onToggleActive={toggleActive}
+          onSuggestAdjacency={() => commit({ ...selected, adjacency: suggestAdjacency(selected) })}
+        />
+      )}
+
+      {pendingDelete && (
+        <ConfirmDialog
+          title="Delete board"
+          message={
+            <>
+              Delete <strong>{pendingDelete}</strong> and its art?
+              {pendingDelete === activeId && (
+                <> The game will go back to the built-in Return to Dark Tower board.</>
+              )}
+            </>
+          }
+          onConfirm={() => removeBoard(pendingDelete)}
+          onCancel={() => setPendingDelete(null)}
+        />
+      )}
+
+      {pendingActivate && (
+        <ConfirmDialog
+          title="Replace the authored board setup?"
+          message={
+            <>
+              This scenario has a hand-authored <code>setup.board.boardState</code> (hero start
+              locations and the buildings registry). A custom board replaces it — the two are
+              mutually exclusive.
+              <br />
+              <br />
+              Switching back to the built-in board in this session restores it, but that stash is
+              not saved to the file.
+            </>
+          }
+          confirmLabel="Use custom board"
+          onConfirm={() => {
+            setActiveBoard(pendingActivate);
+            setPendingActivate(null);
+          }}
+          onCancel={() => setPendingActivate(null)}
+        />
+      )}
+    </div>
+  );
+}
+
+/** Natural dimensions of an encoded data URL — the image space anchors are normalized against. */
+function imageDims(url: string): Promise<{ width: number; height: number }> {
+  return new Promise((resolve) => {
+    const img = new Image();
+    img.onload = () => resolve({ width: img.naturalWidth, height: img.naturalHeight });
+    img.onerror = () => resolve({ width: 2048, height: 2048 });
+    img.src = url;
+  });
+}
+
+const layout: CSSProperties = {
+  display: 'flex',
+  height: '100%',
+  minHeight: 0,
+  overflow: 'hidden',
+};
+
+const center: CSSProperties = {
+  flex: 1,
+  minWidth: 0,
+  display: 'flex',
+  flexDirection: 'column',
+};
+
+const toolbar: CSSProperties = {
+  display: 'flex',
+  gap: 4,
+  alignItems: 'center',
+  padding: 8,
+  borderBottom: '1px solid var(--c-border)',
+};

--- a/apps/creator/src/boards/BoardEditorPanel.tsx
+++ b/apps/creator/src/boards/BoardEditorPanel.tsx
@@ -1,0 +1,386 @@
+// BoardEditorPanel — the Board Designer's right-hand editor: identity, art, calibration, the
+// locations table, and the validation summary.
+//
+// Renaming a location remaps its anchors + adjacency keys in the SAME commit, so the board never
+// lands in a state its own validation rejects. Graph-node props that referenced the old name are
+// deliberately NOT rewritten — L2 surfaces those as dangling refs; the panel hints at it.
+
+import { useRef } from 'react';
+import type { CSSProperties } from 'react';
+import {
+  ANCHOR_SLOTS,
+  BUILDING_TYPES,
+  KINGDOMS,
+  TERRAIN_SUGGESTIONS,
+  dangerIconBtn,
+  inputStyle,
+  isCalibrated,
+  labelStyle,
+  primaryBtn,
+  smallBtn,
+  validateBoard,
+} from './shared';
+import type {
+  AnchorSlot,
+  Board,
+  BoardLocation,
+  BuildingType,
+  Kingdom,
+  LocationAnchors,
+} from './shared';
+import type { BoardEditMode } from './BoardMapCanvas';
+
+export interface BoardEditorPanelProps {
+  board: Board;
+  isActive: boolean;
+  mode: BoardEditMode;
+  activeSlot: AnchorSlot;
+  selectedLocation: string | null;
+  onChange: (next: Board) => void;
+  onSelectLocation: (name: string | null) => void;
+  onActiveSlot: (slot: AnchorSlot) => void;
+  onUploadArt: (file: File) => void;
+  onToggleActive: () => void;
+  onSuggestAdjacency: () => void;
+}
+
+export function BoardEditorPanel({
+  board,
+  isActive,
+  mode,
+  activeSlot,
+  selectedLocation,
+  onChange,
+  onSelectLocation,
+  onActiveSlot,
+  onUploadArt,
+  onToggleActive,
+  onSuggestAdjacency,
+}: BoardEditorPanelProps) {
+  const fileRef = useRef<HTMLInputElement | null>(null);
+  const problems = validateBoard(board);
+  const errors = problems.filter((p) => p.level === 'error');
+  const warns = problems.filter((p) => p.level === 'warn');
+  const calibrated = isCalibrated(board.imageInfo);
+
+  const patchLocation = (index: number, patch: Partial<BoardLocation>): void => {
+    const locations = board.locations.map((l, i) => (i === index ? { ...l, ...patch } : l));
+    onChange({ ...board, locations });
+  };
+
+  /** Rename remaps anchors + adjacency keys/values in the same commit. */
+  const renameLocation = (index: number, nextName: string): void => {
+    const prev = board.locations[index].name;
+    if (prev === nextName) return;
+    const locations = board.locations.map((l, i) => (i === index ? { ...l, name: nextName } : l));
+
+    const anchors: Record<string, LocationAnchors> = {};
+    for (const [k, v] of Object.entries(board.anchors ?? {}))
+      anchors[k === prev ? nextName : k] = v;
+
+    const adjacency: Record<string, string[]> = {};
+    for (const [k, v] of Object.entries(board.adjacency ?? {})) {
+      adjacency[k === prev ? nextName : k] = v.map((n) => (n === prev ? nextName : n));
+    }
+
+    onChange({ ...board, locations, anchors, adjacency });
+    if (selectedLocation === prev) onSelectLocation(nextName);
+  };
+
+  const addLocation = (): void => {
+    let n = board.locations.length + 1;
+    let name = `Location ${n}`;
+    const taken = new Set(board.locations.map((l) => l.name));
+    while (taken.has(name)) name = `Location ${++n}`;
+    onChange({
+      ...board,
+      locations: [...board.locations, { name, kingdom: 'north', terrain: 'Grasslands' }],
+    });
+    onSelectLocation(name);
+  };
+
+  const removeLocation = (index: number): void => {
+    const name = board.locations[index].name;
+    const locations = board.locations.filter((_, i) => i !== index);
+    const anchors = { ...(board.anchors ?? {}) };
+    delete anchors[name];
+    const adjacency: Record<string, string[]> = {};
+    for (const [k, v] of Object.entries(board.adjacency ?? {})) {
+      if (k === name) continue;
+      const kept = v.filter((x) => x !== name);
+      if (kept.length > 0) adjacency[k] = kept;
+    }
+    onChange({ ...board, locations, anchors, adjacency });
+    if (selectedLocation === name) onSelectLocation(null);
+  };
+
+  return (
+    <div style={panel}>
+      <section style={section}>
+        <label style={labelStyle}>Name</label>
+        <input
+          style={inputStyle}
+          value={board.name}
+          onChange={(e) => onChange({ ...board, name: e.target.value })}
+        />
+        <div style={{ fontSize: 11, color: 'var(--c-text-muted)', marginTop: 4 }}>
+          id: <code>{board.id}</code>
+        </div>
+
+        <div style={{ display: 'flex', gap: 6, marginTop: 8, alignItems: 'center' }}>
+          <button style={isActive ? primaryBtn : smallBtn} onClick={onToggleActive}>
+            {isActive ? '✓ Used in game' : 'Use in game'}
+          </button>
+          <span style={{ fontSize: 11, color: calibrated ? '#4ade80' : 'var(--c-text-muted)' }}>
+            {calibrated ? '● 3D-ready' : '○ 2D only'}
+          </span>
+        </div>
+      </section>
+
+      <section style={section}>
+        <label style={labelStyle}>Board art</label>
+        <input
+          ref={fileRef}
+          type="file"
+          accept="image/*"
+          style={{ display: 'none' }}
+          onChange={(e) => {
+            const f = e.target.files?.[0];
+            if (f) onUploadArt(f);
+            e.target.value = '';
+          }}
+        />
+        <button style={smallBtn} onClick={() => fileRef.current?.click()}>
+          {board.imageRef ? 'Replace art…' : 'Upload art…'}
+        </button>
+        <div style={{ fontSize: 11, color: 'var(--c-text-muted)', marginTop: 4 }}>
+          {board.imageInfo.width}×{board.imageInfo.height}
+          {board.imageRef ? '' : ' · no art yet (renders blank)'}
+        </div>
+      </section>
+
+      {mode === 'calibrate' && (
+        <section style={section}>
+          <label style={labelStyle}>Calibration</label>
+          <div style={{ fontSize: 11, color: 'var(--c-text-muted)', marginBottom: 6 }}>
+            Fit the circle to the printed board. All four values are needed for the 3D view.
+          </div>
+          <NumberRow
+            label="North heading°"
+            value={board.imageInfo.northHeadingDegrees}
+            min={0}
+            max={359.9}
+            onChange={(v) =>
+              onChange({ ...board, imageInfo: { ...board.imageInfo, northHeadingDegrees: v } })
+            }
+          />
+          <div style={{ fontSize: 11, color: 'var(--c-text-muted)', marginTop: 6 }}>
+            centre {fmt(board.imageInfo.centerX)}, {fmt(board.imageInfo.centerY)} · radius{' '}
+            {fmt(board.imageInfo.radius)}
+          </div>
+        </section>
+      )}
+
+      {mode === 'anchors' && (
+        <section style={section}>
+          <label style={labelStyle}>Anchor slot</label>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4 }}>
+            {ANCHOR_SLOTS.map((slot) => (
+              <button
+                key={slot}
+                style={slot === activeSlot ? primaryBtn : smallBtn}
+                onClick={() => onActiveSlot(slot)}
+              >
+                {slot}
+              </button>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {mode === 'adjacency' && (
+        <section style={section}>
+          <div style={noteBox}>
+            <strong>Authoring aid — not enforced during play.</strong> Adjacency is saved with the
+            board and available to tools, but v1 does not validate hero movement against it.
+          </div>
+          <button style={smallBtn} onClick={onSuggestAdjacency}>
+            Suggest from proximity
+          </button>
+        </section>
+      )}
+
+      <section
+        style={{ ...section, flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}
+      >
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <label style={labelStyle}>Locations ({board.locations.length})</label>
+          <button style={smallBtn} onClick={addLocation}>
+            + Add
+          </button>
+        </div>
+        <div style={{ overflowY: 'auto', flex: 1, minHeight: 0 }}>
+          {board.locations.map((loc, i) => (
+            <div
+              key={i}
+              style={{
+                ...row,
+                outline:
+                  loc.name === selectedLocation ? '1px solid var(--c-accent, #38bdf8)' : 'none',
+              }}
+              onClick={() => onSelectLocation(loc.name)}
+            >
+              <input
+                style={{ ...inputStyle, flex: 2, minWidth: 0 }}
+                value={loc.name}
+                onChange={(e) => renameLocation(i, e.target.value)}
+              />
+              <select
+                style={{ ...inputStyle, flex: 1, minWidth: 0 }}
+                value={loc.kingdom}
+                onChange={(e) => patchLocation(i, { kingdom: e.target.value as Kingdom })}
+              >
+                {KINGDOMS.map((k) => (
+                  <option key={k} value={k}>
+                    {k}
+                  </option>
+                ))}
+              </select>
+              <input
+                style={{ ...inputStyle, flex: 1, minWidth: 0 }}
+                list="udt-terrains"
+                value={loc.terrain}
+                onChange={(e) => patchLocation(i, { terrain: e.target.value })}
+              />
+              <select
+                style={{ ...inputStyle, flex: 1, minWidth: 0 }}
+                value={loc.building ?? ''}
+                onChange={(e) =>
+                  patchLocation(i, {
+                    building: e.target.value ? (e.target.value as BuildingType) : undefined,
+                  })
+                }
+              >
+                <option value="">—</option>
+                {BUILDING_TYPES.map((b) => (
+                  <option key={b} value={b}>
+                    {b}
+                  </option>
+                ))}
+              </select>
+              <button
+                style={dangerIconBtn}
+                title="Remove location"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  removeLocation(i);
+                }}
+              >
+                ×
+              </button>
+            </div>
+          ))}
+        </div>
+        <datalist id="udt-terrains">
+          {TERRAIN_SUGGESTIONS.map((t) => (
+            <option key={t} value={t} />
+          ))}
+        </datalist>
+        <div style={{ fontSize: 11, color: 'var(--c-text-muted)', marginTop: 6 }}>
+          Renaming remaps anchors + adjacency. Graph nodes that referenced the old name are not
+          rewritten — the Problems panel will flag them.
+        </div>
+      </section>
+
+      <section style={section}>
+        <label style={labelStyle}>
+          Validation {errors.length === 0 ? '✓' : `— ${errors.length} error(s)`}
+        </label>
+        <div style={{ maxHeight: 120, overflowY: 'auto' }}>
+          {problems.length === 0 && (
+            <div style={{ fontSize: 11, color: '#4ade80' }}>No problems.</div>
+          )}
+          {errors.map((p, i) => (
+            <div key={`e${i}`} style={{ fontSize: 11, color: '#f87171' }}>
+              ✕ {p.message}
+            </div>
+          ))}
+          {warns.map((p, i) => (
+            <div key={`w${i}`} style={{ fontSize: 11, color: '#fbbf24' }}>
+              ⚠ {p.message}
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function NumberRow({
+  label,
+  value,
+  min,
+  max,
+  onChange,
+}: {
+  label: string;
+  value: number | undefined;
+  min: number;
+  max: number;
+  onChange: (v: number) => void;
+}) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+      <span style={{ fontSize: 11, flex: 1 }}>{label}</span>
+      <input
+        style={{ ...inputStyle, width: 80 }}
+        type="number"
+        min={min}
+        max={max}
+        step={0.1}
+        value={value ?? ''}
+        onChange={(e) => {
+          const v = Number(e.target.value);
+          if (Number.isFinite(v)) onChange(v);
+        }}
+      />
+    </div>
+  );
+}
+
+const fmt = (v: number | undefined): string => (typeof v === 'number' ? v.toFixed(3) : '—');
+
+const panel: CSSProperties = {
+  width: 340,
+  flexShrink: 0,
+  borderLeft: '1px solid var(--c-border)',
+  display: 'flex',
+  flexDirection: 'column',
+  overflowY: 'auto',
+  background: 'var(--c-surface-0)',
+};
+
+const section: CSSProperties = {
+  padding: 10,
+  borderBottom: '1px solid var(--c-border)',
+};
+
+const row: CSSProperties = {
+  display: 'flex',
+  gap: 4,
+  alignItems: 'center',
+  padding: '3px 2px',
+  borderRadius: 4,
+  cursor: 'pointer',
+};
+
+const noteBox: CSSProperties = {
+  fontSize: 11,
+  lineHeight: 1.45,
+  padding: 8,
+  marginBottom: 8,
+  borderRadius: 4,
+  border: '1px solid #fbbf24',
+  background: 'rgba(251,191,36,.08)',
+  color: 'var(--c-text)',
+};

--- a/apps/creator/src/boards/BoardJsonPanel.tsx
+++ b/apps/creator/src/boards/BoardJsonPanel.tsx
@@ -1,0 +1,51 @@
+// BoardJsonPanel — read-only JSON of the selected board, shown in the right sidebar while the
+// Boards view is active (mirrors DungeonJsonPanel). Selection is mirrored into the store by
+// BoardBuilderView (boardSelection); this component only reads it.
+
+import type { CSSProperties } from 'react';
+import { useCreatorStore } from '../store';
+import { boardsOf } from './shared';
+
+export function BoardJsonPanel() {
+  const schemaDoc = useCreatorStore((s) => s.schemaDoc);
+  const boardSelection = useCreatorStore((s) => s.boardSelection);
+  const board = boardSelection ? boardsOf(schemaDoc)[boardSelection] : undefined;
+
+  return (
+    <div style={wrap}>
+      <div style={header}>Board JSON</div>
+      {board ? (
+        <pre style={pre}>{JSON.stringify(board, null, 2)}</pre>
+      ) : (
+        <div style={{ padding: 12, fontSize: 12, color: 'var(--c-text-faint)' }}>
+          Select a board to view its JSON.
+        </div>
+      )}
+    </div>
+  );
+}
+
+const wrap: CSSProperties = {
+  height: '100%',
+  display: 'flex',
+  flexDirection: 'column',
+  minHeight: 0,
+};
+
+const header: CSSProperties = {
+  padding: '8px 10px',
+  fontSize: 12,
+  fontWeight: 600,
+  borderBottom: '1px solid var(--c-border)',
+};
+
+const pre: CSSProperties = {
+  margin: 0,
+  padding: 10,
+  fontSize: 10,
+  lineHeight: 1.45,
+  overflow: 'auto',
+  flex: 1,
+  minHeight: 0,
+  color: 'var(--c-text-muted)',
+};

--- a/apps/creator/src/boards/BoardListRail.tsx
+++ b/apps/creator/src/boards/BoardListRail.tsx
@@ -1,0 +1,150 @@
+// BoardListRail — the left rail of the board designer: the board list (library.boards) with add
+// (validated id) + delete + selection, plus "Clone RtDT preset". Mirrors DungeonListRail.
+
+import { useState } from 'react';
+import type { CSSProperties } from 'react';
+import { ID_RE, dangerIconBtn, inputStyle, primaryBtn, smallBtn } from './shared';
+
+export interface BoardListRailProps {
+  ids: string[];
+  selectedId: string | null;
+  activeId: string | null;
+  onSelect: (id: string) => void;
+  onAdd: (id: string) => void;
+  onClonePreset: (id: string) => void;
+  onRemove: (id: string) => void;
+}
+
+export function BoardListRail({
+  ids,
+  selectedId,
+  activeId,
+  onSelect,
+  onAdd,
+  onClonePreset,
+  onRemove,
+}: BoardListRailProps) {
+  const [newId, setNewId] = useState('');
+  const trimmed = newId.trim();
+  const valid = trimmed !== '' && ID_RE.test(trimmed) && !ids.includes(trimmed);
+
+  const freshPresetId = (): string => {
+    let id = 'rtdt-copy';
+    let n = 1;
+    while (ids.includes(id)) id = `rtdt-copy-${++n}`;
+    return id;
+  };
+
+  return (
+    <div style={rail}>
+      <div style={header}>Boards</div>
+
+      <div style={{ padding: 8, borderBottom: '1px solid var(--c-border)' }}>
+        <button style={primaryBtn} onClick={() => onClonePreset(freshPresetId())}>
+          Clone RtDT preset
+        </button>
+        <div style={{ fontSize: 11, color: 'var(--c-text-muted)', marginTop: 6, lineHeight: 1.4 }}>
+          A full copy of the built-in board — all 60 locations, anchors and adjacency, ready to
+          rename and re-art.
+        </div>
+      </div>
+
+      <div style={{ flex: 1, overflowY: 'auto' }}>
+        {ids.length === 0 && (
+          <div style={{ padding: 12, fontSize: 12, color: 'var(--c-text-faint)' }}>
+            No custom boards. The game uses the built-in Return to Dark Tower board.
+          </div>
+        )}
+        {ids.map((id) => (
+          <div
+            key={id}
+            style={{
+              ...item,
+              background: id === selectedId ? 'var(--c-surface-2)' : 'transparent',
+            }}
+            onClick={() => onSelect(id)}
+          >
+            <span style={{ flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis' }}>
+              {id}
+            </span>
+            {id === activeId && (
+              <span style={activeChip} title="Used in game">
+                in game
+              </span>
+            )}
+            <button
+              style={dangerIconBtn}
+              title="Delete board"
+              onClick={(e) => {
+                e.stopPropagation();
+                onRemove(id);
+              }}
+            >
+              ×
+            </button>
+          </div>
+        ))}
+      </div>
+
+      <div style={{ padding: 8, borderTop: '1px solid var(--c-border)' }}>
+        <input
+          style={{ ...inputStyle, width: '100%' }}
+          placeholder="new-board-id"
+          value={newId}
+          onChange={(e) => setNewId(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && valid) {
+              onAdd(trimmed);
+              setNewId('');
+            }
+          }}
+        />
+        <button
+          style={{ ...smallBtn, marginTop: 6, opacity: valid ? 1 : 0.5 }}
+          disabled={!valid}
+          onClick={() => {
+            if (!valid) return;
+            onAdd(trimmed);
+            setNewId('');
+          }}
+        >
+          + Add empty board
+        </button>
+      </div>
+    </div>
+  );
+}
+
+const rail: CSSProperties = {
+  width: 200,
+  flexShrink: 0,
+  borderRight: '1px solid var(--c-border)',
+  display: 'flex',
+  flexDirection: 'column',
+  background: 'var(--c-surface-0)',
+};
+
+const header: CSSProperties = {
+  padding: '8px 10px',
+  fontSize: 12,
+  fontWeight: 600,
+  borderBottom: '1px solid var(--c-border)',
+};
+
+const item: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 6,
+  padding: '6px 8px',
+  fontSize: 12,
+  cursor: 'pointer',
+};
+
+const activeChip: CSSProperties = {
+  fontSize: 10,
+  padding: '1px 5px',
+  borderRadius: 3,
+  background: 'var(--c-accent, #38bdf8)',
+  color: '#0b1220',
+  fontWeight: 600,
+};

--- a/apps/creator/src/boards/BoardMapCanvas.tsx
+++ b/apps/creator/src/boards/BoardMapCanvas.tsx
@@ -1,0 +1,345 @@
+// BoardMapCanvas — the board art with its anchors, adjacency graph and circle calibration
+// overlaid. Coordinates are normalized [0,1] against the image, matching `$defs/anchorPoint`
+// and `BOARD_ANCHORS`, so the annotation is resolution-independent.
+//
+// Zoom/pan is patterned on DungeonMapCanvas: wheel to zoom at the cursor, drag the background
+// to pan. Mode decides what a click does — see `BoardEditMode`.
+
+import { useRef, useState } from 'react';
+import type { CSSProperties } from 'react';
+import type { AnchorSlot, Board } from './shared';
+import { bfsDistance, locationPoint } from './shared';
+
+export type BoardEditMode = 'locations' | 'anchors' | 'adjacency' | 'calibrate';
+
+export interface BoardMapCanvasProps {
+  board: Board;
+  imageUrl?: string;
+  mode: BoardEditMode;
+  /** The location being edited (anchor placement targets this one). */
+  selectedLocation: string | null;
+  /** Which anchor slot `anchors` mode places. */
+  activeSlot: AnchorSlot;
+  /** Adjacency mode: the first-clicked endpoint, if any. */
+  adjacencyFrom: string | null;
+  onSelectLocation: (name: string | null) => void;
+  onPlaceAnchor: (name: string, slot: AnchorSlot, at: { x: number; y: number }) => void;
+  onToggleAdjacency: (a: string, b: string) => void;
+  onCalibrate: (patch: { centerX?: number; centerY?: number; radius?: number }) => void;
+}
+
+const KINGDOM_COLOR: Record<string, string> = {
+  north: '#60a5fa',
+  east: '#facc15',
+  south: '#4ade80',
+  west: '#f87171',
+};
+
+export function BoardMapCanvas({
+  board,
+  imageUrl,
+  mode,
+  selectedLocation,
+  activeSlot,
+  adjacencyFrom,
+  onSelectLocation,
+  onPlaceAnchor,
+  onToggleAdjacency,
+  onCalibrate,
+}: BoardMapCanvasProps) {
+  const svgRef = useRef<SVGSVGElement | null>(null);
+  const [zoom, setZoom] = useState(1);
+  const [pan, setPan] = useState({ x: 0, y: 0 });
+  const [panning, setPanning] = useState(false);
+  const dragRef = useRef<{ x: number; y: number; pan: { x: number; y: number } } | null>(null);
+  const calibDragRef = useRef<'center' | 'radius' | null>(null);
+
+  const { width, height } = board.imageInfo;
+
+  // Reset the view when the board changes, so a new board isn't inherited zoomed in on some
+  // spot from the last one. Tracked as render-phase state (the adjust-during-render pattern the
+  // deck/dungeon builders use) rather than an effect.
+  const [viewedBoardId, setViewedBoardId] = useState(board.id);
+  if (viewedBoardId !== board.id) {
+    setViewedBoardId(board.id);
+    setZoom(1);
+    setPan({ x: 0, y: 0 });
+  }
+
+  /** Client point → normalized [0,1] image coords. */
+  const toNorm = (clientX: number, clientY: number): { x: number; y: number } | null => {
+    const svg = svgRef.current;
+    if (!svg) return null;
+    const rect = svg.getBoundingClientRect();
+    // The viewBox maps 1:1 to the rect, so invert rect → viewBox → normalized.
+    const vx = ((clientX - rect.left) / rect.width) * (width / zoom) + pan.x;
+    const vy = ((clientY - rect.top) / rect.height) * (height / zoom) + pan.y;
+    return { x: clamp01(vx / width), y: clamp01(vy / height) };
+  };
+
+  const handleWheel = (e: React.WheelEvent) => {
+    e.preventDefault();
+    const next = clamp(zoom * (e.deltaY < 0 ? 1.15 : 1 / 1.15), 1, 12);
+    setZoom(next);
+  };
+
+  const handleBackgroundDown = (e: React.MouseEvent) => {
+    if (mode === 'calibrate' && e.shiftKey) return;
+    dragRef.current = { x: e.clientX, y: e.clientY, pan };
+    setPanning(true);
+  };
+
+  const handleMove = (e: React.MouseEvent) => {
+    if (calibDragRef.current) {
+      const p = toNorm(e.clientX, e.clientY);
+      if (!p) return;
+      if (calibDragRef.current === 'center') onCalibrate({ centerX: p.x, centerY: p.y });
+      else {
+        const cx = board.imageInfo.centerX ?? 0.5;
+        const cy = board.imageInfo.centerY ?? 0.5;
+        onCalibrate({ radius: clamp(Math.hypot(p.x - cx, p.y - cy), 0.01, 1) });
+      }
+      return;
+    }
+    const drag = dragRef.current;
+    if (!drag) return;
+    const svg = svgRef.current;
+    if (!svg) return;
+    const rect = svg.getBoundingClientRect();
+    const dx = ((e.clientX - drag.x) / rect.width) * (width / zoom);
+    const dy = ((e.clientY - drag.y) / rect.height) * (height / zoom);
+    setPan({ x: drag.pan.x - dx, y: drag.pan.y - dy });
+  };
+
+  const endDrag = () => {
+    dragRef.current = null;
+    calibDragRef.current = null;
+    setPanning(false);
+  };
+
+  const handleClick = (e: React.MouseEvent) => {
+    if (mode !== 'anchors' || !selectedLocation) return;
+    const p = toNorm(e.clientX, e.clientY);
+    if (p) onPlaceAnchor(selectedLocation, activeSlot, p);
+  };
+
+  const info = board.imageInfo;
+  const cx = (info.centerX ?? 0.5) * width;
+  const cy = (info.centerY ?? 0.5) * height;
+  const r = (info.radius ?? 0.5) * Math.min(width, height);
+  const dot = Math.max(width, height) / 140;
+
+  return (
+    <div style={wrap}>
+      <svg
+        ref={svgRef}
+        viewBox={`${pan.x} ${pan.y} ${width / zoom} ${height / zoom}`}
+        preserveAspectRatio="xMidYMid meet"
+        style={{ width: '100%', height: '100%', cursor: panning ? 'grabbing' : 'grab' }}
+        onWheel={handleWheel}
+        onMouseDown={handleBackgroundDown}
+        onMouseMove={handleMove}
+        onMouseUp={endDrag}
+        onMouseLeave={endDrag}
+        onClick={handleClick}
+      >
+        {imageUrl ? (
+          <image href={imageUrl} x={0} y={0} width={width} height={height} />
+        ) : (
+          <rect x={0} y={0} width={width} height={height} fill="var(--c-surface-2, #1f2937)" />
+        )}
+
+        {/* adjacency edges, under the anchors */}
+        {mode === 'adjacency' &&
+          adjacencyEdges(board).map(([a, b, pa, pb]) => (
+            <line
+              key={`${a}|${b}`}
+              x1={pa.x * width}
+              y1={pa.y * height}
+              x2={pb.x * width}
+              y2={pb.y * height}
+              stroke="#38bdf8"
+              strokeWidth={dot / 3}
+              opacity={0.85}
+            />
+          ))}
+
+        {/* calibration overlay */}
+        {mode === 'calibrate' && (
+          <>
+            <circle
+              cx={cx}
+              cy={cy}
+              r={r}
+              fill="none"
+              stroke="#fbbf24"
+              strokeWidth={dot / 2}
+              strokeDasharray={`${dot * 2} ${dot}`}
+            />
+            <circle
+              cx={cx}
+              cy={cy}
+              r={dot}
+              fill="#fbbf24"
+              style={{ cursor: 'move' }}
+              onMouseDown={(e) => {
+                e.stopPropagation();
+                calibDragRef.current = 'center';
+              }}
+            />
+            <circle
+              cx={cx + r}
+              cy={cy}
+              r={dot}
+              fill="#f97316"
+              style={{ cursor: 'ew-resize' }}
+              onMouseDown={(e) => {
+                e.stopPropagation();
+                calibDragRef.current = 'radius';
+              }}
+            />
+            {/* north heading indicator — a spoke from the center */}
+            {typeof info.northHeadingDegrees === 'number' && (
+              <line
+                x1={cx}
+                y1={cy}
+                x2={cx + r * Math.cos(((info.northHeadingDegrees - 90) * Math.PI) / 180)}
+                y2={cy + r * Math.sin(((info.northHeadingDegrees - 90) * Math.PI) / 180)}
+                stroke="#fbbf24"
+                strokeWidth={dot / 2}
+              />
+            )}
+          </>
+        )}
+
+        {/* location anchors */}
+        {board.locations.map((loc) => {
+          const slots = board.anchors?.[loc.name];
+          if (!slots) return null;
+          const isSelected = loc.name === selectedLocation;
+          const isFrom = loc.name === adjacencyFrom;
+          return Object.entries(slots).map(([slot, p]) => {
+            if (!p) return null;
+            const emphasize = isSelected && (mode !== 'anchors' || slot === activeSlot);
+            return (
+              <g key={`${loc.name}:${slot}`}>
+                <circle
+                  cx={p.x * width}
+                  cy={p.y * height}
+                  r={emphasize || isFrom ? dot * 1.5 : dot}
+                  fill={KINGDOM_COLOR[loc.kingdom] ?? '#94a3b8'}
+                  stroke={isFrom ? '#38bdf8' : emphasize ? '#fff' : 'rgba(0,0,0,.55)'}
+                  strokeWidth={dot / 2.5}
+                  opacity={slot === 'hero' || mode === 'anchors' ? 1 : 0.75}
+                  style={{ cursor: 'pointer' }}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    if (mode === 'adjacency') {
+                      if (adjacencyFrom && adjacencyFrom !== loc.name) {
+                        onToggleAdjacency(adjacencyFrom, loc.name);
+                        onSelectLocation(null);
+                      } else {
+                        onSelectLocation(loc.name);
+                      }
+                      return;
+                    }
+                    onSelectLocation(loc.name);
+                  }}
+                />
+                {emphasize && (
+                  <text
+                    x={p.x * width}
+                    y={p.y * height - dot * 2}
+                    textAnchor="middle"
+                    fontSize={dot * 2.6}
+                    fill="#fff"
+                    stroke="rgba(0,0,0,.7)"
+                    strokeWidth={dot / 4}
+                    paintOrder="stroke"
+                    style={{ pointerEvents: 'none' }}
+                  >
+                    {loc.name}
+                  </text>
+                )}
+              </g>
+            );
+          });
+        })}
+      </svg>
+
+      <div style={hint}>
+        {mode === 'anchors' && selectedLocation
+          ? `Click the map to place "${selectedLocation}" · ${activeSlot}`
+          : mode === 'anchors'
+            ? 'Pick a location to place its anchors'
+            : mode === 'adjacency'
+              ? adjacencyFrom
+                ? `Linking from "${adjacencyFrom}" — click another location (click it again to unlink)`
+                : 'Click two locations to link/unlink them'
+              : mode === 'calibrate'
+                ? 'Drag the centre dot and the radius handle to fit the board circle'
+                : 'Wheel to zoom · drag to pan'}
+        {mode === 'adjacency' && adjacencyFrom && (
+          <AdjacencyDistanceHint board={board} from={adjacencyFrom} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** Live BFS preview: how far the rest of the board is from the picked endpoint. */
+function AdjacencyDistanceHint({ board, from }: { board: Board; from: string }) {
+  const reachable = board.locations
+    .map((l) => ({ name: l.name, d: bfsDistance(board, from, l.name) }))
+    .filter((e) => e.d !== null && e.d > 0);
+  const unreachable = board.locations.length - 1 - reachable.length;
+  const max = reachable.reduce((m, e) => Math.max(m, e.d as number), 0);
+  return (
+    <span style={{ marginLeft: 10, opacity: 0.85 }}>
+      · reaches {reachable.length} location{reachable.length === 1 ? '' : 's'} (max {max} steps)
+      {unreachable > 0 ? `, ${unreachable} unreachable` : ''}
+    </span>
+  );
+}
+
+function adjacencyEdges(
+  board: Board,
+): Array<[string, string, { x: number; y: number }, { x: number; y: number }]> {
+  const out: Array<[string, string, { x: number; y: number }, { x: number; y: number }]> = [];
+  const seen = new Set<string>();
+  for (const [a, tos] of Object.entries(board.adjacency ?? {})) {
+    for (const b of tos) {
+      const key = a < b ? `${a}|${b}` : `${b}|${a}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      const pa = locationPoint(board, a);
+      const pb = locationPoint(board, b);
+      if (pa && pb) out.push([a, b, pa, pb]);
+    }
+  }
+  return out;
+}
+
+const clamp = (v: number, lo: number, hi: number): number => Math.min(hi, Math.max(lo, v));
+const clamp01 = (v: number): number => clamp(v, 0, 1);
+
+const wrap: CSSProperties = {
+  position: 'relative',
+  flex: 1,
+  minWidth: 0,
+  display: 'flex',
+  background: 'var(--c-surface-1)',
+  overflow: 'hidden',
+};
+
+const hint: CSSProperties = {
+  position: 'absolute',
+  left: 8,
+  bottom: 8,
+  padding: '4px 8px',
+  borderRadius: 4,
+  background: 'rgba(0,0,0,.6)',
+  color: '#e5e7eb',
+  fontSize: 11,
+  pointerEvents: 'none',
+};

--- a/apps/creator/src/boards/boards.test.ts
+++ b/apps/creator/src/boards/boards.test.ts
@@ -1,0 +1,293 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import Ajv from 'ajv/dist/2020';
+import addFormats from 'ajv-formats';
+import { scenarioSchema } from '@udtc/schema';
+import { useCreatorStore } from '../store';
+import { buildRtdtPreset } from './presetRtdt';
+import { activeBoardId, boardsOf, suggestAdjacency, bfsDistance, validateBoard } from './shared';
+import type { Board } from './shared';
+import { activeBoardLocationNames } from './vocabulary';
+import { scaffoldScenario } from '../utils/scaffold';
+import type { ScenarioDoc } from '../types';
+
+function scaffold(): ScenarioDoc {
+  return scaffoldScenario({
+    title: 'Board test',
+    designer: 'Test',
+    mode: 'coop',
+    difficultyProfile: 'heroic',
+    skullSupply: 30,
+    monthEndMin: 5,
+    monthEndMax: 8,
+  });
+}
+
+function load(doc: ScenarioDoc): void {
+  useCreatorStore.getState().loadScenario(doc, false);
+}
+
+const store = () => useCreatorStore.getState();
+
+beforeEach(() => {
+  useCreatorStore.getState().clearScenario();
+});
+
+describe('buildRtdtPreset', () => {
+  it('clones the built-in board with all 60 locations and its calibration', () => {
+    const preset = buildRtdtPreset('rtdt-copy');
+    expect(preset.id).toBe('rtdt-copy');
+    expect(preset.locations).toHaveLength(60);
+    expect(preset.imageInfo).toEqual({
+      width: 4096,
+      height: 4096,
+      centerX: 0.5,
+      centerY: 0.5,
+      radius: 0.5,
+      northHeadingDegrees: 135,
+    });
+  });
+
+  it('LOWERCASES building types — core says Citadel, the schema enum says citadel', () => {
+    const preset = buildRtdtPreset('rtdt-copy');
+    const buildings = preset.locations.map((l) => l.building).filter(Boolean);
+    expect(buildings.length).toBe(16);
+    for (const b of buildings) expect(b).toBe(b!.toLowerCase());
+    expect(preset.locations.find((l) => l.name === 'Radiant Mountains')?.building).toBe('citadel');
+  });
+
+  it('carries no imageRef (RtDT art is not bundled into documents)', () => {
+    expect(buildRtdtPreset('rtdt-copy').imageRef).toBeUndefined();
+  });
+
+  it('has no validation problems beyond the "no anchors"/calibration advisories', () => {
+    const errors = validateBoard(buildRtdtPreset('rtdt-copy')).filter((p) => p.level === 'error');
+    expect(errors).toEqual([]);
+  });
+
+  // THE preset trap: a spread of RTDT_BOARD_DEFINITION would fail L1 on capitalized buildings.
+  // Assert FULL schema validity, not just casing.
+  it('produces a document that passes L1 schema validation', () => {
+    const doc = scaffold() as unknown as Record<string, unknown>;
+    doc.schemaVersion = '0.4.6';
+    const preset = buildRtdtPreset('rtdt-copy');
+    (doc.library as Record<string, unknown>).boards = { 'rtdt-copy': preset };
+    (doc.setup as Record<string, unknown>).board = { boardRef: 'rtdt-copy' };
+
+    const ajv = new Ajv({ allErrors: true, strict: true });
+    addFormats(ajv);
+    const validate = ajv.compile(scenarioSchema);
+    const valid = validate(doc);
+    expect(validate.errors ?? []).toEqual([]);
+    expect(valid).toBe(true);
+  });
+});
+
+describe('store — commitBoards / setActiveBoard', () => {
+  it('writes and clears library.boards', () => {
+    load(scaffold());
+    const preset = buildRtdtPreset('b1');
+    store().commitBoards({ b1: preset });
+    expect(Object.keys(boardsOf(store().schemaDoc))).toEqual(['b1']);
+
+    store().commitBoards({});
+    expect((store().schemaDoc!.library as Record<string, unknown>).boards).toBeUndefined();
+  });
+
+  it('setActiveBoard points setup.board at the board, and null goes back to the default', () => {
+    load(scaffold());
+    store().commitBoards({ b1: buildRtdtPreset('b1') });
+
+    store().setActiveBoard('b1');
+    expect(activeBoardId(store().schemaDoc)).toBe('b1');
+    expect(store().schemaDoc!.setup.board).toEqual({ boardRef: 'b1' });
+
+    store().setActiveBoard(null);
+    expect(activeBoardId(store().schemaDoc)).toBeNull();
+  });
+
+  // THE Phase 5 trap: setup.board is a oneOf, so {boardRef} and {boardState} are mutually
+  // exclusive — a naive setActiveBoard silently destroys a hand-authored inline boardState.
+  it('ROUND-TRIP: an inline boardState survives custom-board → back', () => {
+    const doc = scaffold();
+    const authored = {
+      home: { north: 'Radiant Mountains' },
+      buildings: [{ kingdom: 'north', type: 'citadel', location: 'Radiant Mountains' }],
+    };
+    (doc.setup as Record<string, unknown>).board = { boardState: authored };
+    load(doc);
+
+    store().commitBoards({ b1: buildRtdtPreset('b1') });
+    store().setActiveBoard('b1');
+    expect(store().schemaDoc!.setup.board).toEqual({ boardRef: 'b1' });
+
+    store().setActiveBoard(null);
+    expect(store().schemaDoc!.setup.board).toEqual({ boardState: authored });
+  });
+
+  it('ROUND-TRIP: custom → another custom → back still restores the ORIGINAL boardState', () => {
+    const doc = scaffold();
+    const authored = { home: { north: 'Radiant Mountains' }, buildings: [] };
+    (doc.setup as Record<string, unknown>).board = { boardState: authored };
+    load(doc);
+
+    store().commitBoards({ b1: buildRtdtPreset('b1'), b2: buildRtdtPreset('b2') });
+    store().setActiveBoard('b1');
+    store().setActiveBoard('b2'); // must NOT overwrite the stash with {boardRef:'b1'}
+    store().setActiveBoard(null);
+    expect(store().schemaDoc!.setup.board).toEqual({ boardState: authored });
+  });
+
+  it('deleting the ACTIVE board restores the previous setup.board rather than dangling', () => {
+    const doc = scaffold();
+    const authored = { home: { north: 'Radiant Mountains' }, buildings: [] };
+    (doc.setup as Record<string, unknown>).board = { boardState: authored };
+    load(doc);
+
+    store().commitBoards({ b1: buildRtdtPreset('b1') });
+    store().setActiveBoard('b1');
+    store().commitBoards({}); // delete it while active
+
+    expect(activeBoardId(store().schemaDoc)).toBeNull();
+    expect(store().schemaDoc!.setup.board).toEqual({ boardState: authored });
+  });
+
+  it('deleting an INACTIVE board leaves setup.board alone', () => {
+    load(scaffold());
+    store().commitBoards({ b1: buildRtdtPreset('b1'), b2: buildRtdtPreset('b2') });
+    store().setActiveBoard('b1');
+    store().commitBoards({ b1: buildRtdtPreset('b1') }); // drop b2
+    expect(activeBoardId(store().schemaDoc)).toBe('b1');
+  });
+
+  it('scaffold: with no custom board, setup.board keeps its original branch', () => {
+    load(scaffold());
+    expect(activeBoardId(store().schemaDoc)).toBeNull();
+    expect(store().schemaDoc!.setup.board).toEqual({ boardStateRef: 'board-main' });
+  });
+});
+
+describe('vocabulary', () => {
+  it('falls back to the RtDT roster with no custom board', () => {
+    load(scaffold());
+    const names = activeBoardLocationNames(store().schemaDoc);
+    expect(names).toHaveLength(60);
+    expect(names).toContain('Broken Lands');
+  });
+
+  it('offers the custom board’s names once it is active', () => {
+    load(scaffold());
+    const board: Board = {
+      id: 'b1',
+      name: 'B1',
+      imageInfo: { width: 100, height: 100 },
+      locations: [
+        { name: 'Emberfall', kingdom: 'north', terrain: 'Ash' },
+        { name: 'Coldwatch', kingdom: 'north', terrain: 'Tundra' },
+      ],
+    };
+    store().commitBoards({ b1: board });
+    store().setActiveBoard('b1');
+    expect(activeBoardLocationNames(store().schemaDoc)).toEqual(['Emberfall', 'Coldwatch']);
+  });
+
+  it('falls back to RtDT for a dangling boardRef rather than offering an empty list', () => {
+    load(scaffold());
+    store().commitBoards({ b1: buildRtdtPreset('b1') });
+    store().setActiveBoard('b1');
+    // Force a dangle the UI would normally prevent.
+    const doc = store().schemaDoc!;
+    (doc.library as Record<string, unknown>).boards = {};
+    expect(activeBoardLocationNames(doc)).toHaveLength(60);
+  });
+
+  it('returns the RtDT roster for a null doc', () => {
+    expect(activeBoardLocationNames(null)).toHaveLength(60);
+  });
+});
+
+describe('adjacency helpers', () => {
+  const board: Board = {
+    id: 'b',
+    name: 'b',
+    imageInfo: { width: 100, height: 100 },
+    locations: [
+      { name: 'A', kingdom: 'north', terrain: 't' },
+      { name: 'B', kingdom: 'north', terrain: 't' },
+      { name: 'C', kingdom: 'north', terrain: 't' },
+      { name: 'D', kingdom: 'north', terrain: 't' },
+    ],
+    anchors: {
+      A: { hero: { x: 0.1, y: 0.1 } },
+      B: { hero: { x: 0.15, y: 0.1 } }, // within the default radius of A
+      C: { hero: { x: 0.9, y: 0.9 } },
+      D: { hero: { x: 0.95, y: 0.9 } }, // within the default radius of C
+    },
+    adjacency: { A: ['B'], B: ['A', 'C'], C: ['B'], D: [] },
+  };
+
+  it('bfsDistance walks the graph and reports unreachable as null', () => {
+    expect(bfsDistance(board, 'A', 'A')).toBe(0);
+    expect(bfsDistance(board, 'A', 'B')).toBe(1);
+    expect(bfsDistance(board, 'A', 'C')).toBe(2);
+    expect(bfsDistance(board, 'A', 'D')).toBeNull();
+  });
+
+  it('suggestAdjacency links only nearby anchors, symmetrically', () => {
+    const adj = suggestAdjacency(board);
+    expect(adj.A).toEqual(['B']);
+    expect(adj.B).toEqual(['A']);
+    expect(adj.C).toEqual(['D']);
+    expect(adj.D).toEqual(['C']);
+  });
+});
+
+describe('validateBoard', () => {
+  const base: Board = {
+    id: 'b',
+    name: 'B',
+    imageInfo: { width: 100, height: 100 },
+    locations: [{ name: 'A', kingdom: 'north', terrain: 't', building: 'citadel' }],
+    anchors: { A: { hero: { x: 0.1, y: 0.1 } } },
+  };
+
+  it('flags asymmetric adjacency as an error', () => {
+    const problems = validateBoard({ ...base, adjacency: { A: ['A'] } });
+    // A→A is symmetric by definition; use a real asymmetry instead.
+    expect(problems.some((p) => p.level === 'error' && p.message.includes('not symmetric'))).toBe(
+      false,
+    );
+
+    const two: Board = {
+      ...base,
+      locations: [...base.locations, { name: 'B', kingdom: 'north', terrain: 't' }],
+      adjacency: { A: ['B'] },
+    };
+    expect(
+      validateBoard(two).some((p) => p.level === 'error' && p.message.includes('not symmetric')),
+    ).toBe(true);
+  });
+
+  it('flags duplicate names and anchors that name no location', () => {
+    const dup: Board = {
+      ...base,
+      locations: [...base.locations, { name: 'A', kingdom: 'south', terrain: 't' }],
+    };
+    expect(validateBoard(dup).some((p) => p.message.includes('duplicate location name'))).toBe(
+      true,
+    );
+
+    const badAnchor: Board = { ...base, anchors: { Nowhere: { hero: { x: 0, y: 0 } } } };
+    expect(validateBoard(badAnchor).some((p) => p.message.includes('is not a location'))).toBe(
+      true,
+    );
+  });
+
+  it('warns (not errors) about an uncalibrated board', () => {
+    const p = validateBoard(base).find((x) => x.message.includes('not calibrated'));
+    expect(p?.level).toBe('warn');
+  });
+
+  it('reports no errors for the RtDT preset', () => {
+    expect(validateBoard(buildRtdtPreset('x')).filter((p) => p.level === 'error')).toEqual([]);
+  });
+});

--- a/apps/creator/src/boards/index.ts
+++ b/apps/creator/src/boards/index.ts
@@ -1,0 +1,2 @@
+export { BoardBuilderView } from './BoardBuilderView';
+export { BoardJsonPanel } from './BoardJsonPanel';

--- a/apps/creator/src/boards/presetRtdt.ts
+++ b/apps/creator/src/boards/presetRtdt.ts
@@ -1,0 +1,69 @@
+// The built-in Return to Dark Tower board, as a cloneable editor preset.
+//
+// TRAP — this cannot be a spread of `RTDT_BOARD_DEFINITION`. That definition keeps core's
+// CAPITALIZED building names ('Citadel'), because the board renderers only test `building` for
+// truthiness. The scenario schema's `$defs/buildingType` is a CLOSED LOWERCASE enum, so a spread
+// clone fails L1 validation. Every `building` must go through `.toLowerCase()` here.
+// (`terrain` is an open string in the schema, so 'Grasslands' passes through as-is.)
+//
+// No `imageRef`: the RtDT art is not bundled into scenario documents. A clone renders on the
+// player's own copy of the board image; the author can upload their own art to override it.
+
+// RtDT data comes from @udtc/adapters' reference layer, NOT a direct import of
+// `ultimatedarktower`/`ultimatedarktowerboard`. See the note in ./vocabulary.ts — importing either
+// here pulls UDT's Node-only BLE stack into the browser bundle and the app dies at load.
+import { getUDTReferenceLayer } from '@udtc/adapters';
+import type { Board, BuildingType, Kingdom, LocationAnchors } from './shared';
+import { BUILDING_TYPES } from './shared';
+
+function toBuildingType(raw: string | undefined): BuildingType | undefined {
+  if (!raw) return undefined;
+  const lowered = raw.toLowerCase();
+  return (BUILDING_TYPES as readonly string[]).includes(lowered)
+    ? (lowered as BuildingType)
+    : undefined;
+}
+
+/** A deep clone of the built-in RtDT board under `id`, schema-valid and 3D-ready. */
+export function buildRtdtPreset(id: string): Board {
+  const udt = getUDTReferenceLayer();
+  const locations = udt.boardLocations.map((l) => {
+    const building = toBuildingType(l.building);
+    return {
+      name: l.name,
+      kingdom: l.kingdom as Kingdom,
+      terrain: String(l.terrain),
+      ...(building ? { building } : {}),
+    };
+  });
+
+  const anchors: Record<string, LocationAnchors> = {};
+  for (const [name, slots] of Object.entries(udt.boardAnchors)) {
+    const copy: LocationAnchors = {};
+    for (const [slot, point] of Object.entries(slots)) {
+      if (point) copy[slot as keyof LocationAnchors] = { x: point.x, y: point.y };
+    }
+    anchors[name] = copy;
+  }
+
+  const adjacency: Record<string, string[]> = {};
+  for (const [name, neighbours] of Object.entries(udt.boardAdjacency)) {
+    adjacency[name] = [...neighbours];
+  }
+
+  return {
+    id,
+    name: 'Return to Dark Tower (copy)',
+    imageInfo: {
+      width: udt.boardImageInfo.width,
+      height: udt.boardImageInfo.height,
+      centerX: udt.boardImageInfo.centerX,
+      centerY: udt.boardImageInfo.centerY,
+      radius: udt.boardImageInfo.radius,
+      northHeadingDegrees: udt.boardImageInfo.northHeadingDegrees,
+    },
+    locations,
+    anchors,
+    adjacency,
+  };
+}

--- a/apps/creator/src/boards/shared.ts
+++ b/apps/creator/src/boards/shared.ts
@@ -1,0 +1,279 @@
+// Board Designer — shared types + pure helpers. Mirrors `../dungeons/shared.ts`.
+//
+// The `Board` types here mirror `$defs/boardDef` in the scenario schema (0.4.6); keep them in
+// step with it. Styling/limit helpers are reused from the dungeon module rather than re-declared.
+
+import type { ScenarioDoc } from '../types';
+
+export { imagesOf, resolveImage, byteLen, IMAGE_BUDGET_BYTES } from '../dungeons/shared';
+export {
+  inputStyle,
+  smallBtn,
+  primaryBtn,
+  dangerBtn,
+  dangerIconBtn,
+  labelStyle,
+} from '../dungeons/shared';
+
+export const ID_RE = /^[a-z0-9]+(?:[-_][a-z0-9]+)*$/;
+
+export const KINGDOMS = ['north', 'south', 'east', 'west'] as const;
+export type Kingdom = (typeof KINGDOMS)[number];
+
+/** The schema's closed lowercase enum ($defs/buildingType). */
+export const BUILDING_TYPES = ['citadel', 'sanctuary', 'village', 'bazaar'] as const;
+export type BuildingType = (typeof BUILDING_TYPES)[number];
+
+/** RtDT's own six terrains — suggestions only; `terrain` is an open string in the schema. */
+export const TERRAIN_SUGGESTIONS = [
+  'Hills',
+  'Lake',
+  'Desert',
+  'Mountains',
+  'Grasslands',
+  'Forest',
+] as const;
+
+export const ANCHOR_SLOTS = ['building', 'skull', 'hero', 'foe', 'marker'] as const;
+export type AnchorSlot = (typeof ANCHOR_SLOTS)[number];
+
+export type AnchorPoint = { x: number; y: number };
+export type LocationAnchors = Partial<Record<AnchorSlot, AnchorPoint>>;
+
+export type BoardLocation = {
+  name: string;
+  kingdom: Kingdom;
+  terrain: string;
+  building?: BuildingType;
+};
+
+export type BoardImageInfo = {
+  width: number;
+  height: number;
+  centerX?: number;
+  centerY?: number;
+  radius?: number;
+  northHeadingDegrees?: number;
+};
+
+export type Board = {
+  id: string;
+  name: string;
+  imageRef?: string;
+  imageInfo: BoardImageInfo;
+  locations: BoardLocation[];
+  anchors?: Record<string, LocationAnchors>;
+  adjacency?: Record<string, string[]>;
+};
+
+/** Board art caps. Larger than decks (750×1050/250KB) and dungeons (1024×1024/400KB) — a board is
+ *  the one image a player stares at — but `library.boards` is a MAP sharing one 5 MB budget, so
+ *  ~3 boards with art will overrun it. {@link boardArtBytes} feeds the Asset usage meter. */
+export const BOARD_IMAGE_OPTS = { maxW: 2048, maxH: 2048, capBytes: 1_500_000 } as const;
+
+export function boardsOf(doc: ScenarioDoc | null): Record<string, Board> {
+  const lib = (doc?.library as Record<string, unknown> | undefined) ?? {};
+  return (lib.boards as Record<string, Board> | undefined) ?? {};
+}
+
+/**
+ * The active custom board's id, or `null` for the implicit built-in RtDT board.
+ * `doc.setup` is `Record<string, unknown>`, so this narrows rather than dot-accessing.
+ */
+export function activeBoardId(doc: ScenarioDoc | null): string | null {
+  const setup = doc?.setup as Record<string, unknown> | undefined;
+  const board = setup?.board;
+  if (board === null || typeof board !== 'object' || Array.isArray(board)) return null;
+  const ref = (board as Record<string, unknown>).boardRef;
+  return typeof ref === 'string' ? ref : null;
+}
+
+/** Total bytes of board art in the doc — the Board Designer's slice of the shared image budget. */
+export function boardArtBytes(doc: ScenarioDoc | null): number {
+  const lib = (doc?.library as Record<string, unknown> | undefined) ?? {};
+  const resources = lib.resources as Record<string, unknown> | undefined;
+  const images = (resources?.images as Record<string, string> | undefined) ?? {};
+  let total = 0;
+  for (const [key, uri] of Object.entries(images)) {
+    if (key.startsWith('board-') && typeof uri === 'string') total += uri.length;
+  }
+  return total;
+}
+
+/** The resource key a board's art is stored under. */
+export const boardImageKey = (boardId: string): string => `board-${boardId}`;
+
+/** True when the board carries a full circle calibration (⇒ the 3D disc view is available). */
+export function isCalibrated(info: BoardImageInfo | undefined): boolean {
+  if (!info) return false;
+  return (
+    typeof info.centerX === 'number' &&
+    typeof info.centerY === 'number' &&
+    typeof info.radius === 'number' &&
+    info.radius > 0 &&
+    typeof info.northHeadingDegrees === 'number'
+  );
+}
+
+/** Adjacency written symmetrically — the schema documents the relation as symmetric and L2 enforces it. */
+export function toggleAdjacency(board: Board, a: string, b: string): Record<string, string[]> {
+  const adj: Record<string, string[]> = {};
+  for (const [k, v] of Object.entries(board.adjacency ?? {})) adj[k] = [...v];
+  const linked = (adj[a] ?? []).includes(b);
+  const drop = (from: string, to: string): void => {
+    adj[from] = (adj[from] ?? []).filter((n) => n !== to);
+    if (adj[from].length === 0) delete adj[from];
+  };
+  const add = (from: string, to: string): void => {
+    if (!adj[from]) adj[from] = [];
+    if (!adj[from].includes(to)) adj[from].push(to);
+  };
+  if (linked) {
+    drop(a, b);
+    drop(b, a);
+  } else {
+    add(a, b);
+    add(b, a);
+  }
+  return adj;
+}
+
+/** A location's representative point (its `hero` anchor, else any slot it has). */
+export function locationPoint(board: Board, name: string): AnchorPoint | undefined {
+  const slots = board.anchors?.[name];
+  if (!slots) return undefined;
+  return slots.hero ?? slots.building ?? slots.foe ?? slots.marker ?? slots.skull;
+}
+
+/**
+ * Proximity-suggested adjacency: links each pair of locations whose anchors are within
+ * `radius` (normalized units). An authoring aid — the author edits the result.
+ */
+export function suggestAdjacency(board: Board, radius = 0.12): Record<string, string[]> {
+  const pts = board.locations
+    .map((l) => ({ name: l.name, p: locationPoint(board, l.name) }))
+    .filter((e): e is { name: string; p: AnchorPoint } => e.p !== undefined);
+  const adj: Record<string, string[]> = {};
+  for (let i = 0; i < pts.length; i++) {
+    for (let j = i + 1; j < pts.length; j++) {
+      const dx = pts[i].p.x - pts[j].p.x;
+      const dy = pts[i].p.y - pts[j].p.y;
+      if (Math.hypot(dx, dy) > radius) continue;
+      (adj[pts[i].name] ??= []).push(pts[j].name);
+      (adj[pts[j].name] ??= []).push(pts[i].name);
+    }
+  }
+  return adj;
+}
+
+/** Step distance over the adjacency graph, or `null` when unreachable. BFS — the editor preview. */
+export function bfsDistance(board: Board, from: string, to: string): number | null {
+  if (from === to) return 0;
+  const adj = board.adjacency ?? {};
+  const seen = new Set<string>([from]);
+  let frontier = [from];
+  let dist = 0;
+  while (frontier.length > 0) {
+    dist++;
+    const next: string[] = [];
+    for (const node of frontier) {
+      for (const n of adj[node] ?? []) {
+        if (seen.has(n)) continue;
+        if (n === to) return dist;
+        seen.add(n);
+        next.push(n);
+      }
+    }
+    frontier = next;
+  }
+  return null;
+}
+
+export type BoardProblem = { level: 'error' | 'warn'; message: string };
+
+/**
+ * Editor-side board validation. Mirrors the L2 checks in `@udtc/adapters`' `validate-refs`
+ * (duplicate names, anchors/adjacency confined to real locations, adjacency symmetry) so the
+ * author sees them while editing rather than at export.
+ */
+export function validateBoard(board: Board): BoardProblem[] {
+  const problems: BoardProblem[] = [];
+  if (!ID_RE.test(board.id)) {
+    problems.push({ level: 'error', message: `id "${board.id}" must be kebab/snake case` });
+  }
+  if (!board.name.trim()) problems.push({ level: 'error', message: 'name is required' });
+  if (board.locations.length === 0) {
+    problems.push({ level: 'error', message: 'a board needs at least one location' });
+  }
+
+  const names = new Set<string>();
+  for (const loc of board.locations) {
+    if (!loc.name.trim()) {
+      problems.push({ level: 'error', message: 'a location has an empty name' });
+      continue;
+    }
+    if (names.has(loc.name)) {
+      problems.push({ level: 'error', message: `duplicate location name "${loc.name}"` });
+    }
+    names.add(loc.name);
+    if (!loc.terrain.trim()) {
+      problems.push({ level: 'error', message: `location "${loc.name}" has no terrain` });
+    }
+  }
+
+  for (const key of Object.keys(board.anchors ?? {})) {
+    if (!names.has(key)) {
+      problems.push({ level: 'error', message: `anchors key "${key}" is not a location` });
+    }
+  }
+
+  const adj = board.adjacency ?? {};
+  for (const [from, tos] of Object.entries(adj)) {
+    if (!names.has(from)) {
+      problems.push({ level: 'error', message: `adjacency key "${from}" is not a location` });
+      continue;
+    }
+    for (const to of tos) {
+      if (!names.has(to)) {
+        problems.push({
+          level: 'error',
+          message: `adjacency "${from}" → "${to}" is not a location`,
+        });
+        continue;
+      }
+      if (!(adj[to] ?? []).includes(from)) {
+        problems.push({
+          level: 'error',
+          message: `adjacency is not symmetric: "${from}" lists "${to}" but not the reverse`,
+        });
+      }
+    }
+  }
+
+  // Warnings — authorable but probably a mistake.
+  for (const kingdom of KINGDOMS) {
+    const inK = board.locations.filter((l) => l.kingdom === kingdom);
+    if (inK.length === 0) {
+      problems.push({ level: 'warn', message: `no locations in the ${kingdom} kingdom` });
+      continue;
+    }
+    if (!inK.some((l) => l.building === 'citadel')) {
+      problems.push({
+        level: 'warn',
+        message: `${kingdom} has no citadel — its hero has no start location`,
+      });
+    }
+  }
+  for (const loc of board.locations) {
+    if (!board.anchors?.[loc.name]) {
+      problems.push({ level: 'warn', message: `"${loc.name}" has no anchors — it won't render` });
+    }
+  }
+  if (!isCalibrated(board.imageInfo)) {
+    problems.push({
+      level: 'warn',
+      message: 'not calibrated — the board is 2D-only (set center, radius and north for 3D)',
+    });
+  }
+  return problems;
+}

--- a/apps/creator/src/boards/vocabulary.ts
+++ b/apps/creator/src/boards/vocabulary.ts
@@ -1,0 +1,30 @@
+// The active board's location vocabulary — what every location dropdown in the app offers.
+//
+// A scenario with a custom board (setup.board.boardRef) offers that board's names; everything
+// else keeps the built-in Return to Dark Tower roster. This mirrors the L2 check in
+// `@udtc/adapters`' `validate-refs`, so what the editor offers is exactly what validates.
+
+// RtDT data comes from @udtc/adapters' reference layer, NOT a direct import of
+// `ultimatedarktower`/`ultimatedarktowerboard`: the creator's Vite config aliases UDT to its CJS
+// build, whose entry reaches UDT's Node-only BLE stack (@stoprocent/noble) and breaks the browser
+// bundle. `udt.ts` is the single module allowed to import UDT, and it is pre-bundled for the browser.
+import { getUDTReferenceLayer } from '@udtc/adapters';
+import type { ScenarioDoc } from '../types';
+import { activeBoardId, boardsOf } from './shared';
+
+const RTDT_LOCATION_NAMES: readonly string[] = getUDTReferenceLayer().boardLocations.map(
+  (l) => l.name,
+);
+
+/**
+ * Location names for the scenario's active board, in authored order. Falls back to the RtDT
+ * roster when no custom board is selected — or when the selected one is missing/empty, so a
+ * dangling `boardRef` (which L2 flags) degrades to a usable list instead of an empty dropdown.
+ */
+export function activeBoardLocationNames(doc: ScenarioDoc | null): readonly string[] {
+  const id = activeBoardId(doc);
+  if (!id) return RTDT_LOCATION_NAMES;
+  const board = boardsOf(doc)[id];
+  const names = board?.locations?.map((l) => l.name).filter(Boolean) ?? [];
+  return names.length > 0 ? names : RTDT_LOCATION_NAMES;
+}

--- a/apps/creator/src/editors/InspectorPanel.tsx
+++ b/apps/creator/src/editors/InspectorPanel.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useState } from 'react';
 import { getUDTReferenceLayer } from '@udtc/adapters';
 import { useCreatorStore } from '../store';
+import { activeBoardLocationNames } from '../boards/vocabulary';
 import { categoryFor } from '../types';
 import type { ScenarioDoc, SchemaNode, GroupProps } from '../types';
 
@@ -921,9 +922,6 @@ function ScenarioSetupEditor({
 
 const FOE_STATUSES = ['panicked', 'unsteady', 'ready', 'savage', 'lethal'] as const;
 
-// UDT board-location vocabulary (60 named spaces) — resolved once at load, like NewScenarioDialog.
-const BOARD_LOCATION_NAMES: string[] = Object.keys(getUDTReferenceLayer().boardLocationByName);
-
 type SpawnRow = { foeId?: string; location?: string; status?: string };
 
 // The foes an author can place = those the scenario declares (library.foes keys ∪ tier selections),
@@ -958,12 +956,14 @@ function BoardSetupEditor({
   const raw = sn.props?.spawns;
   const spawns: SpawnRow[] = Array.isArray(raw) ? (raw as SpawnRow[]) : [];
   const foeIds = scenarioFoeIds(schemaDoc);
+  // The active board's vocabulary — a custom board's own names, else the built-in RtDT roster.
+  const locationNames = [...activeBoardLocationNames(schemaDoc)];
 
   const commit = (next: SpawnRow[]) => onUpdate({ spawns: next });
   const updateRow = (i: number, patch: SpawnRow) =>
     commit(spawns.map((r, idx) => (idx === i ? { ...r, ...patch } : r)));
   const addRow = () =>
-    commit([...spawns, { foeId: foeIds[0] ?? '', location: BOARD_LOCATION_NAMES[0] ?? '' }]);
+    commit([...spawns, { foeId: foeIds[0] ?? '', location: locationNames[0] ?? '' }]);
   const removeRow = (i: number) => commit(spawns.filter((_, idx) => idx !== i));
 
   // Keep a hand-authored foe/location that isn't in the option list visible + selectable.
@@ -1025,7 +1025,7 @@ function BoardSetupEditor({
             style={selectStyle}
             title="Board location"
           >
-            {withCurrent(BOARD_LOCATION_NAMES, row.location).map((loc) => (
+            {withCurrent(locationNames, row.location).map((loc) => (
               <option key={loc} value={loc}>
                 {loc}
               </option>

--- a/apps/creator/src/editors/effects/EffectRow.tsx
+++ b/apps/creator/src/editors/effects/EffectRow.tsx
@@ -18,6 +18,8 @@ import {
   coerceFlagValue,
   type FieldSpec,
 } from './opForms';
+import { useCreatorStore } from '../../store';
+import { activeBoardLocationNames } from '../../boards/vocabulary';
 
 export interface EffectRowProps {
   effect: Record<string, unknown>;
@@ -38,6 +40,8 @@ export function EffectRow({
   foeIds,
   depth,
 }: EffectRowProps) {
+  const schemaDoc = useCreatorStore((s) => s.schemaDoc);
+  const locationNames = [...activeBoardLocationNames(schemaDoc)];
   const op = typeof effect.op === 'string' ? effect.op : '';
   const scopeCapped = op === 'hero.scope' && depth >= SCOPE_DEPTH_CAP;
   const structured = hasStructuredForm(op) && !scopeCapped;
@@ -112,6 +116,7 @@ export function EffectRow({
               effect={effect}
               deckIds={deckIds}
               foeIds={foeIds}
+              locationNames={locationNames}
               onSet={setField}
             />
           ))}
@@ -128,12 +133,14 @@ function Field({
   effect,
   deckIds,
   foeIds,
+  locationNames,
   onSet,
 }: {
   spec: FieldSpec;
   effect: Record<string, unknown>;
   deckIds: string[];
   foeIds: string[];
+  locationNames: string[];
   onSet: (key: string, value: unknown, optional?: boolean) => void;
 }) {
   const { key, kind, label, min, optional } = spec;
@@ -166,7 +173,9 @@ function Field({
     kind === 'kingdom' ||
     kind === 'foeStatus' ||
     kind === 'deck' ||
-    kind === 'foe'
+    kind === 'foe' ||
+    // a board with no locations yet would render an empty dropdown — fall back to free text
+    (kind === 'location' && locationNames.length > 0)
   ) {
     const options =
       kind === 'resource'
@@ -177,7 +186,9 @@ function Field({
             ? [...FOE_STATUSES]
             : kind === 'deck'
               ? deckIds
-              : foeIds;
+              : kind === 'location'
+                ? locationNames
+                : foeIds;
     const cur = String(raw ?? '');
     return (
       <label style={fieldRow}>

--- a/apps/creator/src/editors/effects/opForms.ts
+++ b/apps/creator/src/editors/effects/opForms.ts
@@ -32,7 +32,16 @@ export function getOpEnum(): string[] {
 }
 
 export type FieldKind =
-  'number' | 'text' | 'bool' | 'resource' | 'kingdom' | 'foeStatus' | 'deck' | 'foe';
+  | 'number'
+  | 'text'
+  | 'bool'
+  | 'resource'
+  | 'kingdom'
+  | 'foeStatus'
+  | 'deck'
+  | 'foe'
+  // a space on the ACTIVE board — a custom board's own names, else the built-in RtDT roster
+  | 'location';
 
 export interface FieldSpec {
   key: string;
@@ -65,12 +74,12 @@ export const OP_FORMS: Record<string, FieldSpec[]> = {
   'skull.remove': [{ key: 'count', kind: 'number', label: 'Count', min: 1 }],
   'foe.spawn': [
     { key: 'foeId', kind: 'foe', label: 'Foe' },
-    { key: 'location', kind: 'text', label: 'Location' },
+    { key: 'location', kind: 'location', label: 'Location' },
     { key: 'status', kind: 'foeStatus', label: 'Status', optional: true },
   ],
   'foe.move': [
     { key: 'foeId', kind: 'foe', label: 'Foe' },
-    { key: 'to', kind: 'text', label: 'To' },
+    { key: 'to', kind: 'location', label: 'To' },
   ],
   'foe.remove': [{ key: 'foeId', kind: 'foe', label: 'Foe', optional: true }],
   'foe.escalateStatus': [

--- a/apps/creator/src/simulator/SimulatorPanel.tsx
+++ b/apps/creator/src/simulator/SimulatorPanel.tsx
@@ -9,7 +9,12 @@ import {
   type Directive,
   type StepResult,
 } from '@udtc/engine';
-import { createResolver, createDisplayAdapter, createBoardAdapter } from '@udtc/adapters';
+import {
+  createResolver,
+  createDisplayAdapter,
+  createBoardAdapter,
+  resolveActiveBoardDef,
+} from '@udtc/adapters';
 import { useCreatorStore } from '../store';
 import type { ScenarioDoc } from '../types';
 
@@ -139,7 +144,12 @@ export function SimulatorPanel() {
   useEffect(() => {
     const resolver = createResolver();
     const display = createDisplayAdapter({ resolver });
-    const board = createBoardAdapter();
+    // Seed the board adapter from the scenario's active board so its building spaces match a
+    // custom board. Read straight from the store: this effect intentionally runs once per panel
+    // lifetime, and re-creating the adapter on every doc keystroke would churn the 3D view.
+    const board = createBoardAdapter({
+      board: resolveActiveBoardDef(useCreatorStore.getState().schemaDoc)?.def,
+    });
     displayRef.current = display;
     boardRef.current = board;
 

--- a/apps/creator/src/store/index.ts
+++ b/apps/creator/src/store/index.ts
@@ -17,9 +17,11 @@ import { canonicalJson } from '../utils/canonical';
 import { applyDagreLayout } from '../utils/layout';
 import { syncDungeonNodes, BASE_X, BASE_Y } from '../dungeons/dungeonNodes';
 import type { Dungeon } from '../dungeons/shared';
+import type { Board } from '../boards/shared';
+import { activeBoardId } from '../boards/shared';
 
 // The center workspace view. The deck-builder-first-class switcher accommodates the dungeon builder.
-export type CenterView = 'canvas' | 'decks' | 'dungeons';
+export type CenterView = 'canvas' | 'decks' | 'dungeons' | 'boards';
 
 interface CreatorStore {
   schemaDoc: ScenarioDoc | null;
@@ -36,6 +38,18 @@ interface CreatorStore {
   deckCardKey: string | null;
   // read-only mirror of DungeonBuilderView's selected dungeonId (for the DungeonJsonPanel sidebar).
   dungeonSelection: string | null;
+  boardSelection: string | null;
+  /**
+   * The `setup.board` value displaced when a custom board was activated. `setup.board` is a
+   * schema `oneOf`, so `{boardRef}` is mutually exclusive with a hand-authored `{boardState}`
+   * (its `home` hero-start map and `buildings` registry) — writing one destroys the other.
+   * Stashing the outgoing value lets `setActiveBoard(null)` put it back verbatim.
+   *
+   * Session-scoped on purpose: it is NOT persisted (no schema surface for it). The editor
+   * therefore also confirms before overwriting a non-empty inline `boardState`, which covers
+   * activating a board in a later session than the one that authored it.
+   */
+  priorSetupBoard?: Record<string, unknown>;
   // set true when an autosave hits the localStorage quota (surfaced as a topbar warning chip, C3)
   draftSaveFailed: boolean;
   // last-known canvas pan/zoom, so switching to Decks/Dungeons and back doesn't reset the viewport.
@@ -55,6 +69,7 @@ interface CreatorStore {
   setDeckSelection: (sel: DeckSelection | null) => void;
   setDeckCardKey: (key: string | null) => void;
   setDungeonSelection: (id: string | null) => void;
+  setBoardSelection: (id: string | null) => void;
   setCanvasViewport: (viewport: Viewport | null) => void;
 
   // library.cards / library.decks / library.resources.images editing (schema 0.4.3, deck builder).
@@ -70,6 +85,13 @@ interface CreatorStore {
   // the turn loop (actionMiddle.dungeon → subflow, subflow.completed/left → actionEnd), which then
   // triggers room-node materialization. Switches to the canvas so the generated graph is visible.
   addDungeonSubflow: (dungeonId: string) => void;
+  // library.boards editing (schema 0.4.6, board designer). Replaces the whole map (or clears it
+  // when empty). No node sync — a board has no graph nodes (locations are opaque strings).
+  commitBoards: (boards: Record<string, Board>) => void;
+  // Points setup.board at a custom board, or back to the built-in RtDT board with `null`.
+  // setup.board is a oneOf, so {boardRef} is mutually exclusive with a hand-authored
+  // {boardState}/{boardStateRef} — see the implementation for how that value survives.
+  setActiveBoard: (boardId: string | null) => void;
 
   // RF state sync (called by canvas on drag-end, connect, delete)
   syncFromRF: (nodes: CreatorNode[], edges: Edge[]) => void;
@@ -154,6 +176,8 @@ export const useCreatorStore = create<CreatorStore>((set, get) => ({
   deckSelection: null,
   deckCardKey: null,
   dungeonSelection: null,
+  boardSelection: null,
+  priorSetupBoard: undefined,
   draftSaveFailed: false,
   canvasViewport: null,
 
@@ -175,6 +199,10 @@ export const useCreatorStore = create<CreatorStore>((set, get) => ({
 
   setDungeonSelection(id) {
     set({ dungeonSelection: id });
+  },
+
+  setBoardSelection(id) {
+    set({ boardSelection: id });
   },
 
   setCanvasViewport(viewport) {
@@ -218,6 +246,8 @@ export const useCreatorStore = create<CreatorStore>((set, get) => ({
       deckSelection: null,
       deckCardKey: null,
       dungeonSelection: null,
+      boardSelection: null,
+      priorSetupBoard: undefined,
       validationResults: null,
       isDirty: false,
     });
@@ -607,6 +637,83 @@ export const useCreatorStore = create<CreatorStore>((set, get) => ({
       meta: { ...schemaDoc.meta, layout },
       graph: { ...schemaDoc.graph, nodes },
     };
+    const { nodes: rfNodes, edges } = deriveRF(updated);
+    const results = revalidate(updated);
+    const annotated = annotateErrors(rfNodes, results);
+    set({
+      schemaDoc: updated,
+      rfNodes: annotated,
+      rfEdges: edges,
+      validationResults: results,
+      isDirty: true,
+    });
+  },
+
+  commitBoards(boards) {
+    const { schemaDoc } = get();
+    if (!schemaDoc) return;
+    const library = { ...((schemaDoc.library as Record<string, unknown> | undefined) ?? {}) };
+    if (Object.keys(boards).length > 0) library.boards = boards;
+    else delete library.boards;
+
+    let updated: ScenarioDoc = { ...schemaDoc, library };
+
+    // If the ACTIVE board was just deleted, setup.board would be left pointing at nothing (a
+    // dangling boardRef — an L2 error). Fall back to the built-in RtDT board, restoring any
+    // stashed inline boardState exactly as setActiveBoard(null) does: deleting a board must not
+    // eat an authored boardState either.
+    const active = activeBoardId(updated);
+    if (active !== null && !(active in boards)) {
+      const prior = get().priorSetupBoard;
+      updated = {
+        ...updated,
+        setup: { ...updated.setup, board: prior ?? { boardStateRef: 'board-main' } },
+      };
+      set({ priorSetupBoard: undefined });
+    }
+
+    const { nodes: rfNodes, edges } = deriveRF(updated);
+    const results = revalidate(updated);
+    const annotated = annotateErrors(rfNodes, results);
+    set({
+      schemaDoc: updated,
+      rfNodes: annotated,
+      rfEdges: edges,
+      validationResults: results,
+      isDirty: true,
+    });
+  },
+
+  setActiveBoard(boardId) {
+    const { schemaDoc } = get();
+    if (!schemaDoc) return;
+    const setup = { ...(schemaDoc.setup as Record<string, unknown>) };
+    const current = setup.board;
+
+    if (boardId === null) {
+      // Back to the built-in RtDT board: restore whatever setup.board held before the custom
+      // board took over, so a hand-authored inline boardState (hero homes + buildings registry)
+      // survives the round-trip. Only fall back to the scaffold's boardStateRef if there was
+      // nothing to restore.
+      const prior = get().priorSetupBoard;
+      setup.board = prior ?? { boardStateRef: 'board-main' };
+      set({ priorSetupBoard: undefined });
+    } else {
+      // {boardRef} is a oneOf branch — writing it DESTROYS an inline {boardState}. Stash the
+      // outgoing value so toggling back restores it. (Stash it only on the way in from a
+      // non-boardRef value; switching custom→custom must not overwrite the original stash.)
+      const isBoardRef =
+        current !== null &&
+        typeof current === 'object' &&
+        !Array.isArray(current) &&
+        'boardRef' in (current as Record<string, unknown>);
+      if (!isBoardRef && current !== undefined) {
+        set({ priorSetupBoard: current as Record<string, unknown> });
+      }
+      setup.board = { boardRef: boardId };
+    }
+
+    const updated: ScenarioDoc = { ...schemaDoc, setup };
     const { nodes: rfNodes, edges } = deriveRF(updated);
     const results = revalidate(updated);
     const annotated = annotateErrors(rfNodes, results);

--- a/apps/creator/src/utils/scaffold.ts
+++ b/apps/creator/src/utils/scaffold.ts
@@ -4,7 +4,7 @@
 
 import type { ScenarioDoc } from '../types';
 
-const SCHEMA_VERSION = '0.4.1';
+const SCHEMA_VERSION = '0.4.6';
 const UDT_PIN = '5.0.0';
 
 export interface ScaffoldInput {

--- a/apps/player/src/game/index.ts
+++ b/apps/player/src/game/index.ts
@@ -9,6 +9,7 @@ import {
   validateRefs,
   validateGraph,
   createBoardAdapter,
+  resolveActiveBoardDef,
   createDisplayAdapter,
   createResolver,
 } from '@udtc/adapters';
@@ -26,6 +27,12 @@ const PLAYER_COUNT = 1;
 // Module-level singletons — survive component remounts.
 let _relay: RelayClient | null = null;
 let _board: ReturnType<typeof createBoardAdapter> | null = null;
+// The scenario's custom board (schema 0.4.6 setup.board.boardRef), or null for the built-in
+// RtDT board. Resolved on load AND on session resume — a resumed scenario must render on the
+// board it was authored for, not the default.
+let _activeBoard: ReturnType<typeof resolveActiveBoardDef> = null;
+// Data URL of the custom board's art, pulled from library.resources.images.
+let _activeBoardImageUrl: string | undefined;
 let _display: ReturnType<typeof createDisplayAdapter> | null = null;
 // The all-in-one board stage (2D/3D/PiP switcher, pop-out, kingdom-zoom) shown for the
 // emulator target. Its `tower3D` is a Display TowerRenderView the engine drives directly.
@@ -56,8 +63,27 @@ const BOARD_IMAGE_URL = `${import.meta.env.BASE_URL}assets/board.png`;
 const BOARD_ASSET_BASE = `${import.meta.env.BASE_URL}assets/tokens/`;
 
 function board(): ReturnType<typeof createBoardAdapter> {
-  if (!_board) _board = createBoardAdapter();
+  if (!_board) _board = createBoardAdapter({ board: _activeBoard?.def });
   return _board;
+}
+
+/**
+ * Resolve the scenario's board + art, and force the board adapter to be rebuilt for it.
+ * Called from BOTH loadGame and resumeSession: the adapter seeds its building spaces from the
+ * board definition, so a stale adapter would track the wrong board.
+ */
+function adoptScenarioBoard(doc: unknown): void {
+  _activeBoard = resolveActiveBoardDef(doc);
+  _activeBoardImageUrl = resolveBoardImageUrl(doc, _activeBoard?.imageRef);
+  _board = null; // rebuilt on next board() with the new definition
+}
+
+/** The board art data URL for `imageRef`, read out of library.resources.images. */
+function resolveBoardImageUrl(doc: unknown, imageRef: string | undefined): string | undefined {
+  if (!imageRef) return undefined;
+  const d = doc as { library?: { resources?: { images?: Record<string, string> } } } | null;
+  const uri = d?.library?.resources?.images?.[imageRef];
+  return typeof uri === 'string' ? uri : undefined;
 }
 
 function display(): ReturnType<typeof createDisplayAdapter> {
@@ -148,12 +174,24 @@ export function mountDisplay(el: HTMLElement, mode: DisplayMode = 'lite'): void 
 
 async function mountStage(el: HTMLElement, gen: number): Promise<void> {
   const { BoardStageView } = await import('ultimatedarktowerboard/stage');
+  const { isBoardCalibrated } = await import('ultimatedarktowerboard');
   if (gen !== _mountGen) return;
+
+  // The 3D disc projection needs the board's circle calibration. An uncalibrated custom board
+  // renders in 2D instead of placing tokens at meaningless spots.
+  const canRender3D = !_activeBoard || isBoardCalibrated(_activeBoard.def.imageInfo);
+  if (!canRender3D) {
+    usePlayerStore
+      .getState()
+      .addLog('Custom board is not calibrated (no centre/radius/north) — using the 2D map.');
+  }
 
   const stage = new BoardStageView({
     container: el,
     modelUrl: TOWER_MODEL_URL,
-    boardImageUrl: BOARD_IMAGE_URL,
+    // A custom board draws its own uploaded art; a board with no art renders blank.
+    boardImageUrl: _activeBoard ? _activeBoardImageUrl : BOARD_IMAGE_URL,
+    board: _activeBoard?.def,
     assetBaseUrl: BOARD_ASSET_BASE,
     // Foe/adversary/hero art (2D icons + 3D portraits) all resolve from the board library's
     // built-in defaults now — no per-token tokenArt needed here.
@@ -169,12 +207,14 @@ async function mountStage(el: HTMLElement, gen: number): Promise<void> {
     initialState: board().isReady() ? board().getState() : undefined,
   });
 
-  await stage.setTowerEnabled(true);
+  if (canRender3D) await stage.setTowerEnabled(true);
   if (gen !== _mountGen) {
     stage.dispose();
     return;
   }
-  stage.setDisplayMode('2d3d'); // open on the combined 2D map + 3D tower; pills let the user switch
+  // Combined 2D map + 3D tower when the board supports it; 2D-only otherwise. Pills let the
+  // user switch within whatever is available.
+  stage.setDisplayMode(canRender3D ? '2d3d' : '2d');
 
   // Drive the engine's tower.program (lights / drums / seals) into the stage's TowerRenderView.
   const towerView = stage.tower3D;
@@ -305,6 +345,8 @@ export function loadGame(doc: unknown): void {
   void clearSession();
   store.setPhase('validating');
   store.addLog('Validating scenario (L1–L4)…');
+
+  adoptScenarioBoard(doc);
 
   const results = validateScenario(doc);
   store.setScenario(doc, results);
@@ -469,6 +511,9 @@ export async function resumeSession(): Promise<void> {
     store.setResumable(null);
     return;
   }
+
+  // Resume renders the SAVED scenario, so re-resolve its board before any adapter is built.
+  adoptScenarioBoard(saved.scenario);
 
   let engineState: EngineState;
   try {

--- a/docs/creator/board-designer.md
+++ b/docs/creator/board-designer.md
@@ -1,0 +1,76 @@
+# Board Designer
+
+The Board Designer (the **Boards** tab in the Creator app) lets a creator author a **custom game
+board** — their own art, locations, anchors and adjacency — and play it in `@udtc/player`.
+
+A scenario that doesn't author a board keeps using the built-in Return to Dark Tower board exactly
+as before. Nothing about custom boards is opt-out; it is entirely opt-in.
+
+## The model
+
+A custom board keeps the RtDT **location shape** — `{name, kingdom, terrain, building?}` — on
+purpose. Locations are opaque strings everywhere in the system (engine state, effect ops,
+conditions), so a custom vocabulary works with **every existing node kind and effect op
+unchanged**. Authoring a board re-sources the dropdowns; it does not add new authoring primitives.
+
+| Field                                                  | Required | Notes                                                                                         |
+| ------------------------------------------------------ | -------- | --------------------------------------------------------------------------------------------- |
+| `id` / `name`                                          | yes      | `id` is the `library.boards` key and must be kebab/snake case                                 |
+| `imageRef`                                             | no       | a `library.resources.images` key; without art the board renders blank                         |
+| `imageInfo.width` / `.height`                          | yes      | the image space anchors are normalized against                                                |
+| `imageInfo.centerX/centerY/radius/northHeadingDegrees` | no       | all four ⇒ **3D-ready** (see below)                                                           |
+| `locations[]`                                          | yes      | `kingdom` is the closed 4-enum; `terrain` is an open string; `building` is the lowercase enum |
+| `anchors`                                              | no       | per-location `building`/`skull`/`hero`/`foe`/`marker` points, normalized `[0,1]`              |
+| `adjacency`                                            | no       | name → names, symmetric (see the caveat below)                                                |
+
+Stored at `library.boards[id]` (schema **0.4.6**); a scenario selects one with
+`setup.board = { boardRef: id }`.
+
+## Authoring flow
+
+1. **Boards tab → Clone RtDT preset.** A full copy of the built-in board — 60 locations, anchors,
+   adjacency, calibration — ready to rename and re-art. (Or **Add empty board** to start bare.)
+2. **Upload art.** Capped at 2048×2048 / ~1.5 MB. The stored image's real dimensions become
+   `imageInfo.width/height`.
+3. **Locations.** Add/rename/delete; set kingdom, terrain and building. A **rename remaps this
+   board's anchors and adjacency in the same commit** — but it does **not** rewrite graph nodes that
+   referenced the old name. Those surface in the Problems panel as dangling refs; fix them there.
+4. **Anchors.** Pick a location, pick a slot, click the map. Tokens are drawn at these points.
+5. **Adjacency.** Click two locations to link/unlink (always written symmetrically). _Suggest from
+   proximity_ seeds the graph from anchor distance.
+6. **Calibrate.** Drag the centre dot and radius handle to fit the board's printed circle, and set
+   the north heading. Needed only for 3D.
+7. **Use in game.** Points `setup.board` at this board. The Inspector's location dropdowns and the
+   `foe.spawn` / `foe.move` effect fields immediately offer the custom names, and L2 validates
+   against them.
+
+## Things worth knowing
+
+**Each kingdom needs a citadel.** Heroes start on their home kingdom's citadel space. The engine
+takes the _first_ citadel authored in each kingdom; a kingdom without one leaves its hero unplaced.
+The editor warns about this.
+
+**Adjacency is an authoring aid — it is not enforced during play (v1).** It is saved, validated for
+symmetry, and available to tools, but nothing validates hero movement against it. This matches the
+built-in board, where adjacency has always been data plus pure helpers. The Adjacency tab says so
+in place.
+
+**3D needs calibration.** The 3D disc projection maps a board's anchors from image space onto the
+tower's ground disc using `centerX/centerY/radius`. Without all four calibration values the board is
+**2D-only**: the player logs a line and stays on the 2D map. (`northHeadingDegrees` is authored but
+the 3D pipeline currently consumes quadrant-based `northKingdom` — a known v1 limitation.)
+
+**Board art shares one budget.** `library.boards` is a map, and all art in a document shares the
+~5 MB localStorage draft budget with decks and dungeons. Roughly three arted boards will overrun it
+and autosave starts failing. The toolbar surfaces the total once a second board gains art.
+
+**Switching boards touches `setup.board`.** It is a schema `oneOf`, so `{boardRef}` is mutually
+exclusive with a hand-authored `{boardState}` (hero homes + buildings registry). Toggling a board on
+stashes the previous value and toggling back restores it — but that stash is **session-scoped**, so
+the editor asks for confirmation before replacing a non-empty inline `boardState`.
+
+## Relationship to the location-marker tool
+
+`packages/core/tools/location-marker/` is the standalone dev tool that generates the **built-in RtDT
+board data** (via `gen-board-data.mjs`). It remains the pipeline for that one board. The Board
+Designer supersedes it for authoring _custom_ boards inside a scenario.

--- a/packages/board/__tests__/boardDefinition.test.ts
+++ b/packages/board/__tests__/boardDefinition.test.ts
@@ -1,0 +1,189 @@
+import {
+  BOARD_LOCATIONS,
+  BoardMap2D,
+  RTDT_BOARD_DEFINITION,
+  boardScaleFactor,
+  createDefaultBoardState,
+  isBoardCalibrated,
+  resolveBoard,
+} from '../src/index';
+import type { BoardDefinition, BoardState } from '../src/index';
+
+/** A small custom board: 2048² (half the RtDT reference), one citadel, one plain space. */
+function customBoard(overrides: Partial<BoardDefinition> = {}): BoardDefinition {
+  return {
+    id: 'shattered-reach',
+    name: 'The Shattered Reach',
+    imageInfo: {
+      width: 2048,
+      height: 2048,
+      centerX: 0.5,
+      centerY: 0.5,
+      radius: 0.5,
+      northHeadingDegrees: 135,
+    },
+    locations: [
+      { name: 'Emberfall', kingdom: 'north', terrain: 'Ash Flats', building: 'citadel' },
+      { name: 'Coldwatch', kingdom: 'north', terrain: 'Tundra' },
+    ],
+    anchors: {
+      Emberfall: { building: { x: 0.25, y: 0.25 }, hero: { x: 0.2, y: 0.2 } },
+      Coldwatch: { hero: { x: 0.75, y: 0.75 } },
+    },
+    ...overrides,
+  };
+}
+
+function render(
+  state: BoardState,
+  options: ConstructorParameters<typeof BoardMap2D>[1] = {},
+): string {
+  const host = document.createElement('div');
+  new BoardMap2D(host, options).render(state);
+  return host.innerHTML;
+}
+
+describe('resolveBoard', () => {
+  it('defaults to the built-in RtDT board', () => {
+    const resolved = resolveBoard();
+    expect(resolved.def.id).toBe('rtdt');
+    expect(resolved.def.locations).toHaveLength(BOARD_LOCATIONS.length);
+    expect(resolved.locationByName['Broken Lands']?.kingdom).toBe('north');
+  });
+
+  it('indexes a custom board by name and collects its building locations', () => {
+    const resolved = resolveBoard(customBoard());
+    expect(resolved.locationByName['Coldwatch']?.terrain).toBe('Tundra');
+    expect(resolved.buildingLocations).toEqual(['Emberfall']);
+  });
+
+  it('RtDT has 16 building spaces', () => {
+    expect(resolveBoard().buildingLocations).toHaveLength(16);
+  });
+});
+
+describe('isBoardCalibrated', () => {
+  it('accepts the built-in board (it carries a full circle)', () => {
+    expect(isBoardCalibrated(RTDT_BOARD_DEFINITION.imageInfo)).toBe(true);
+  });
+
+  it('rejects width/height-only and partially-calibrated boards', () => {
+    expect(isBoardCalibrated({ width: 100, height: 100 })).toBe(false);
+    expect(isBoardCalibrated({ width: 100, height: 100, centerX: 0.5, centerY: 0.5 })).toBe(false);
+    expect(
+      isBoardCalibrated({ width: 100, height: 100, centerX: 0.5, centerY: 0.5, radius: 0 }),
+    ).toBe(false);
+  });
+
+  it('accepts a fully-calibrated custom board', () => {
+    expect(isBoardCalibrated(customBoard().imageInfo)).toBe(true);
+  });
+});
+
+describe('createDefaultBoardState', () => {
+  it('seeds RtDT building spaces when no board is passed', () => {
+    const state = createDefaultBoardState();
+    expect(Object.keys(state.buildings)).toHaveLength(16);
+    expect(state.buildings['Radiant Mountains']).toEqual({ skulls: 0, destroyed: false });
+  });
+
+  it("seeds a custom board's building spaces only", () => {
+    const state = createDefaultBoardState(customBoard());
+    expect(Object.keys(state.buildings)).toEqual(['Emberfall']);
+    expect(state.buildings['Emberfall']).toEqual({ skulls: 0, destroyed: false });
+  });
+});
+
+describe('boardScaleFactor', () => {
+  it('is exactly 1 for the 4096² reference board', () => {
+    expect(boardScaleFactor(RTDT_BOARD_DEFINITION.imageInfo)).toBe(1);
+  });
+
+  it('scales by the SHORTER side, so a portrait board keeps tokens in proportion', () => {
+    // width/4096 would give 1 here and render tokens 4x oversized against the visible board.
+    expect(boardScaleFactor({ width: 4096, height: 1024 })).toBe(0.25);
+    expect(boardScaleFactor({ width: 1024, height: 4096 })).toBe(0.25);
+  });
+});
+
+describe('BoardMap2D board injection', () => {
+  it('renders a custom board at its own anchors and viewBox', () => {
+    const board = customBoard();
+    const state = createDefaultBoardState(board);
+    state.heroes = { h1: { location: 'Coldwatch' } };
+    const html = render(state, { board, assetBaseUrl: '/t/' });
+
+    // viewBox is the custom image size, not RtDT's 4096².
+    expect(html).toContain('viewBox="0 0 2048 2048"');
+    // The hero lands on Coldwatch's anchor: 0.75 * 2048 = 1536.
+    expect(html).toContain('translate(1536 1536)');
+  });
+
+  it('scales token geometry to a NON-SQUARE board by min(w,h)/4096', () => {
+    const board = customBoard({
+      imageInfo: { width: 4096, height: 1024 },
+      anchors: { Coldwatch: { hero: { x: 0.5, y: 0.5 } } },
+    });
+    const state = createDefaultBoardState(board);
+    state.heroes = { h1: { location: 'Coldwatch' } };
+    const html = render(state, { board, assetBaseUrl: '/t/' });
+
+    // factor = min(4096,1024)/4096 = 0.25 ⇒ SLOT_SIZE 150 → 37.5. The token has no art, so it
+    // draws the fallback disc at size*0.42 = 15.75. Scaling on width alone would give factor 1
+    // and a full-size 63 — four times too big for a board only 1024px tall.
+    expect(html).toContain('r="15.75"');
+    expect(html).toContain('viewBox="0 0 4096 1024"');
+  });
+
+  it('uses full-size token geometry on the 4096² reference board', () => {
+    const state = createDefaultBoardState();
+    state.heroes = { h1: { location: 'Radiant Mountains' } };
+    // SLOT_SIZE 150 unscaled ⇒ fallback disc r = 150 * 0.42 = 63.
+    expect(render(state, { assetBaseUrl: '/t/' })).toContain('r="63"');
+  });
+
+  // THE back-compat proof for the published package: injecting the built-in board explicitly
+  // must be indistinguishable from omitting the option, byte for byte.
+  it('identity regression — no board option renders identically to RTDT_BOARD_DEFINITION', () => {
+    const state = createDefaultBoardState();
+    state.heroes = { h1: { location: 'Radiant Mountains' }, h2: { location: 'Broken Lands' } };
+    state.foes = { f1: { foe: 'Brigands', location: 'Yellowpike', status: 'ready' } };
+    state.buildings['Radiant Mountains'] = { skulls: 3, destroyed: false };
+    state.buildings['Duwani'] = { skulls: 0, destroyed: true };
+    state.spaceMarkers = { Arkartus: ['wasteland'] };
+    state.questMarkers = { Dayside: ['main-goal'] };
+    state.adversary = { id: 'the-baron', location: 'Fivepint' };
+
+    const opts = { assetBaseUrl: '/t/', boardImageUrl: '/board.png' };
+    const withoutOption = render(state, opts);
+    const withExplicitBoard = render(state, { ...opts, board: RTDT_BOARD_DEFINITION });
+    expect(withExplicitBoard).toBe(withoutOption);
+
+    // …and again through a STRUCTURAL CLONE. `resolveBoard` fast-paths the RTDT singleton by
+    // identity, so the assertion above alone would not exercise the generic custom-board path.
+    // A clone has a different identity, so this proves that path reproduces the built-in board
+    // byte for byte — which is what makes the new option safe for existing consumers.
+    const clone: BoardDefinition = { ...RTDT_BOARD_DEFINITION, id: 'rtdt-clone' };
+    expect(render(state, { ...opts, board: clone })).toBe(withoutOption);
+  });
+
+  // A kingdom focus is the case that actually reads the resolved location INDEX (it drives both
+  // the focus viewBox and per-token dimming), so this is where an injected board is compared
+  // against the default — including through a structural clone, which bypasses `resolveBoard`'s
+  // identity fast-path and therefore exercises the generic index-building path end to end.
+  it('identity regression holds under a kingdom focus (viewBox + dimming), incl. via a clone', () => {
+    const state = createDefaultBoardState();
+    state.heroes = { h1: { location: 'Radiant Mountains' }, h2: { location: 'Big Sister' } };
+    const focus = { kingdom: 'north', angle: 'top' } as const;
+
+    const renderFocused = (board?: BoardDefinition): string => {
+      const host = document.createElement('div');
+      new BoardMap2D(host, { assetBaseUrl: '/t/', board }).render(state, focus);
+      return host.innerHTML;
+    };
+
+    const baseline = renderFocused();
+    expect(renderFocused(RTDT_BOARD_DEFINITION)).toBe(baseline);
+    expect(renderFocused({ ...RTDT_BOARD_DEFINITION, id: 'rtdt-clone' })).toBe(baseline);
+  });
+});

--- a/packages/board/src/data/boardDefinition.ts
+++ b/packages/board/src/data/boardDefinition.ts
@@ -1,0 +1,142 @@
+// A board's data, as data — so a host can render a board this package doesn't ship.
+//
+// The built-in Return to Dark Tower board stays the default everywhere: every `board`
+// option is optional and `resolveBoard(undefined)` returns the RtDT board, so existing
+// consumers are unaffected. Pure data + pure functions — no `three`, no Display, so this
+// stays importable from the light root entry.
+
+import type { Anchor, AnchorSlot, BoardAnchorMap, BoardKingdom } from './udtReexports';
+import { BOARD_ADJACENCY, BOARD_ANCHORS, BOARD_IMAGE_INFO, BOARD_LOCATIONS } from './udtReexports';
+
+/**
+ * A location on a custom board. Deliberately looser than UDT's `BoardLocation`:
+ * `terrain` and `building` are open strings so a custom board can invent its own
+ * vocabulary. Renderers only ever test `building` for truthiness; hosts that care
+ * about a specific building type should compare case-insensitively (core spells it
+ * `'Citadel'`, the Creator schema spells it `'citadel'`).
+ */
+export interface BoardDefLocation {
+  name: string;
+  kingdom: BoardKingdom;
+  terrain?: string;
+  building?: string;
+}
+
+/**
+ * Board-image metadata. Only `width`/`height` are required — a board with no circle
+ * calibration still renders in 2D. The other four together make it 3D-capable; see
+ * {@link isBoardCalibrated}.
+ */
+export interface BoardDefImageInfo {
+  width: number;
+  height: number;
+  centerX?: number;
+  centerY?: number;
+  radius?: number;
+  northHeadingDegrees?: number;
+}
+
+/** Movement adjacency, location name → neighbouring location names. */
+export type BoardDefAdjacency = Readonly<Record<string, readonly string[]>>;
+
+/**
+ * Everything this package needs to render and track a board. `anchors` are normalized
+ * [0, 1] against the board image, exactly like UDT's `BOARD_ANCHORS`.
+ */
+export interface BoardDefinition {
+  id: string;
+  name?: string;
+  imageInfo: BoardDefImageInfo;
+  locations: readonly BoardDefLocation[];
+  anchors: BoardAnchorMap;
+  adjacency?: BoardDefAdjacency;
+}
+
+/**
+ * A board definition plus the lookups renderers want, computed once. `calibrated`
+ * gates the 3D disc view (see {@link isBoardCalibrated}).
+ */
+export interface ResolvedBoard {
+  def: BoardDefinition;
+  locationByName: Readonly<Record<string, BoardDefLocation>>;
+  buildingLocations: readonly string[];
+  calibrated: boolean;
+}
+
+/** The built-in Return to Dark Tower board, assembled from UDT's generated data. */
+export const RTDT_BOARD_DEFINITION: BoardDefinition = {
+  id: 'rtdt',
+  name: 'Return to Dark Tower',
+  imageInfo: BOARD_IMAGE_INFO,
+  locations: BOARD_LOCATIONS,
+  anchors: BOARD_ANCHORS,
+  adjacency: BOARD_ADJACENCY,
+};
+
+/**
+ * True when the board carries a full circle calibration (center, radius, and north
+ * heading), which is what the 3D disc projection needs. Uncalibrated boards are 2D-only.
+ */
+export function isBoardCalibrated(info: BoardDefImageInfo | undefined): boolean {
+  if (!info) return false;
+  return (
+    typeof info.centerX === 'number' &&
+    typeof info.centerY === 'number' &&
+    typeof info.radius === 'number' &&
+    info.radius > 0 &&
+    typeof info.northHeadingDegrees === 'number'
+  );
+}
+
+const RTDT_RESOLVED: ResolvedBoard = buildResolved(RTDT_BOARD_DEFINITION);
+
+/**
+ * Resolves a board definition into its lookups. `undefined` → the built-in RtDT board,
+ * which is what every existing caller gets by omitting the option.
+ */
+export function resolveBoard(def?: BoardDefinition): ResolvedBoard {
+  if (!def || def === RTDT_BOARD_DEFINITION) return RTDT_RESOLVED;
+  return buildResolved(def);
+}
+
+function buildResolved(def: BoardDefinition): ResolvedBoard {
+  const locationByName: Record<string, BoardDefLocation> = {};
+  const buildingLocations: string[] = [];
+  for (const location of def.locations) {
+    locationByName[location.name] = location;
+    if (location.building) buildingLocations.push(location.name);
+  }
+  return {
+    def,
+    locationByName,
+    buildingLocations,
+    calibrated: isBoardCalibrated(def.imageInfo),
+  };
+}
+
+/**
+ * The anchor for `slot` at `loc`, in image-space px. Returns `null` when the location
+ * has no such slot.
+ */
+export function anchorPxOf(board: ResolvedBoard, loc: string, slot: AnchorSlot): Anchor | null {
+  const anchor = board.def.anchors[loc]?.[slot];
+  if (!anchor) return null;
+  const { width, height } = board.def.imageInfo;
+  return { x: anchor.x * width, y: anchor.y * height };
+}
+
+/**
+ * Token geometry in this package is tuned in image-space px against the 4096² RtDT
+ * board. A custom board of another size needs those constants scaled, or tokens come
+ * out wildly over/undersized.
+ *
+ * Uses `min(width, height)`, not `width`: a portrait board scaled on width alone puts
+ * tokens out of proportion with the visible board.
+ */
+export const REFERENCE_BOARD_EXTENT = 4096;
+
+export function boardScaleFactor(info: BoardDefImageInfo): number {
+  const extent = Math.min(info.width, info.height);
+  if (!extent || extent <= 0) return 1;
+  return extent / REFERENCE_BOARD_EXTENT;
+}

--- a/packages/board/src/index.ts
+++ b/packages/board/src/index.ts
@@ -21,3 +21,4 @@ export * from './view/focusControls';
 export * from './ui';
 
 export * from './data/udtReexports';
+export * from './data/boardDefinition';

--- a/packages/board/src/plugin/index.ts
+++ b/packages/board/src/plugin/index.ts
@@ -26,7 +26,8 @@ import type {
 } from 'ultimatedarktowerdisplay';
 import type { BoardState, LocationName } from '../state/boardState';
 import type { AnchorSlot, BoardKingdom } from '../data/udtReexports';
-import { BOARD_ANCHORS } from '../data/udtReexports';
+import type { BoardDefinition, ResolvedBoard } from '../data/boardDefinition';
+import { resolveBoard } from '../data/boardDefinition';
 import type { BoardFocus, BoardViewAngle } from '../renderers/shared';
 import { DEFAULT_FOCUS, focusEquals } from '../renderers/shared';
 import {
@@ -113,6 +114,13 @@ export interface Board3DPluginOptions {
    */
   northKingdom?: 0 | 1 | 2 | 3;
   /**
+   * The board to place tokens for. Omit for the built-in RtDT board. A custom board's
+   * anchors are remapped from image space onto the disc via its circle calibration, so
+   * it must be calibrated (see `isBoardCalibrated`) — hosts should fall back to the 2D
+   * map otherwise.
+   */
+  board?: BoardDefinition;
+  /**
    * Per-token art overrides, keyed by kind → art id. The 3D path renders a per-token `model3d`
    * (GLB), else the token's image as a sprite billboard (`image3d ?? image2d`); pass the SAME
    * object to the 2D map for its `image2d` slot. A per-token `model3d` is preferred over
@@ -194,6 +202,8 @@ export class Board3DPlugin implements ScenePlugin {
   readonly id = 'ultimatedarktowerboard:board3d';
 
   private ctx: ScenePluginContext | null = null;
+  /** The board being placed (RtDT unless `options.board` said otherwise). */
+  private readonly boardData: ResolvedBoard;
   private disc: DiscMetrics | null = null;
   private group: THREE.Group | null = null;
   private board: THREE.Mesh | null = null;
@@ -215,6 +225,7 @@ export class Board3DPlugin implements ScenePlugin {
     private readonly options: Board3DPluginOptions = {},
   ) {
     this.boardState = options.boardState ?? null;
+    this.boardData = resolveBoard(options.board);
   }
 
   attach(ctx: ScenePluginContext): void {
@@ -289,8 +300,10 @@ export class Board3DPlugin implements ScenePlugin {
    */
   private buildBoard(url: string, disc: DiscMetrics, northKingdom: 0 | 1 | 2 | 3): THREE.Mesh {
     const lift = disc.radius * 0.001; // tiny lift above the disc mesh to avoid z-fighting
+    // Corners go through the same image→disc remap as the anchors, so a board whose
+    // printed circle is inset in its art is scaled to line the circle up with the disc.
     const corner = (x: number, y: number): THREE.Vector3 => {
-      const p = anchorToWorld({ x, y }, disc, northKingdom);
+      const p = anchorToWorld(this.toDiscAnchor({ x, y }), disc, northKingdom);
       p.y += lift;
       return p;
     };
@@ -418,7 +431,8 @@ export class Board3DPlugin implements ScenePlugin {
     const adversary = state.adversary;
     if (adversary?.location) {
       const anchor =
-        BOARD_ANCHORS[adversary.location]?.foe ?? BOARD_ANCHORS[adversary.location]?.building;
+        this.boardData.def.anchors[adversary.location]?.foe ??
+        this.boardData.def.anchors[adversary.location]?.building;
       if (anchor) {
         this.addToken(
           { kind: 'adversary', id: adversary.id, location: adversary.location },
@@ -432,7 +446,7 @@ export class Board3DPlugin implements ScenePlugin {
     // Buildings: skull stacks + monument / razed overlays (a click selects the building).
     for (const [loc, b] of Object.entries(state.buildings)) {
       if (b.skulls > 0) {
-        const anchor = BOARD_ANCHORS[loc]?.skull;
+        const anchor = this.boardData.def.anchors[loc]?.skull;
         if (anchor) {
           const base = this.worldAt(anchor);
           const count = Math.min(b.skulls, MAX_FANNED_SKULLS);
@@ -449,7 +463,7 @@ export class Board3DPlugin implements ScenePlugin {
         }
       }
       if (b.monument || b.destroyed) {
-        const anchor = BOARD_ANCHORS[loc]?.building;
+        const anchor = this.boardData.def.anchors[loc]?.building;
         if (anchor) {
           const pos = this.worldAt(anchor);
           const selection: TokenSelection = { kind: 'building', id: loc, location: loc };
@@ -489,7 +503,7 @@ export class Board3DPlugin implements ScenePlugin {
   ): void {
     const radius = this.fanRadius();
     for (const [loc, entries] of byLocation) {
-      const anchor = BOARD_ANCHORS[loc]?.[slot];
+      const anchor = this.boardData.def.anchors[loc]?.[slot];
       if (!anchor) continue;
       const base = this.worldAt(anchor);
       entries.forEach((entry, i) => {
@@ -643,7 +657,25 @@ export class Board3DPlugin implements ScenePlugin {
   }
 
   private worldAt(anchor: { x: number; y: number }): THREE.Vector3 {
-    return anchorToWorld(anchor, this.disc as DiscMetrics, this.options.northKingdom ?? 0);
+    return anchorToWorld(
+      this.toDiscAnchor(anchor),
+      this.disc as DiscMetrics,
+      this.options.northKingdom ?? 0,
+    );
+  }
+
+  /**
+   * Image-normalized anchor → disc-normalized anchor, so the board's printed circle lands
+   * on the 3D disc regardless of how the art is framed. For RtDT (center 0.5,0.5 / radius
+   * 0.5 — the circle inscribed in a square image) this is the identity.
+   */
+  private toDiscAnchor(anchor: { x: number; y: number }): { x: number; y: number } {
+    const { centerX, centerY, radius } = this.boardData.def.imageInfo;
+    if (typeof centerX !== 'number' || typeof centerY !== 'number' || !radius) return anchor;
+    return {
+      x: 0.5 + (anchor.x - centerX) / (2 * radius),
+      y: 0.5 + (anchor.y - centerY) / (2 * radius),
+    };
   }
 
   private tokenSize(): number {
@@ -693,7 +725,7 @@ export class Board3DPlugin implements ScenePlugin {
     this.clearSpaceTargets();
     if (!this.disc) return;
     const radius = this.tokenSize();
-    for (const [loc, slots] of Object.entries(BOARD_ANCHORS)) {
+    for (const [loc, slots] of Object.entries(this.boardData.def.anchors)) {
       const anchor = slots.hero ?? slots.building;
       if (!anchor) continue;
       const geometry = new THREE.SphereGeometry(radius, 6, 4);

--- a/packages/board/src/plugin/stageTower.ts
+++ b/packages/board/src/plugin/stageTower.ts
@@ -11,6 +11,7 @@ import { TowerRenderView, TOWER_DISPLAY_CSS } from 'ultimatedarktowerdisplay';
 import type { Tower3DView } from 'ultimatedarktowerdisplay';
 import { attachBoard3D } from './index';
 import type { BoardState } from '../state/boardState';
+import type { BoardDefinition } from '../data/boardDefinition';
 import type { LocationName } from '../state/boardState';
 import type { BoardFocus } from '../renderers/shared';
 import type {
@@ -33,6 +34,8 @@ export interface BoardTower3DOptions {
   assetBaseUrl?: string;
   /** Board surface image; renders the board's own art on the disc and hides Display's placeholder. */
   boardImageUrl?: string;
+  /** The board to place tokens for. Omit for the built-in RtDT board. */
+  board?: BoardDefinition;
   /** Per-token art overrides (the SAME object passed to the 2D map). */
   tokenArt?: TokenArtConfig;
   /** Override the default 3D sprite art path; `null` → fallback. */
@@ -76,6 +79,7 @@ export function createBoardTower3D(options: BoardTower3DOptions): BoardTower3DHa
   const handle = attachBoard3D(view3D, {
     assetBaseUrl: options.assetBaseUrl,
     boardImageUrl: options.boardImageUrl,
+    board: options.board,
     boardState: options.boardState,
     tokenArt: options.tokenArt,
     resolveTokenImage: options.resolveTokenImage,

--- a/packages/board/src/renderers/map2d.ts
+++ b/packages/board/src/renderers/map2d.ts
@@ -1,6 +1,7 @@
 import type { BoardState, LocationName } from '../state/boardState';
 import type { AnchorSlot, BoardKingdom } from '../data/udtReexports';
-import { BOARD_ANCHORS, BOARD_IMAGE_INFO, BOARD_LOCATION_BY_NAME } from '../data/udtReexports';
+import type { BoardDefImageInfo, BoardDefinition, ResolvedBoard } from '../data/boardDefinition';
+import { boardScaleFactor, resolveBoard } from '../data/boardDefinition';
 import type { BoardFocus, BoardRenderer } from './shared';
 import { DEFAULT_FOCUS, focusEquals } from './shared';
 import { KIND_TINT, KIND_Z_2D, normalizeAssetBaseUrl, resolveTokenImageFor } from './assetPaths';
@@ -37,7 +38,11 @@ export type {
 const SVG_NS = 'http://www.w3.org/2000/svg';
 const XLINK_NS = 'http://www.w3.org/1999/xlink';
 
-/** Token box (image-space px) and fan/selection geometry. The board image is 4096². */
+/**
+ * Token box (image-space px) and fan/selection geometry, tuned against the 4096² RtDT
+ * board image. A custom board of a different size scales these by `boardScaleFactor` —
+ * see {@link boardGeometry}. The RtDT factor is exactly 1, so its numbers are unchanged.
+ */
 const SLOT_SIZE = 150;
 const SKULL_SIZE = 90;
 const FAN_RADIUS = 55;
@@ -45,6 +50,28 @@ const SELECTION_RING_R = 95;
 const DIM_OPACITY = 0.22;
 const VIEWBOX_PAD = 250;
 const SPACE_HIT_R = 130;
+
+/** The above, scaled to a given board's image size. */
+interface BoardGeometry {
+  slotSize: number;
+  skullSize: number;
+  fanRadius: number;
+  selectionRingR: number;
+  viewboxPad: number;
+  spaceHitR: number;
+}
+
+function boardGeometry(info: BoardDefImageInfo): BoardGeometry {
+  const f = boardScaleFactor(info);
+  return {
+    slotSize: SLOT_SIZE * f,
+    skullSize: SKULL_SIZE * f,
+    fanRadius: FAN_RADIUS * f,
+    selectionRingR: SELECTION_RING_R * f,
+    viewboxPad: VIEWBOX_PAD * f,
+    spaceHitR: SPACE_HIT_R * f,
+  };
+}
 
 /** Mouse-zoom tuning. One wheel notch scales the view by `WHEEL_STEP`; `DEFAULT_MAX_ZOOM`
  *  caps how far in you can go (base width ÷ this). `DRAG_THRESHOLD_PX` is the movement that
@@ -92,14 +119,20 @@ export interface BoardMap2DOptions {
    * Wheel-zoom and double-click-reset work in both modes.
    */
   dragMode?: DragMode;
+  /**
+   * The board to render. Omit for the built-in Return to Dark Tower board — existing
+   * consumers need no change. A custom board supplies its own locations, anchors and
+   * image size; token geometry scales to that size automatically.
+   */
+  board?: BoardDefinition;
 }
 
 /** Left-drag behavior on the 2D map; see {@link BoardMap2DOptions.dragMode}. */
 export type DragMode = 'rotate' | 'pan';
 
 /**
- * 2D overhead map renderer. Draws the board image and places tokens via UDT's
- * normalized `BOARD_ANCHORS` (resolution-independent). Each token is rotated so
+ * 2D overhead map renderer. Draws the board image and places tokens via the board's
+ * normalized anchors (resolution-independent). Each token is rotated so
  * its "up" faces inward toward the central tower, matching the board's radially-printed
  * spaces. Inline SVG: jsdom-testable, DOM hit-testing for click-to-select, crisp scaling.
  * Display-/three-free.
@@ -115,6 +148,10 @@ export class BoardMap2D implements BoardRenderer {
   private readonly maxZoom: number;
   private dragMode: DragMode;
   private readonly unsubPick?: () => void;
+  /** The board being rendered (RtDT unless `options.board` said otherwise). */
+  private readonly boardData: ResolvedBoard;
+  /** Token/fan geometry scaled to `boardData`'s image size. */
+  private readonly geom: BoardGeometry;
 
   private svg?: SVGSVGElement;
   private rotateLayer?: SVGGElement;
@@ -125,7 +162,7 @@ export class BoardMap2D implements BoardRenderer {
   private readonly onClick = (event: Event): void => this.handleClick(event);
 
   /** The focus-derived view (recomputed each render); zoom/pan stay inside it. */
-  private baseViewBox: Rect = { x: 0, y: 0, w: BOARD_IMAGE_INFO.width, h: BOARD_IMAGE_INFO.height };
+  private baseViewBox: Rect;
   /** Present once the user has zoomed/panned; cleared by focus change or `resetView`. */
   private userViewBox?: Rect;
   /** In-flight drag-pan state (mouse events; jsdom has no PointerEvent). */
@@ -154,6 +191,10 @@ export class BoardMap2D implements BoardRenderer {
     private readonly container: HTMLElement,
     options: BoardMap2DOptions = {},
   ) {
+    this.boardData = resolveBoard(options.board);
+    this.geom = boardGeometry(this.boardData.def.imageInfo);
+    const { width, height } = this.boardData.def.imageInfo;
+    this.baseViewBox = { x: 0, y: 0, w: width, h: height };
     this.assetBaseUrl = normalizeAssetBaseUrl(options.assetBaseUrl);
     this.boardImageUrl = options.boardImageUrl;
     this.onTokenSelect = options.onTokenSelect;
@@ -182,7 +223,7 @@ export class BoardMap2D implements BoardRenderer {
     this.lastState = state;
     this.lastFocus = focus;
 
-    const { width, height } = BOARD_IMAGE_INFO;
+    const { width, height } = this.boardData.def.imageInfo;
     this.baseViewBox = this.focusViewBox(focus, width, height);
     const svg = document.createElementNS(SVG_NS, 'svg');
     svg.setAttribute('viewBox', rectToViewBox(this.userViewBox ?? this.baseViewBox));
@@ -297,7 +338,8 @@ export class BoardMap2D implements BoardRenderer {
 
   /** The `rotate(...)` transform for the content layer — spin about the board center. */
   private rotateTransform(): string {
-    return `rotate(${this.rotationDeg} ${BOARD_IMAGE_INFO.width / 2} ${BOARD_IMAGE_INFO.height / 2})`;
+    const { width, height } = this.boardData.def.imageInfo;
+    return `rotate(${this.rotationDeg} ${width / 2} ${height / 2})`;
   }
 
   /** Force a full re-render at the last state/focus (used when the armed state toggles). */
@@ -310,20 +352,20 @@ export class BoardMap2D implements BoardRenderer {
 
   /** Invisible-but-clickable space targets at the anchors (filtered by the pending placement). */
   private renderSpaceTargets(root: SVGGElement, focus: BoardFocus): void {
-    const { width, height } = BOARD_IMAGE_INFO;
+    const { width, height } = this.boardData.def.imageInfo;
     const targets = this.locationPick?.getPending()?.targets ?? 'all';
     const slot: AnchorSlot = targets === 'buildings' ? 'building' : 'hero';
-    for (const [loc, slots] of Object.entries(BOARD_ANCHORS)) {
+    for (const [loc, slots] of Object.entries(this.boardData.def.anchors)) {
       const anchor = slots[slot];
       if (!anchor) continue;
-      if (focus.kingdom !== 'all' && BOARD_LOCATION_BY_NAME[loc]?.kingdom !== focus.kingdom)
+      if (focus.kingdom !== 'all' && this.boardData.locationByName[loc]?.kingdom !== focus.kingdom)
         continue;
       const circle = document.createElementNS(SVG_NS, 'circle');
       circle.setAttribute('class', 'udt-space');
       circle.setAttribute('data-location', loc);
       circle.setAttribute('cx', String(anchor.x * width));
       circle.setAttribute('cy', String(anchor.y * height));
-      circle.setAttribute('r', String(SPACE_HIT_R));
+      circle.setAttribute('r', String(this.geom.spaceHitR));
       circle.setAttribute('fill', 'rgba(251, 191, 36, 0.18)');
       circle.setAttribute('stroke', '#fbbf24');
       circle.setAttribute('stroke-width', '6');
@@ -355,14 +397,15 @@ export class BoardMap2D implements BoardRenderer {
           const adversary = state.adversary;
           if (adversary?.location) {
             const px =
-              anchorPx(adversary.location, 'foe') ?? anchorPx(adversary.location, 'building');
+              anchorPx(this.boardData, adversary.location, 'foe') ??
+              anchorPx(this.boardData, adversary.location, 'building');
             if (px) {
               root.appendChild(
                 this.makeToken(
                   { kind: 'adversary', id: adversary.id, location: adversary.location },
                   { kind: 'adversary', id: adversary.id },
                   px,
-                  SLOT_SIZE,
+                  this.geom.slotSize,
                   this.dim(adversary.location, focus),
                 ),
               );
@@ -376,7 +419,7 @@ export class BoardMap2D implements BoardRenderer {
           for (const [loc, b] of Object.entries(state.buildings)) {
             const opacity = this.dim(loc, focus);
             if (b.skulls > 0) {
-              const px = anchorPx(loc, 'skull');
+              const px = anchorPx(this.boardData, loc, 'skull');
               if (px) {
                 const count = Math.min(b.skulls, MAX_FANNED_SKULLS);
                 const group = this.makeSelectableGroup(
@@ -389,15 +432,15 @@ export class BoardMap2D implements BoardRenderer {
                     group,
                     { kind: 'skull', id: 'skull' },
                     'building',
-                    SKULL_SIZE,
-                    fanOffset(i, count, FAN_RADIUS),
+                    this.geom.skullSize,
+                    fanOffset(i, count, this.geom.fanRadius),
                   );
                 }
                 root.appendChild(group);
               }
             }
             if (b.monument || b.destroyed) {
-              const px = anchorPx(loc, 'building');
+              const px = anchorPx(this.boardData, loc, 'building');
               if (px) {
                 const group = this.makeSelectableGroup(
                   { kind: 'building', id: loc, location: loc },
@@ -409,9 +452,9 @@ export class BoardMap2D implements BoardRenderer {
                     group,
                     { kind: 'monument', id: b.monument },
                     'building',
-                    SLOT_SIZE,
+                    this.geom.slotSize,
                   );
-                if (b.destroyed) group.appendChild(razedOverlay(SLOT_SIZE));
+                if (b.destroyed) group.appendChild(razedOverlay(this.geom.slotSize));
                 root.appendChild(group);
               }
             }
@@ -470,15 +513,15 @@ export class BoardMap2D implements BoardRenderer {
     toArt: (entry: LocatedEntry) => TokenArtRef,
   ): void {
     for (const [loc, entries] of byLocation) {
-      const px = anchorPx(loc, slot);
+      const px = anchorPx(this.boardData, loc, slot);
       if (!px) continue;
       const opacity = this.dim(loc, focus);
       entries.forEach((entry, i) => {
-        const off = fanOffset(i, entries.length, FAN_RADIUS);
+        const off = fanOffset(i, entries.length, this.geom.fanRadius);
         const center = { x: px.x + off.dx, y: px.y + off.dy };
         const selection = toSelection(entry);
         const group = this.makeSelectableGroup(selection, center, opacity);
-        this.appendArtOrFallback(group, toArt(entry), selection.kind, SLOT_SIZE);
+        this.appendArtOrFallback(group, toArt(entry), selection.kind, this.geom.slotSize);
         root.appendChild(group);
       });
     }
@@ -511,7 +554,7 @@ export class BoardMap2D implements BoardRenderer {
     group.setAttribute('data-cy', String(center.y));
     group.setAttribute(
       'transform',
-      `translate(${center.x} ${center.y}) rotate(${inwardAlignDeg(center)})`,
+      `translate(${center.x} ${center.y}) rotate(${inwardAlignDeg(this.boardData, center)})`,
     );
     if (opacity < 1) group.setAttribute('opacity', String(opacity));
     group.style.cursor = 'pointer';
@@ -558,7 +601,7 @@ export class BoardMap2D implements BoardRenderer {
 
   private dim(loc: LocationName, focus: BoardFocus): number {
     if (focus.kingdom === 'all') return 1;
-    return BOARD_LOCATION_BY_NAME[loc]?.kingdom === (focus.kingdom as BoardKingdom)
+    return this.boardData.locationByName[loc]?.kingdom === (focus.kingdom as BoardKingdom)
       ? 1
       : DIM_OPACITY;
   }
@@ -570,8 +613,8 @@ export class BoardMap2D implements BoardRenderer {
     let minY = Infinity;
     let maxX = -Infinity;
     let maxY = -Infinity;
-    for (const [loc, slots] of Object.entries(BOARD_ANCHORS)) {
-      if (BOARD_LOCATION_BY_NAME[loc]?.kingdom !== (focus.kingdom as BoardKingdom)) continue;
+    for (const [loc, slots] of Object.entries(this.boardData.def.anchors)) {
+      if (this.boardData.locationByName[loc]?.kingdom !== (focus.kingdom as BoardKingdom)) continue;
       for (const anchor of Object.values(slots)) {
         if (!anchor) continue;
         minX = Math.min(minX, anchor.x * width);
@@ -581,11 +624,12 @@ export class BoardMap2D implements BoardRenderer {
       }
     }
     if (!Number.isFinite(minX)) return full;
+    const pad = this.geom.viewboxPad;
     return {
-      x: minX - VIEWBOX_PAD,
-      y: minY - VIEWBOX_PAD,
-      w: maxX - minX + VIEWBOX_PAD * 2,
-      h: maxY - minY + VIEWBOX_PAD * 2,
+      x: minX - pad,
+      y: minY - pad,
+      w: maxX - minX + pad * 2,
+      h: maxY - minY + pad * 2,
     };
   }
 
@@ -638,7 +682,7 @@ export class BoardMap2D implements BoardRenderer {
   private beginRotate(event: MouseEvent): void {
     if (!this.svg) return;
     const rect = this.svg.getBoundingClientRect();
-    const { width, height } = BOARD_IMAGE_INFO;
+    const { width, height } = this.boardData.def.imageInfo;
     const pivot = viewBoxPointToClient(width / 2, height / 2, this.currentViewBox(), rect);
     this.rotateStart = {
       pivot,
@@ -774,7 +818,7 @@ export class BoardMap2D implements BoardRenderer {
     const ring = document.createElementNS(SVG_NS, 'circle');
     ring.setAttribute('cx', ringHost.getAttribute('data-cx') ?? '0');
     ring.setAttribute('cy', ringHost.getAttribute('data-cy') ?? '0');
-    ring.setAttribute('r', String(SELECTION_RING_R));
+    ring.setAttribute('r', String(this.geom.selectionRingR));
     ring.setAttribute('fill', 'none');
     ring.setAttribute('stroke', '#fbbf24');
     ring.setAttribute('stroke-width', '10');
@@ -794,25 +838,26 @@ interface Offset {
   dy: number;
 }
 
-const BOARD_CENTER: Point = {
-  x: BOARD_IMAGE_INFO.width / 2,
-  y: BOARD_IMAGE_INFO.height / 2,
-};
+function boardCenter(board: ResolvedBoard): Point {
+  const { width, height } = board.def.imageInfo;
+  return { x: width / 2, y: height / 2 };
+}
 
 /**
  * Degrees to rotate a token at `center` so its "up" points inward toward the board center,
  * matching the board's radially-printed spaces. Composes with the lazy-susan layer rotation.
  */
-function inwardAlignDeg(center: Point): number {
-  const deg =
-    Math.atan2(center.y - BOARD_CENTER.y, center.x - BOARD_CENTER.x) * (180 / Math.PI) - 90;
+function inwardAlignDeg(board: ResolvedBoard, center: Point): number {
+  const origin = boardCenter(board);
+  const deg = Math.atan2(center.y - origin.y, center.x - origin.x) * (180 / Math.PI) - 90;
   return Math.round(deg * 100) / 100;
 }
 
-function anchorPx(loc: LocationName, slot: AnchorSlot): Point | null {
-  const anchor = BOARD_ANCHORS[loc]?.[slot];
+function anchorPx(board: ResolvedBoard, loc: LocationName, slot: AnchorSlot): Point | null {
+  const anchor = board.def.anchors[loc]?.[slot];
   if (!anchor) return null;
-  return { x: anchor.x * BOARD_IMAGE_INFO.width, y: anchor.y * BOARD_IMAGE_INFO.height };
+  const { width, height } = board.def.imageInfo;
+  return { x: anchor.x * width, y: anchor.y * height };
 }
 
 function makeImage(url: string, size: number, off: Offset): SVGImageElement {

--- a/packages/board/src/renderers/readout.ts
+++ b/packages/board/src/renderers/readout.ts
@@ -1,6 +1,7 @@
 import type { BoardState, LocationName } from '../state/boardState';
-import { BOARD_LOCATION_BY_NAME } from '../data/udtReexports';
 import type { BoardKingdom } from '../data/udtReexports';
+import type { BoardDefinition } from '../data/boardDefinition';
+import { resolveBoard } from '../data/boardDefinition';
 import type { BoardFocus, BoardRenderer } from './shared';
 import { DEFAULT_FOCUS } from './shared';
 
@@ -16,19 +17,27 @@ import { DEFAULT_FOCUS } from './shared';
 export class BoardReadout implements BoardRenderer {
   private last = '';
 
+  /** `board` selects the location vocabulary; omit for the built-in RtDT board. */
+  constructor(private readonly board?: BoardDefinition) {}
+
   render(state: BoardState, focus: BoardFocus = DEFAULT_FOCUS): void {
-    this.last = BoardReadout.toText(state, focus);
+    this.last = BoardReadout.toText(state, focus, this.board);
   }
 
   getText(): string {
     return this.last;
   }
 
-  static toText(state: BoardState, focus: BoardFocus = DEFAULT_FOCUS): string {
+  static toText(
+    state: BoardState,
+    focus: BoardFocus = DEFAULT_FOCUS,
+    board?: BoardDefinition,
+  ): string {
     const { kingdom } = focus;
+    const { locationByName } = resolveBoard(board);
     /** A location passes the filter when focus is `all`, or its kingdom matches. */
     const inFocus = (loc: LocationName): boolean =>
-      kingdom === 'all' || BOARD_LOCATION_BY_NAME[loc]?.kingdom === (kingdom as BoardKingdom);
+      kingdom === 'all' || locationByName[loc]?.kingdom === (kingdom as BoardKingdom);
 
     const lines: string[] = [`Board — focus: ${focus.kingdom}/${focus.angle}`];
 

--- a/packages/board/src/stage/boardStageView.ts
+++ b/packages/board/src/stage/boardStageView.ts
@@ -13,6 +13,8 @@ import { BoardRenderView } from '../view/boardRenderView';
 import { mountBoardUI } from '../ui';
 import type { BoardUIHandle, BoardUIOptions } from '../ui';
 import type { BoardState } from '../state/boardState';
+import type { BoardDefinition } from '../data/boardDefinition';
+import { RTDT_BOARD_DEFINITION, isBoardCalibrated } from '../data/boardDefinition';
 import type { BoardKingdom } from '../data/udtReexports';
 import type { BoardFocus } from '../renderers/shared';
 import type {
@@ -49,6 +51,12 @@ export interface BoardStageViewOptions {
   assetBaseUrl?: string;
   /** Board surface image, e.g. `'./board.png'`. */
   boardImageUrl?: string;
+  /**
+   * The board to render. Omit for the built-in Return to Dark Tower board. A board without
+   * a full circle calibration is 2D-only: the 3D tower refuses to enable (see
+   * {@link BoardStageView.setTowerEnabled}).
+   */
+  board?: BoardDefinition;
   /** Per-token art overrides shared by the 2D map and the 3D tower. */
   tokenArt?: TokenArtConfig;
   /** Override the default token-art path; `null` → fallback. */
@@ -154,6 +162,7 @@ export class BoardStageView {
       mapContainer: this.els.mapHost,
       assetBaseUrl: options.assetBaseUrl,
       boardImageUrl: options.boardImageUrl,
+      board: options.board,
       tokenArt: options.tokenArt,
       resolveTokenImage: options.resolveTokenImage,
       enableZoom: options.enableZoom,
@@ -340,6 +349,15 @@ export class BoardStageView {
         console.warn('[BoardStageView] tower3D requested but no modelUrl was provided.');
         return;
       }
+      // The 3D disc projection needs the board's circle (center/radius/north). An
+      // uncalibrated custom board stays 2D rather than placing tokens at nonsense spots.
+      if (!isBoardCalibrated(this.options.board?.imageInfo ?? RTDT_BOARD_DEFINITION.imageInfo)) {
+        console.warn(
+          '[BoardStageView] tower3D requested but the board is not calibrated ' +
+            '(needs centerX/centerY/radius/northHeadingDegrees) — staying in 2D.',
+        );
+        return;
+      }
       if (!this.towerModule) this.towerModule = await import('../plugin/stageTower');
       this.buildTower(this.els.tower3dHost);
       this.towerEnabled = Boolean(this.tower);
@@ -398,6 +416,7 @@ export class BoardStageView {
       boardState: this.view.controller.getState(),
       assetBaseUrl: this.options.assetBaseUrl,
       boardImageUrl: this.options.boardImageUrl,
+      board: this.options.board,
       tokenArt: this.options.tokenArt,
       resolveTokenImage: this.options.resolveTokenImage,
       locationPick: this.view.locationPick,

--- a/packages/board/src/state/boardState.ts
+++ b/packages/board/src/state/boardState.ts
@@ -1,5 +1,6 @@
 import type { BoardKingdom, FoeStatus } from '../data/udtReexports';
-import { BOARD_LOCATIONS } from '../data/udtReexports';
+import type { BoardDefinition } from '../data/boardDefinition';
+import { resolveBoard } from '../data/boardDefinition';
 
 /** A `BOARD_LOCATIONS[n].name`. Kept as a string — the board never validates it. */
 export type LocationName = string;
@@ -87,16 +88,17 @@ export interface BoardState {
 }
 
 /**
- * An empty board: no heroes/foes/adversary/markers/quests, with all 16 building spaces
+ * An empty board: no heroes/foes/adversary/markers/quests, with every building space
  * present at `{ skulls: 0, destroyed: false }`. Optional keys are omitted so the
  * state round-trips through JSON without `undefined`-vs-absent mismatches.
+ *
+ * `board` selects which board's locations to seed from; omit it for the built-in
+ * Return to Dark Tower board (its 16 building spaces).
  */
-export function createDefaultBoardState(): BoardState {
+export function createDefaultBoardState(board?: BoardDefinition): BoardState {
   const buildings: Record<LocationName, BuildingState> = {};
-  for (const location of BOARD_LOCATIONS) {
-    if (location.building) {
-      buildings[location.name] = { skulls: 0, destroyed: false };
-    }
+  for (const location of resolveBoard(board).buildingLocations) {
+    buildings[location] = { skulls: 0, destroyed: false };
   }
   return { heroes: {}, foes: {}, buildings, spaceMarkers: {}, questMarkers: {} };
 }

--- a/packages/board/src/ui/index.ts
+++ b/packages/board/src/ui/index.ts
@@ -13,8 +13,6 @@ import type { BoardKingdom } from '../data/udtReexports';
 import {
   ADVERSARIES,
   ALLIES,
-  BOARD_LOCATIONS,
-  BOARD_LOCATION_BY_NAME,
   DIFFICULTIES,
   FOE_STATUSES,
   HEROES,
@@ -23,6 +21,8 @@ import {
   TIER2_FOES,
   TIER3_FOES,
 } from '../data/udtReexports';
+import type { BoardDefinition, ResolvedBoard } from '../data/boardDefinition';
+import { resolveBoard } from '../data/boardDefinition';
 import type { TokenSelection } from '../renderers/assetPaths';
 import type { LocationPickStore, PendingPlacement, SelectionStore } from './stores';
 
@@ -77,6 +77,8 @@ export interface BoardUIOptions {
   generateId?: (kind: 'foe', state: BoardState) => string;
   /** Draggable floating panels (default `true`). */
   floating?: boolean;
+  /** The board whose locations the panels offer. Omit for the built-in RtDT board. */
+  board?: BoardDefinition;
 }
 
 export interface BoardUIHandle {
@@ -90,7 +92,6 @@ const KINGDOMS: { value: BoardKingdom; label: string }[] = [
   { value: 'south', label: 'S' },
   { value: 'west', label: 'W' },
 ];
-const BUILDING_LOCATIONS = BOARD_LOCATIONS.filter((l) => l.building).map((l) => l.name);
 
 /**
  * Mounts the dockable editing UI into a host element. Returns a handle to toggle panels
@@ -103,6 +104,7 @@ export function mountBoardUI(host: HTMLElement, options: BoardUIOptions): BoardU
   const floating = options.floating ?? true;
   const rosters = resolveRosters(options.rosters);
   const genId = options.generateId ?? defaultFoeId;
+  const board = resolveBoard(options.board);
 
   const root = document.createElement('div');
   root.className = 'udt-board-ui';
@@ -124,10 +126,12 @@ export function mountBoardUI(host: HTMLElement, options: BoardUIOptions): BoardU
   };
 
   makeAndRegister('palette', 'Palette', (body) =>
-    buildPalette(body, controller, locationPick, rosters, genId),
+    buildPalette(body, controller, locationPick, rosters, genId, board),
   );
-  makeAndRegister('inspector', 'Inspector', (body) => buildInspector(body, controller, selection));
-  makeAndRegister('summary', 'Summary', (body) => buildSummary(body, controller));
+  makeAndRegister('inspector', 'Inspector', (body) =>
+    buildInspector(body, controller, selection, board),
+  );
+  makeAndRegister('summary', 'Summary', (body) => buildSummary(body, controller, board));
 
   host.appendChild(root);
 
@@ -278,6 +282,7 @@ function buildPalette(
   locationPick: LocationPickStore | undefined,
   rosters: BoardUIRosters,
   genId: (kind: 'foe', state: BoardState) => string,
+  board: ResolvedBoard,
 ): void {
   const kindSelect = makeSelect(
     [
@@ -352,7 +357,7 @@ function buildPalette(
   confirmRow.style.display = 'none';
   const hint = document.createElement('span');
   hint.className = 'udt-palette-hint';
-  let locationSelect = makeLocationSelect('all', undefined, 'udt-palette-location');
+  let locationSelect = makeLocationSelect('all', undefined, 'udt-palette-location', board);
   const confirmBtn = makeButton('Confirm', 'udt-palette-confirm-btn');
   const cancelBtn = makeButton('Cancel', 'udt-palette-cancel-btn');
   confirmRow.append(hint, locationSelect, confirmBtn, cancelBtn);
@@ -387,7 +392,7 @@ function buildPalette(
       monument: monumentCustom.value.trim() || optionText(monumentSelect),
     });
     // Rebuild the location select for the right target set.
-    const fresh = makeLocationSelect(targets, undefined, 'udt-palette-location');
+    const fresh = makeLocationSelect(targets, undefined, 'udt-palette-location', board);
     locationSelect.replaceWith(fresh);
     locationSelect = fresh;
     hint.textContent = locationPick
@@ -501,6 +506,7 @@ function buildInspector(
   body: HTMLElement,
   controller: BoardStateController,
   selection: SelectionStore,
+  board: ResolvedBoard,
 ): void {
   const render = (): void => {
     body.replaceChildren();
@@ -512,13 +518,13 @@ function buildInspector(
     const state = controller.getState();
     switch (sel.kind) {
       case 'hero':
-        renderHero(body, controller, state, sel);
+        renderHero(body, controller, state, sel, board);
         break;
       case 'foe':
-        renderFoe(body, controller, state, sel);
+        renderFoe(body, controller, state, sel, board);
         break;
       case 'adversary':
-        renderAdversary(body, controller, state);
+        renderAdversary(body, controller, state, board);
         break;
       case 'building':
         renderBuilding(body, controller, state, sel);
@@ -552,11 +558,12 @@ function renderHero(
   controller: BoardStateController,
   state: BoardState,
   sel: TokenSelection,
+  board: ResolvedBoard,
 ): void {
   const hero = state.heroes[sel.id];
   if (!hero) return void body.appendChild(emptyNote('Hero no longer on the board.'));
   body.appendChild(heading(`Hero: ${sel.id}`));
-  const move = makeLocationSelect('all', hero.location, 'udt-inspector-move');
+  const move = makeLocationSelect('all', hero.location, 'udt-inspector-move', board);
   move.addEventListener('change', () => controller.moveHero(sel.id, move.value));
   body.append(
     labeled('Location', move),
@@ -569,11 +576,12 @@ function renderFoe(
   controller: BoardStateController,
   state: BoardState,
   sel: TokenSelection,
+  board: ResolvedBoard,
 ): void {
   const foe = state.foes[sel.id];
   if (!foe) return void body.appendChild(emptyNote('Foe no longer on the board.'));
   body.appendChild(heading(`Foe: ${sel.id} (${foe.foe})`));
-  const move = makeLocationSelect('all', foe.location, 'udt-inspector-move');
+  const move = makeLocationSelect('all', foe.location, 'udt-inspector-move', board);
   move.addEventListener('change', () => controller.moveFoe(sel.id, move.value));
   const status = makeSelect(
     FOE_STATUSES.map((s) => ({ value: s, label: s })),
@@ -594,11 +602,12 @@ function renderAdversary(
   body: HTMLElement,
   controller: BoardStateController,
   state: BoardState,
+  board: ResolvedBoard,
 ): void {
   const adv = state.adversary;
   if (!adv) return void body.appendChild(emptyNote('No adversary selected.'));
   body.appendChild(heading(`Adversary: ${adv.id}`));
-  const move = makeLocationSelect('all', adv.location, 'udt-inspector-move');
+  const move = makeLocationSelect('all', adv.location, 'udt-inspector-move', board);
   move.addEventListener('change', () => controller.placeAdversary(move.value));
   body.append(
     labeled('Location', move),
@@ -681,7 +690,11 @@ function renderQuest(
 
 // ── Summary ───────────────────────────────────────────────────────────────────
 
-function buildSummary(body: HTMLElement, controller: BoardStateController): void {
+function buildSummary(
+  body: HTMLElement,
+  controller: BoardStateController,
+  board: ResolvedBoard,
+): void {
   const table = document.createElement('table');
   table.className = 'udt-summary';
   body.appendChild(table);
@@ -696,7 +709,7 @@ function buildSummary(body: HTMLElement, controller: BoardStateController): void
     for (const k of KINGDOMS) {
       const row = document.createElement('tr');
       row.setAttribute('data-kingdom', k.value);
-      const m = kingdomMetrics(state, k.value);
+      const m = kingdomMetrics(state, k.value, board);
       row.appendChild(cell('th', k.label));
       row.appendChild(metricCell('heroes', m.heroes));
       row.appendChild(metricCell('foes', m.foes));
@@ -726,8 +739,12 @@ interface KingdomMetrics {
   adversary: boolean;
 }
 
-function kingdomMetrics(state: BoardState, kingdom: BoardKingdom): KingdomMetrics {
-  const inK = (loc: LocationName): boolean => BOARD_LOCATION_BY_NAME[loc]?.kingdom === kingdom;
+function kingdomMetrics(
+  state: BoardState,
+  kingdom: BoardKingdom,
+  board: ResolvedBoard,
+): KingdomMetrics {
+  const inK = (loc: LocationName): boolean => board.locationByName[loc]?.kingdom === kingdom;
   const heroes = Object.values(state.heroes).filter((h) => inK(h.location)).length;
   const foes = Object.values(state.foes).filter((f) => inK(f.location)).length;
   let skulls = 0;
@@ -808,15 +825,17 @@ function makeLocationSelect(
   targets: 'all' | 'buildings',
   value: string | undefined,
   className: string,
+  board: ResolvedBoard,
 ): HTMLSelectElement {
   const select = document.createElement('select');
   select.className = className;
-  const names = targets === 'buildings' ? BUILDING_LOCATIONS : BOARD_LOCATIONS.map((l) => l.name);
+  const names =
+    targets === 'buildings' ? board.buildingLocations : board.def.locations.map((l) => l.name);
   for (const k of KINGDOMS) {
     const group = document.createElement('optgroup');
     group.label = k.label;
     for (const name of names) {
-      if (BOARD_LOCATION_BY_NAME[name]?.kingdom !== k.value) continue;
+      if (board.locationByName[name]?.kingdom !== k.value) continue;
       const option = document.createElement('option');
       option.value = name;
       option.textContent = name;

--- a/packages/board/src/view/boardRenderView.ts
+++ b/packages/board/src/view/boardRenderView.ts
@@ -1,5 +1,6 @@
 import { BoardStateController } from '../state/controller';
 import type { BoardState } from '../state/boardState';
+import type { BoardDefinition } from '../data/boardDefinition';
 import { createDefaultBoardState } from '../state/boardState';
 import { BoardReadout } from '../renderers/readout';
 import { BoardMap2D } from '../renderers/map2d';
@@ -41,6 +42,11 @@ export interface BoardRenderViewOptions {
   /** Base-layer board image for the 2D map. */
   boardImageUrl?: string;
   /**
+   * The board to render. Omit for the built-in Return to Dark Tower board — existing
+   * consumers need no change.
+   */
+  board?: BoardDefinition;
+  /**
    * Per-token art overrides for the 2D map (the `image2d` slot). Pass the SAME object to the
    * 3D plugin (`attachBoard3D`) for the `image3d`/`model3d` slots. See {@link TokenArtConfig}.
    */
@@ -69,7 +75,7 @@ export interface BoardRenderViewOptions {
  */
 export class BoardRenderView {
   readonly controller: BoardStateController;
-  readonly readout = new BoardReadout();
+  readonly readout: BoardReadout;
   readonly map2d?: BoardMap2D;
   /** The active token selection — written by the renderers, read by the editing UI. */
   readonly selection: SelectionStore = createSelectionStore();
@@ -84,15 +90,17 @@ export class BoardRenderView {
 
   constructor(options: BoardRenderViewOptions = {}) {
     this.controller = new BoardStateController({
-      initial: options.initialState ?? createDefaultBoardState(),
+      initial: options.initialState ?? createDefaultBoardState(options.board),
       mode: options.mode,
     });
+    this.readout = new BoardReadout(options.board);
     this.onFocusChange = options.onFocusChange;
 
     if (options.mapContainer) {
       this.map2d = new BoardMap2D(options.mapContainer, {
         assetBaseUrl: options.assetBaseUrl,
         boardImageUrl: options.boardImageUrl,
+        board: options.board,
         tokenArt: options.tokenArt,
         resolveTokenImage: options.resolveTokenImage,
         enableZoom: options.enableZoom,
@@ -121,6 +129,8 @@ export class BoardRenderView {
         selection: this.selection,
         locationPick: this.locationPick,
         ...options.ui,
+        // The view owns the board; `ui.board` must not disagree with what the map renders.
+        board: options.board,
       });
     }
 

--- a/packages/core/tools/location-marker/README.md
+++ b/packages/core/tools/location-marker/README.md
@@ -14,6 +14,16 @@ This is **dev-only** — it has no runtime relationship to the published package
 package's `files` whitelist already excludes `tools/`). It only _produces files_ that
 get dropped into the library's `src/`.
 
+> **Authoring a _custom_ board? Use the Creator app's Board Designer instead**
+> (the **Boards** tab — see [`docs/creator/board-designer.md`](../../../../docs/creator/board-designer.md)).
+> It does the same job — locations, anchors, adjacency, circle calibration — but against
+> your own art, and stores the result in the scenario document (`library.boards`), so the
+> board renders and plays in `@udtc/player` with no code changes.
+>
+> This tool remains the pipeline for the **built-in Return to Dark Tower board data**: it is
+> what regenerates `BOARD_ANCHORS` / `BOARD_ADJACENCY` / `BOARD_IMAGE_INFO` as generated
+> TypeScript in `packages/core/src/data/board/` via `gen-board-data.mjs`.
+
 ## Run it
 
 No build step, no dependencies. Either:

--- a/packages/creator-adapters/src/board-def.ts
+++ b/packages/creator-adapters/src/board-def.ts
@@ -1,0 +1,70 @@
+// Resolves the board a scenario plays on.
+//
+// `setup.board` is a oneOf: `{boardStateRef}` / `{boardState}` mean the implicit built-in
+// Return to Dark Tower board (the pre-0.4.6 behaviour), while `{boardRef}` names an entry in
+// `library.boards` — a creator-authored custom board. `resolveActiveBoardDef` returns `null`
+// for the implicit case, which every consumer reads as "use the RtDT default".
+//
+// The `BoardDefinition` import is type-only (precedent: `board.ts`), so this module adds no
+// runtime dependency on `ultimatedarktowerboard`.
+
+import type { BoardDefinition } from 'ultimatedarktowerboard';
+
+/** The custom board a scenario selected, plus where its art lives. */
+export interface ActiveBoard {
+  boardId: string;
+  def: BoardDefinition;
+  /** `library.resources.images` key for the board art, if the author supplied one. */
+  imageRef?: string;
+}
+
+function obj(v: unknown): Record<string, unknown> | undefined {
+  return v !== null && typeof v === 'object' && !Array.isArray(v)
+    ? (v as Record<string, unknown>)
+    : undefined;
+}
+function str(v: unknown): string | undefined {
+  return typeof v === 'string' ? v : undefined;
+}
+
+/**
+ * Coerces a raw `library.boards[id]` entry into a `BoardDefinition`. The document has already
+ * passed L1 (the schema pins the shape), so this is a narrow structural cast rather than a
+ * re-validation — it only guards the fields consumers dereference without checking.
+ */
+export function boardDefFromLibrary(id: string, raw: unknown): BoardDefinition | null {
+  const b = obj(raw);
+  if (!b) return null;
+  const imageInfo = obj(b['imageInfo']);
+  const locations = b['locations'];
+  if (!imageInfo || !Array.isArray(locations)) return null;
+  return {
+    id: str(b['id']) ?? id,
+    name: str(b['name']),
+    imageInfo: imageInfo as unknown as BoardDefinition['imageInfo'],
+    locations: locations as unknown as BoardDefinition['locations'],
+    anchors: (obj(b['anchors']) ?? {}) as unknown as BoardDefinition['anchors'],
+    adjacency: obj(b['adjacency']) as unknown as BoardDefinition['adjacency'],
+  };
+}
+
+/**
+ * The custom board this scenario plays on, or `null` for the implicit built-in RtDT board
+ * (no `boardRef`, or a `boardRef` that doesn't resolve — L2 reports the dangling ref; runtime
+ * degrades to the default rather than throwing).
+ */
+export function resolveActiveBoardDef(scenario: unknown): ActiveBoard | null {
+  const s = obj(scenario);
+  if (!s) return null;
+  const board = obj(obj(s['setup'])?.['board']);
+  const boardId = board ? str(board['boardRef']) : undefined;
+  if (!boardId) return null;
+
+  const boards = obj(obj(s['library'])?.['boards']);
+  const raw = boards?.[boardId];
+  if (raw === undefined) return null;
+
+  const def = boardDefFromLibrary(boardId, raw);
+  if (!def) return null;
+  return { boardId, def, imageRef: str(obj(raw)?.['imageRef']) };
+}

--- a/packages/creator-adapters/src/board.ts
+++ b/packages/creator-adapters/src/board.ts
@@ -8,10 +8,18 @@
 // exists once the promise resolves. Callers wanting the live state should attach via
 // `onReady`/`isReady` rather than reading `getState()` before it resolves ({}).
 
-import type { BoardState as UDTBoardState } from 'ultimatedarktowerboard';
+import type { BoardState as UDTBoardState, BoardDefinition } from 'ultimatedarktowerboard';
 
 export type BoardState = UDTBoardState;
 export type BoardMutateCommand = { command: string; args: Record<string, unknown> };
+
+export interface BoardAdapterOptions {
+  /**
+   * The board to track state for. Omit for the built-in Return to Dark Tower board —
+   * a custom board seeds its own building spaces instead of RtDT's 16.
+   */
+  board?: BoardDefinition;
+}
 
 // Minimal interface covering the BoardStateController methods we call.
 type BoardCtrl = {
@@ -32,7 +40,7 @@ type BoardCtrl = {
   reset(): void;
 };
 
-export function createBoardAdapter(): {
+export function createBoardAdapter(opts: BoardAdapterOptions = {}): {
   getState: () => BoardState;
   loadState: (state: BoardState) => void;
   mutate: (cmd: BoardMutateCommand) => void;
@@ -53,7 +61,7 @@ export function createBoardAdapter(): {
     .then(({ BoardStateController, createDefaultBoardState }) => {
       ctrl = new (
         BoardStateController as new (opts: { initial: BoardState; mode: string }) => BoardCtrl
-      )({ initial: createDefaultBoardState() as BoardState, mode: 'self' });
+      )({ initial: createDefaultBoardState(opts.board) as BoardState, mode: 'self' });
       for (const cmd of pendingMutations.splice(0)) mutate(cmd);
       ready = true;
       for (const cb of readyCbs.splice(0)) cb();

--- a/packages/creator-adapters/src/index.ts
+++ b/packages/creator-adapters/src/index.ts
@@ -5,7 +5,10 @@ export { getUDTReferenceLayer } from './udt';
 export type { UDTReferenceLayer } from './udt';
 
 export { createBoardAdapter } from './board';
-export type { BoardState, BoardMutateCommand } from './board';
+export type { BoardState, BoardMutateCommand, BoardAdapterOptions } from './board';
+
+export { resolveActiveBoardDef, boardDefFromLibrary } from './board-def';
+export type { ActiveBoard } from './board-def';
 
 export { createDisplayAdapter } from './display';
 export type { DisplayAdapter, ScheduledSnapshot } from './display';

--- a/packages/creator-adapters/src/udt.ts
+++ b/packages/creator-adapters/src/udt.ts
@@ -10,7 +10,13 @@ import { data, seed, GLYPHS, TOWER_LIGHT_SEQUENCES, TOWER_AUDIO_LIBRARY } from '
 
 const { FOE_BY_ID, ADVERSARY_ROSTER, ALL_FOES, FOES } = data.foes;
 const { HEROES, HERO_BY_ID } = data.heroes;
-const { BOARD_LOCATIONS, BOARD_LOCATION_BY_NAME } = data.board;
+const {
+  BOARD_LOCATIONS,
+  BOARD_LOCATION_BY_NAME,
+  BOARD_ANCHORS,
+  BOARD_ADJACENCY,
+  BOARD_IMAGE_INFO,
+} = data.board;
 const { TIER1_FOES, TIER2_FOES, TIER3_FOES, ADVERSARIES, ALLIES } = seed;
 
 export type Foe = data.foes.Foe;
@@ -37,6 +43,13 @@ export interface UDTReferenceLayer {
   heroById: typeof HERO_BY_ID;
   boardLocations: typeof BOARD_LOCATIONS;
   boardLocationByName: typeof BOARD_LOCATION_BY_NAME;
+  /** Layout anchors / movement graph / image metadata for the built-in RtDT board. Exposed so
+   *  browser consumers (the Creator's RtDT board preset) can read them without importing
+   *  `ultimatedarktower` — or `ultimatedarktowerboard`, whose entry re-exports it — directly.
+   *  Both drag UDT's Node-only BLE stack (`@stoprocent/noble`) into a browser bundle. */
+  boardAnchors: typeof BOARD_ANCHORS;
+  boardAdjacency: typeof BOARD_ADJACENCY;
+  boardImageInfo: typeof BOARD_IMAGE_INFO;
   glyphs: typeof GLYPHS;
   lightSequences: typeof TOWER_LIGHT_SEQUENCES;
   audioLibrary: typeof TOWER_AUDIO_LIBRARY;
@@ -57,6 +70,9 @@ export function getUDTReferenceLayer(): UDTReferenceLayer {
     heroById: HERO_BY_ID,
     boardLocations: BOARD_LOCATIONS,
     boardLocationByName: BOARD_LOCATION_BY_NAME,
+    boardAnchors: BOARD_ANCHORS,
+    boardAdjacency: BOARD_ADJACENCY,
+    boardImageInfo: BOARD_IMAGE_INFO,
     glyphs: GLYPHS,
     lightSequences: TOWER_LIGHT_SEQUENCES,
     audioLibrary: TOWER_AUDIO_LIBRARY,

--- a/packages/creator-adapters/src/validate-refs.ts
+++ b/packages/creator-adapters/src/validate-refs.ts
@@ -2,6 +2,7 @@
 // or a valid intra-file library key. A miss is a hard fail — callers must block execution.
 
 import { getUDTReferenceLayer } from './udt';
+import { resolveActiveBoardDef } from './board-def';
 
 export type L2Result = { ok: boolean; errors: string[] };
 
@@ -25,6 +26,78 @@ export function validateRefs(scenario: unknown): L2Result {
 
   const setup = obj(s['setup']);
   const selections = setup ? obj(setup['selections']) : undefined;
+
+  // The location vocabulary every location-typed ref is checked against: the active custom
+  // board's names, or UDT's built-in RtDT roster when no custom board is selected.
+  const activeBoard = resolveActiveBoardDef(s);
+  const activeLocations: ReadonlySet<string> = activeBoard
+    ? new Set(activeBoard.def.locations.map((l) => l.name))
+    : new Set(Object.keys(udt.boardLocationByName));
+  const locationSource = activeBoard
+    ? `library.boards.${activeBoard.boardId}`
+    : 'UDT BOARD_LOCATIONS';
+
+  // A boardRef must name a real library.boards entry.
+  const boardRef = setup ? str(obj(setup['board'])?.['boardRef']) : undefined;
+  const boardsLib = obj(obj(s['library'])?.['boards']);
+  if (boardRef !== undefined && !(boardsLib && boardRef in boardsLib)) {
+    errors.push(`setup.board.boardRef "${boardRef}" is not a key in library.boards`);
+  }
+
+  // Per-board integrity: unique names; anchors/adjacency confined to this board's locations;
+  // adjacency symmetric. Checked for EVERY authored board, not just the active one, so an
+  // inactive board can't rot unnoticed.
+  if (boardsLib) {
+    for (const [bId, bRaw] of Object.entries(boardsLib)) {
+      const b = obj(bRaw);
+      if (!b) continue;
+      const locs = arr(b['locations']) ?? [];
+      const names = new Set<string>();
+      for (const lRaw of locs) {
+        const name = str(obj(lRaw)?.['name']);
+        if (name === undefined) continue;
+        if (names.has(name)) {
+          errors.push(`board "${bId}" has duplicate location name "${name}"`);
+        }
+        names.add(name);
+      }
+
+      const anchors = obj(b['anchors']);
+      if (anchors) {
+        for (const key of Object.keys(anchors)) {
+          if (!names.has(key)) {
+            errors.push(`board "${bId}" anchors key "${key}" is not a location on that board`);
+          }
+        }
+      }
+
+      const adjacency = obj(b['adjacency']);
+      if (adjacency) {
+        for (const [from, toRaw] of Object.entries(adjacency)) {
+          if (!names.has(from)) {
+            errors.push(`board "${bId}" adjacency key "${from}" is not a location on that board`);
+            continue;
+          }
+          for (const toVal of arr(toRaw) ?? []) {
+            const to = str(toVal);
+            if (to === undefined) continue;
+            if (!names.has(to)) {
+              errors.push(
+                `board "${bId}" adjacency "${from}" → "${to}" names a location not on that board`,
+              );
+              continue;
+            }
+            const back = arr(adjacency[to]) ?? [];
+            if (!back.some((v) => str(v) === from)) {
+              errors.push(
+                `board "${bId}" adjacency is not symmetric: "${from}" lists "${to}", but "${to}" does not list "${from}"`,
+              );
+            }
+          }
+        }
+      }
+    }
+  }
 
   // adversaryId must be a known adversary
   const adversaryId = selections ? str(selections['adversaryId']) : undefined;
@@ -97,9 +170,9 @@ export function validateRefs(scenario: unknown): L2Result {
         errors.push(`${ctx} foeId "${foeId}" is not in the UDT foe roster`);
       }
     }
-    if (location !== undefined && !(location in udt.boardLocationByName)) {
+    if (location !== undefined && !activeLocations.has(location)) {
       errors.push(
-        `${ctx} location "${location}" is not a known board location (UDT BOARD_LOCATIONS)`,
+        `${ctx} location "${location}" is not a known board location (${locationSource})`,
       );
     }
   };

--- a/packages/creator-adapters/test/board-def.test.ts
+++ b/packages/creator-adapters/test/board-def.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect } from 'vitest';
+import { resolveActiveBoardDef, boardDefFromLibrary, validateRefs } from '../src/index';
+
+const BOARD = {
+  id: 'shattered-reach',
+  name: 'The Shattered Reach',
+  imageRef: 'board-shattered-reach',
+  imageInfo: { width: 2048, height: 2048 },
+  locations: [
+    { name: 'Emberfall', kingdom: 'north', terrain: 'Ash Flats', building: 'citadel' },
+    { name: 'Coldwatch', kingdom: 'north', terrain: 'Tundra' },
+  ],
+  anchors: { Emberfall: { hero: { x: 0.2, y: 0.2 } } },
+  adjacency: { Emberfall: ['Coldwatch'], Coldwatch: ['Emberfall'] },
+};
+
+/** A scenario shell that is only as complete as these tests need. */
+function scenario(over: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    schemaVersion: '0.4.6',
+    setup: { board: { boardRef: 'shattered-reach' } },
+    library: { boards: { 'shattered-reach': BOARD } },
+    graph: { nodes: [] },
+    ...over,
+  };
+}
+
+describe('resolveActiveBoardDef', () => {
+  it('resolves an authored boardRef to its definition', () => {
+    const active = resolveActiveBoardDef(scenario());
+    expect(active).not.toBeNull();
+    expect(active?.boardId).toBe('shattered-reach');
+    expect(active?.imageRef).toBe('board-shattered-reach');
+    expect(active?.def.locations.map((l) => l.name)).toEqual(['Emberfall', 'Coldwatch']);
+  });
+
+  it('returns null for the implicit RtDT board (boardStateRef / boardState branches)', () => {
+    expect(
+      resolveActiveBoardDef(scenario({ setup: { board: { boardStateRef: 'board-main' } } })),
+    ).toBeNull();
+    expect(
+      resolveActiveBoardDef(scenario({ setup: { board: { boardState: { home: {} } } } })),
+    ).toBeNull();
+  });
+
+  it('returns null (not a throw) for a DANGLING boardRef — L2 reports it separately', () => {
+    const doc = scenario({ library: { boards: {} } });
+    expect(resolveActiveBoardDef(doc)).toBeNull();
+  });
+
+  it('returns null for junk input', () => {
+    expect(resolveActiveBoardDef(null)).toBeNull();
+    expect(resolveActiveBoardDef({})).toBeNull();
+    expect(resolveActiveBoardDef({ setup: {} })).toBeNull();
+  });
+});
+
+describe('boardDefFromLibrary', () => {
+  it('falls back to the registry key when the entry has no id', () => {
+    const def = boardDefFromLibrary('my-key', { ...BOARD, id: undefined });
+    expect(def?.id).toBe('my-key');
+  });
+
+  it('rejects entries missing imageInfo or locations', () => {
+    expect(boardDefFromLibrary('x', { imageInfo: { width: 1, height: 1 } })).toBeNull();
+    expect(boardDefFromLibrary('x', { locations: [] })).toBeNull();
+    expect(boardDefFromLibrary('x', 'nope')).toBeNull();
+  });
+
+  it('defaults anchors to an empty map so consumers can index it safely', () => {
+    const def = boardDefFromLibrary('x', { ...BOARD, anchors: undefined });
+    expect(def?.anchors).toEqual({});
+  });
+});
+
+describe('validateRefs — board vocabulary', () => {
+  // lifecycle.boardSetup is the node whose `spawns[]` resolve foeId + location (validate-refs
+  // also checks a foe.spawn EFFECT; both go through the same checkSpawn).
+  const spawnNode = (location: string) => ({
+    id: 'n1',
+    kind: 'lifecycle.boardSetup',
+    props: { spawns: [{ foeId: 'brigands', location }] },
+  });
+
+  it("accepts a spawn at the CUSTOM board's location", () => {
+    const doc = scenario({ graph: { nodes: [spawnNode('Emberfall')] } });
+    const res = validateRefs(doc);
+    expect(res.errors.filter((e) => e.includes('Emberfall'))).toEqual([]);
+  });
+
+  it('rejects an RtDT location once a custom board is active, naming the board as the source', () => {
+    const doc = scenario({ graph: { nodes: [spawnNode('Broken Lands')] } });
+    const res = validateRefs(doc);
+    const err = res.errors.find((e) => e.includes('Broken Lands'));
+    expect(err).toContain('library.boards.shattered-reach');
+  });
+
+  it('still validates against the UDT roster when no custom board is active', () => {
+    const doc = scenario({
+      setup: { board: { boardStateRef: 'board-main' } },
+      library: {},
+      graph: { nodes: [spawnNode('Broken Lands')] },
+    });
+    expect(validateRefs(doc).errors.filter((e) => e.includes('Broken Lands'))).toEqual([]);
+
+    const bad = scenario({
+      setup: { board: { boardStateRef: 'board-main' } },
+      library: {},
+      graph: { nodes: [spawnNode('Emberfall')] },
+    });
+    expect(validateRefs(bad).errors.find((e) => e.includes('Emberfall'))).toContain(
+      'UDT BOARD_LOCATIONS',
+    );
+  });
+
+  it('flags a dangling boardRef', () => {
+    const doc = scenario({ library: { boards: {} } });
+    expect(validateRefs(doc).errors).toContain(
+      'setup.board.boardRef "shattered-reach" is not a key in library.boards',
+    );
+  });
+});
+
+describe('validateRefs — per-board integrity', () => {
+  const withBoard = (patch: Record<string, unknown>) =>
+    scenario({ library: { boards: { 'shattered-reach': { ...BOARD, ...patch } } } });
+
+  it('accepts a well-formed board', () => {
+    expect(validateRefs(scenario()).errors).toEqual([]);
+  });
+
+  it('flags duplicate location names', () => {
+    const doc = withBoard({
+      locations: [...BOARD.locations, { name: 'Emberfall', kingdom: 'south', terrain: 'Bog' }],
+    });
+    expect(validateRefs(doc).errors).toContain(
+      'board "shattered-reach" has duplicate location name "Emberfall"',
+    );
+  });
+
+  it('flags anchors keyed to a non-location', () => {
+    const doc = withBoard({ anchors: { Nowhere: { hero: { x: 0.1, y: 0.1 } } } });
+    expect(validateRefs(doc).errors).toContain(
+      'board "shattered-reach" anchors key "Nowhere" is not a location on that board',
+    );
+  });
+
+  it('flags adjacency pointing off-board', () => {
+    const doc = withBoard({ adjacency: { Emberfall: ['Atlantis'] } });
+    expect(validateRefs(doc).errors.some((e) => e.includes('"Emberfall" → "Atlantis"'))).toBe(true);
+  });
+
+  it('flags ASYMMETRIC adjacency', () => {
+    const doc = withBoard({ adjacency: { Emberfall: ['Coldwatch'] } }); // no reverse edge
+    expect(
+      validateRefs(doc).errors.some(
+        (e) => e.includes('not symmetric') && e.includes('Emberfall') && e.includes('Coldwatch'),
+      ),
+    ).toBe(true);
+  });
+
+  it('checks EVERY authored board, not just the active one', () => {
+    const doc = scenario({
+      library: {
+        boards: {
+          'shattered-reach': BOARD,
+          spare: { ...BOARD, id: 'spare', adjacency: { Emberfall: ['Coldwatch'] } },
+        },
+      },
+    });
+    expect(validateRefs(doc).errors.some((e) => e.includes('board "spare"'))).toBe(true);
+  });
+});

--- a/packages/creator-engine/src/engine/setup.ts
+++ b/packages/creator-engine/src/engine/setup.ts
@@ -17,7 +17,49 @@ import type {
   Effect,
   Directive,
   ScenarioLibrary,
+  ScenarioBoardDef,
+  BuildingType,
 } from './types';
+
+/**
+ * Synthesizes the `{home, buildings}` board state a custom board (schema 0.4.6
+ * `setup.board.boardRef` → `library.boards`) implies, so it feeds the exact same downstream
+ * path as a hand-authored inline `boardState`.
+ *
+ * - `buildings`: every location carrying a building, in authored order.
+ * - `home[kingdom]`: that kingdom's FIRST citadel location — where its hero starts.
+ *
+ * Building types are compared case-insensitively: the schema's enum is lowercase, but core's
+ * `BuildingType` is capitalized ('Citadel'), and a board can be built from either source.
+ *
+ * Returns `null` when there's no `boardRef`, it doesn't resolve, or the board has no locations —
+ * every one of which leaves the caller on the pre-0.4.6 default path.
+ */
+function boardStateFromDef(def: ScenarioBoardDef): {
+  home: Record<string, string>;
+  buildings: Array<{ kingdom: Kingdom; type: BuildingType; location: string }>;
+} | null {
+  const locations = def.locations;
+  if (!Array.isArray(locations) || locations.length === 0) return null;
+  const home: Record<string, string> = {};
+  const buildings: Array<{ kingdom: Kingdom; type: BuildingType; location: string }> = [];
+  for (const loc of locations) {
+    if (!loc || !loc.building) continue;
+    const type = String(loc.building).toLowerCase();
+    buildings.push({ kingdom: loc.kingdom, type: type as BuildingType, location: loc.name });
+    if (type === 'citadel' && home[loc.kingdom] === undefined) home[loc.kingdom] = loc.name;
+  }
+  return { home, buildings };
+}
+
+/** Resolves `setup.board.boardRef` against `library.boards` and synthesizes its board state. */
+function boardStateFromRef(sc: Scenario): ReturnType<typeof boardStateFromDef> {
+  const ref = sc.setup.board && sc.setup.board.boardRef;
+  if (!ref) return null;
+  const def = sc.library.boards && sc.library.boards[ref];
+  if (!def) return null;
+  return boardStateFromDef(def);
+}
 
 // ---------- public API: init (§2.3) ----------
 export function buildKingdoms(
@@ -125,7 +167,11 @@ export function init(scenario: unknown, opts: InitOpts): StepResult {
   // Buildings registry + hero start locations from the authored (opaque-to-L1) boardState:
   // { home: { kingdom: location }, buildings: [{ kingdom, type, location }] }. Heroes start on
   // their home kingdom's citadel space (rules.md §Hero Setup).
-  const boardState = (sc.setup.board && sc.setup.board.boardState) || null;
+  // A `boardRef` (schema 0.4.6) names a custom board in library.boards; its locations imply the
+  // same {home, buildings} shape an inline boardState spells out, so everything downstream is
+  // unchanged. An inline boardState always wins — the branches are mutually exclusive in the
+  // schema, and this ordering keeps every pre-0.4.6 document on its original path.
+  const boardState = (sc.setup.board && sc.setup.board.boardState) || boardStateFromRef(sc) || null;
   const buildings =
     boardState && Array.isArray(boardState.buildings)
       ? boardState.buildings.map((b) => ({

--- a/packages/creator-engine/src/engine/types.ts
+++ b/packages/creator-engine/src/engine/types.ts
@@ -405,6 +405,23 @@ export interface ScenarioLibrary {
    * validate lifecycle.selectHero's authored pool, never mutates it (the runtime pick lands on
    * HeroState.heroRef instead). */
   heroes?: Record<string, { heroId: string; source?: string }>;
+  /** custom game boards (schema 0.4.6 library.boards). Deliberately a MINIMAL view: setup only
+   *  needs each location's kingdom/building to synthesize hero homes + the buildings registry.
+   *  Anchors/adjacency/imageInfo are presentational and never reach engine state. */
+  boards?: Record<string, ScenarioBoardDef>;
+}
+
+/** The engine's structural view of a `library.boards` entry — see {@link ScenarioLibrary.boards}. */
+export interface ScenarioBoardDef {
+  id?: string;
+  name?: string;
+  locations?: Array<{
+    name: string;
+    kingdom: Kingdom;
+    terrain?: string;
+    /** lowercase in the schema, but compared case-insensitively — core spells it 'Citadel'. */
+    building?: string;
+  }>;
 }
 
 // ---- effects (§4.3 closed verb vocabulary) ----
@@ -809,6 +826,9 @@ export interface Scenario {
         home?: Record<string, string>;
         buildings?: Array<{ kingdom: Kingdom; type: BuildingType; location: string }>;
       };
+      /** schema 0.4.6 — names a `library.boards` entry (a custom board). Mutually exclusive
+       *  with `boardState`; when set, setup synthesizes the board state from that definition. */
+      boardRef?: string;
     };
     selections: {
       // Optional since schema 0.4.1: rule-variant scenarios may omit the standard adversary/

--- a/packages/creator-engine/test/board_test.js
+++ b/packages/creator-engine/test/board_test.js
@@ -1,0 +1,192 @@
+// board_test.js — custom game boards (schema 0.4.6 setup.board.boardRef → library.boards).
+//
+// Setup synthesizes the same {home, buildings} shape a hand-authored inline boardState spells
+// out, so nothing downstream changes: hero start locations come from each kingdom's citadel and
+// the buildings registry from every location carrying a building. The golden/lockstep streams
+// are unaffected because this branch only activates when a boardRef is authored (proved by
+// lockstep_test.js / fixture_test.js staying green).
+
+const engine = require('../dist/engine');
+const { golden } = require('../dist/golden-fixture');
+
+let pass = 0,
+  fail = 0;
+function ok(name, cond, extra) {
+  if (cond) {
+    pass++;
+    console.log('PASS  ' + name);
+  } else {
+    fail++;
+    console.log('XXXX  ' + name + (extra ? '  — ' + extra : ''));
+  }
+}
+function check(name, fn) {
+  try {
+    ok(name, fn());
+  } catch (e) {
+    fail++;
+    console.log('XXXX  ' + name + '  — threw: ' + e.message);
+  }
+}
+
+const clone = (o) => JSON.parse(JSON.stringify(o));
+
+/** A 4-kingdom custom board: one citadel each, plus assorted other buildings. */
+function customBoard(overrides) {
+  return Object.assign(
+    {
+      id: 'shattered-reach',
+      name: 'The Shattered Reach',
+      imageInfo: { width: 2048, height: 2048 },
+      locations: [
+        { name: 'Emberfall', kingdom: 'north', terrain: 'Ash', building: 'citadel' },
+        { name: 'Coldwatch', kingdom: 'north', terrain: 'Tundra' },
+        { name: 'Saltmere', kingdom: 'north', terrain: 'Lake', building: 'bazaar' },
+        { name: 'Kingsreach', kingdom: 'south', terrain: 'Plains', building: 'citadel' },
+        { name: 'Thornhollow', kingdom: 'east', terrain: 'Forest', building: 'citadel' },
+        { name: 'Gravelrun', kingdom: 'west', terrain: 'Hills', building: 'citadel' },
+      ],
+    },
+    overrides || {},
+  );
+}
+
+/** The golden fixture, re-pointed at a custom board. */
+function withBoard(board) {
+  const sc = clone(golden);
+  sc.schemaVersion = '0.4.6';
+  sc.setup.board = { boardRef: board.id };
+  sc.library.boards = { [board.id]: board };
+  return sc;
+}
+
+const init = (sc, playerCount) =>
+  engine.init(sc, { seed: 'board-test-seed', playerCount: playerCount || 1 });
+
+// ---------- hero homes ----------
+
+check("boardRef: the hero starts on its kingdom's citadel", () => {
+  const r = init(withBoard(customBoard()));
+  // playerCount 1 ⇒ north is the only active kingdom (see golden's dormant split).
+  return r.state.heroes.hero1.location === 'Emberfall';
+});
+
+check('boardRef: each active kingdom gets its OWN citadel as its hero home', () => {
+  const r = init(withBoard(customBoard()), 4);
+  const owner = r.state.kingdoms.ownership;
+  const at = (k) => r.state.heroes[owner[k]].location;
+  return (
+    at('north') === 'Emberfall' &&
+    at('south') === 'Kingsreach' &&
+    at('east') === 'Thornhollow' &&
+    at('west') === 'Gravelrun'
+  );
+});
+
+check('boardRef: the FIRST citadel in a kingdom wins when several are authored', () => {
+  const board = customBoard({
+    locations: [
+      { name: 'First Keep', kingdom: 'north', terrain: 'Ash', building: 'citadel' },
+      { name: 'Second Keep', kingdom: 'north', terrain: 'Ash', building: 'citadel' },
+    ],
+  });
+  return init(withBoard(board)).state.heroes.hero1.location === 'First Keep';
+});
+
+check('boardRef: a kingdom with no citadel leaves its hero unplaced (null, not a throw)', () => {
+  const board = customBoard({
+    locations: [{ name: 'Coldwatch', kingdom: 'north', terrain: 'Tundra' }],
+  });
+  return init(withBoard(board)).state.heroes.hero1.location === null;
+});
+
+// ---------- buildings registry ----------
+
+check('boardRef: buildings registry lists every building location, in authored order', () => {
+  const r = init(withBoard(customBoard()), 4);
+  const locs = r.state.buildings.map((b) => b.location);
+  return (
+    locs.join(',') === 'Emberfall,Saltmere,Kingsreach,Thornhollow,Gravelrun' &&
+    r.state.buildings.every((b) => b.skulls === 0 && b.destroyed === false)
+  );
+});
+
+check('boardRef: a location with no building is not in the registry', () => {
+  const r = init(withBoard(customBoard()), 4);
+  return !r.state.buildings.some((b) => b.location === 'Coldwatch');
+});
+
+check('boardRef: building types + kingdoms are carried through', () => {
+  const r = init(withBoard(customBoard()), 4);
+  const saltmere = r.state.buildings.find((b) => b.location === 'Saltmere');
+  return saltmere.type === 'bazaar' && saltmere.kingdom === 'north';
+});
+
+// ---------- the case trap ----------
+
+check("boardRef: CAPITALIZED building names are matched case-insensitively ('Citadel')", () => {
+  // Core spells it 'Citadel'; the Creator schema's enum is lowercase. A board built from either
+  // source must place heroes and normalize the registry the same way.
+  const board = customBoard({
+    locations: [
+      { name: 'Emberfall', kingdom: 'north', terrain: 'Ash', building: 'Citadel' },
+      { name: 'Saltmere', kingdom: 'north', terrain: 'Lake', building: 'BAZAAR' },
+    ],
+  });
+  const r = init(withBoard(board));
+  const types = r.state.buildings.map((b) => b.type).join(',');
+  return r.state.heroes.hero1.location === 'Emberfall' && types === 'citadel,bazaar';
+});
+
+// ---------- precedence + inertness ----------
+
+check('an inline boardState still wins over a boardRef (pre-0.4.6 documents are untouched)', () => {
+  const sc = withBoard(customBoard());
+  sc.setup.board = {
+    boardState: {
+      home: { north: 'Hand-Authored Keep' },
+      buildings: [{ kingdom: 'north', type: 'citadel', location: 'Hand-Authored Keep' }],
+    },
+  };
+  const r = init(sc);
+  return (
+    r.state.heroes.hero1.location === 'Hand-Authored Keep' &&
+    r.state.buildings.length === 1 &&
+    r.state.buildings[0].location === 'Hand-Authored Keep'
+  );
+});
+
+check('a DANGLING boardRef falls back to the default (no buildings, no throw)', () => {
+  const sc = withBoard(customBoard());
+  sc.library.boards = {};
+  const r = init(sc);
+  return r.state.buildings === undefined && r.state.heroes.hero1.location === null;
+});
+
+check('a board with NO locations falls back to the default', () => {
+  const sc = withBoard(customBoard({ locations: [] }));
+  const r = init(sc);
+  return r.state.buildings === undefined && r.state.heroes.hero1.location === null;
+});
+
+check('the golden fixture (boardStateRef, no boardRef) is completely unaffected', () => {
+  const a = engine.digest(init(golden).state);
+  const b = engine.digest(init(clone(golden)).state);
+  const untouched = init(golden);
+  return (
+    a === b &&
+    untouched.state.buildings === undefined &&
+    untouched.state.heroes.hero1.location === null
+  );
+});
+
+check('adding an UNREFERENCED library.boards entry does not change the digest', () => {
+  // Adjacency/anchors/imageInfo never reach engine state, and an unused board must not either.
+  const before = engine.digest(init(golden).state);
+  const sc = clone(golden);
+  sc.library.boards = { 'shattered-reach': customBoard() };
+  return engine.digest(init(sc).state) === before;
+});
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/packages/creator-engine/test/run-all.js
+++ b/packages/creator-engine/test/run-all.js
@@ -8,6 +8,7 @@ const suites = [
   'battle_test.js',
   'battle_cards_test.js',
   'dungeon_test.js',
+  'board_test.js',
   'lockstep_test.js',
   'corpus_test.js',
   'fixture_test.js',

--- a/packages/creator-schema/fixtures/invalid/invalid-28-board-def-bad.json
+++ b/packages/creator-schema/fixtures/invalid/invalid-28-board-def-bad.json
@@ -1,0 +1,334 @@
+{
+  "schemaVersion": "0.4.6",
+  "meta": {
+    "title": "v0.4.6 fixture: invalid boardDef (capitalized building, unknown prop)",
+    "scenarioVersion": "0.1.0",
+    "designer": {
+      "name": "Test"
+    },
+    "pins": {
+      "udt": "5.0.0"
+    }
+  },
+  "setup": {
+    "mode": "coop",
+    "difficulty": {
+      "profile": "heroic",
+      "skullSupply": 24
+    },
+    "playerCountScaling": {
+      "turnsPerMonth": {
+        "1": 6,
+        "2": 7,
+        "3": 8,
+        "4": 9
+      }
+    },
+    "monthEnd": {
+      "resolution": "randomInRange",
+      "default": {
+        "minTurn": 3,
+        "maxTurn": 6
+      }
+    },
+    "selections": {
+      "adversaryId": "ashstrider",
+      "foes": {
+        "tier1": "brigands",
+        "tier2": "frost-trolls",
+        "tier3": "dragons"
+      },
+      "mainGoalId": "recover-azkols-treasures"
+    },
+    "board": {
+      "boardRef": "shattered-reach"
+    }
+  },
+  "library": {
+    "resources": {
+      "images": {
+        "dungeon-bitmap": "data:image/png;base64,iVBORw0KGgo=",
+        "board-shattered-reach": "data:image/png;base64,iVBORw0KGgo="
+      }
+    },
+    "buildingTypes": {
+      "citadel": {
+        "free": [
+          {
+            "op": "resource.gain",
+            "resource": "warriors",
+            "amount": 1
+          }
+        ],
+        "enhanced": {
+          "cost": {
+            "resource": "spirit",
+            "amount": 1
+          },
+          "effects": [
+            {
+              "op": "resource.gain",
+              "resource": "warriors",
+              "amount": 2
+            }
+          ]
+        },
+        "skullCapacity": 3
+      },
+      "sanctuary": {
+        "free": [
+          {
+            "op": "resource.gain",
+            "resource": "warriors",
+            "amount": 1
+          }
+        ],
+        "enhanced": {
+          "cost": {
+            "resource": "spirit",
+            "amount": 1
+          },
+          "effects": [
+            {
+              "op": "corruption.remove",
+              "all": true
+            }
+          ]
+        },
+        "skullCapacity": 3
+      },
+      "village": {
+        "free": [
+          {
+            "op": "resource.gain",
+            "resource": "warriors",
+            "amount": 1
+          }
+        ],
+        "enhanced": {
+          "cost": {
+            "resource": "spirit",
+            "amount": 1
+          },
+          "effects": [
+            {
+              "op": "resource.gain",
+              "resource": "spirit",
+              "amount": 1
+            }
+          ]
+        },
+        "skullCapacity": 3
+      },
+      "bazaar": {
+        "free": [
+          {
+            "op": "resource.gain",
+            "resource": "warriors",
+            "amount": 1
+          }
+        ],
+        "enhanced": {
+          "cost": {
+            "resource": "spirit",
+            "amount": 1
+          },
+          "effects": [
+            {
+              "op": "market.refresh"
+            }
+          ]
+        },
+        "skullCapacity": 3
+      }
+    },
+    "dungeons": {
+      "test-dungeon": {
+        "id": "test-dungeon",
+        "name": "Test Dungeon",
+        "trait": "Magic",
+        "grid": {
+          "cols": 2,
+          "rows": 1
+        },
+        "masterBitmap": "dungeon-bitmap",
+        "bitmapRect": {
+          "x": -0.15,
+          "y": 0.1,
+          "w": 2.3,
+          "h": 1.05
+        },
+        "rooms": [
+          {
+            "id": "room-entry",
+            "cell": {
+              "col": 0,
+              "row": 0
+            },
+            "exits": {
+              "E": "door"
+            },
+            "isEntrance": true
+          },
+          {
+            "id": "room-target",
+            "cell": {
+              "col": 1,
+              "row": 0
+            },
+            "exits": {
+              "W": "door"
+            },
+            "isTarget": true
+          }
+        ]
+      }
+    },
+    "boards": {
+      "shattered-reach": {
+        "id": "shattered-reach",
+        "name": "The Shattered Reach",
+        "imageRef": "board-shattered-reach",
+        "imageInfo": {
+          "width": 2048,
+          "height": 2048,
+          "centerX": 0.5,
+          "centerY": 0.5,
+          "radius": 0.48,
+          "northHeadingDegrees": 135
+        },
+        "locations": [
+          {
+            "name": "Emberfall",
+            "kingdom": "north",
+            "terrain": "Ash Flats",
+            "building": "Citadel"
+          },
+          {
+            "name": "Coldwatch",
+            "kingdom": "north",
+            "terrain": "Tundra",
+            "grouping": "Long Water"
+          },
+          {
+            "name": "Saltmere",
+            "kingdom": "east",
+            "terrain": "Lake",
+            "building": "bazaar"
+          },
+          {
+            "name": "Thornhollow",
+            "kingdom": "south",
+            "terrain": "Forest",
+            "building": "sanctuary"
+          },
+          {
+            "name": "Gravelrun",
+            "kingdom": "west",
+            "terrain": "Hills",
+            "building": "village"
+          }
+        ],
+        "anchors": {
+          "Emberfall": {
+            "building": {
+              "x": 0.31,
+              "y": 0.22
+            },
+            "skull": {
+              "x": 0.34,
+              "y": 0.25
+            },
+            "hero": {
+              "x": 0.28,
+              "y": 0.2
+            },
+            "foe": {
+              "x": 0.3,
+              "y": 0.27
+            },
+            "marker": {
+              "x": 0.33,
+              "y": 0.19
+            }
+          },
+          "Coldwatch": {
+            "hero": {
+              "x": 0.44,
+              "y": 0.12
+            },
+            "foe": {
+              "x": 0.47,
+              "y": 0.15
+            }
+          },
+          "Saltmere": {
+            "building": {
+              "x": 0.78,
+              "y": 0.44
+            },
+            "skull": {
+              "x": 0.81,
+              "y": 0.47
+            },
+            "hero": {
+              "x": 0.75,
+              "y": 0.42
+            }
+          },
+          "Thornhollow": {
+            "building": {
+              "x": 0.5,
+              "y": 0.82
+            },
+            "skull": {
+              "x": 0.53,
+              "y": 0.85
+            },
+            "hero": {
+              "x": 0.47,
+              "y": 0.8
+            }
+          },
+          "Gravelrun": {
+            "building": {
+              "x": 0.18,
+              "y": 0.58
+            },
+            "skull": {
+              "x": 0.21,
+              "y": 0.61
+            },
+            "hero": {
+              "x": 0.15,
+              "y": 0.56
+            }
+          }
+        },
+        "adjacency": {
+          "Emberfall": ["Coldwatch", "Gravelrun"],
+          "Coldwatch": ["Emberfall", "Saltmere"],
+          "Saltmere": ["Coldwatch", "Thornhollow"],
+          "Thornhollow": ["Saltmere", "Gravelrun"],
+          "Gravelrun": ["Thornhollow", "Emberfall"]
+        }
+      }
+    }
+  },
+  "graph": {
+    "entry": "n-start",
+    "nodes": [
+      {
+        "id": "n-start",
+        "kind": "lifecycle.gameStart"
+      },
+      {
+        "id": "n-dungeon",
+        "kind": "dungeon.subflow",
+        "props": {
+          "dungeonId": "test-dungeon"
+        }
+      }
+    ]
+  }
+}

--- a/packages/creator-schema/fixtures/valid/valid-24-board-custom.json
+++ b/packages/creator-schema/fixtures/valid/valid-24-board-custom.json
@@ -1,0 +1,333 @@
+{
+  "schemaVersion": "0.4.6",
+  "meta": {
+    "title": "v0.4.6 fixture: custom board (library.boards + setup.board.boardRef)",
+    "scenarioVersion": "0.1.0",
+    "designer": {
+      "name": "Test"
+    },
+    "pins": {
+      "udt": "5.0.0"
+    }
+  },
+  "setup": {
+    "mode": "coop",
+    "difficulty": {
+      "profile": "heroic",
+      "skullSupply": 24
+    },
+    "playerCountScaling": {
+      "turnsPerMonth": {
+        "1": 6,
+        "2": 7,
+        "3": 8,
+        "4": 9
+      }
+    },
+    "monthEnd": {
+      "resolution": "randomInRange",
+      "default": {
+        "minTurn": 3,
+        "maxTurn": 6
+      }
+    },
+    "selections": {
+      "adversaryId": "ashstrider",
+      "foes": {
+        "tier1": "brigands",
+        "tier2": "frost-trolls",
+        "tier3": "dragons"
+      },
+      "mainGoalId": "recover-azkols-treasures"
+    },
+    "board": {
+      "boardRef": "shattered-reach"
+    }
+  },
+  "library": {
+    "resources": {
+      "images": {
+        "dungeon-bitmap": "data:image/png;base64,iVBORw0KGgo=",
+        "board-shattered-reach": "data:image/png;base64,iVBORw0KGgo="
+      }
+    },
+    "buildingTypes": {
+      "citadel": {
+        "free": [
+          {
+            "op": "resource.gain",
+            "resource": "warriors",
+            "amount": 1
+          }
+        ],
+        "enhanced": {
+          "cost": {
+            "resource": "spirit",
+            "amount": 1
+          },
+          "effects": [
+            {
+              "op": "resource.gain",
+              "resource": "warriors",
+              "amount": 2
+            }
+          ]
+        },
+        "skullCapacity": 3
+      },
+      "sanctuary": {
+        "free": [
+          {
+            "op": "resource.gain",
+            "resource": "warriors",
+            "amount": 1
+          }
+        ],
+        "enhanced": {
+          "cost": {
+            "resource": "spirit",
+            "amount": 1
+          },
+          "effects": [
+            {
+              "op": "corruption.remove",
+              "all": true
+            }
+          ]
+        },
+        "skullCapacity": 3
+      },
+      "village": {
+        "free": [
+          {
+            "op": "resource.gain",
+            "resource": "warriors",
+            "amount": 1
+          }
+        ],
+        "enhanced": {
+          "cost": {
+            "resource": "spirit",
+            "amount": 1
+          },
+          "effects": [
+            {
+              "op": "resource.gain",
+              "resource": "spirit",
+              "amount": 1
+            }
+          ]
+        },
+        "skullCapacity": 3
+      },
+      "bazaar": {
+        "free": [
+          {
+            "op": "resource.gain",
+            "resource": "warriors",
+            "amount": 1
+          }
+        ],
+        "enhanced": {
+          "cost": {
+            "resource": "spirit",
+            "amount": 1
+          },
+          "effects": [
+            {
+              "op": "market.refresh"
+            }
+          ]
+        },
+        "skullCapacity": 3
+      }
+    },
+    "dungeons": {
+      "test-dungeon": {
+        "id": "test-dungeon",
+        "name": "Test Dungeon",
+        "trait": "Magic",
+        "grid": {
+          "cols": 2,
+          "rows": 1
+        },
+        "masterBitmap": "dungeon-bitmap",
+        "bitmapRect": {
+          "x": -0.15,
+          "y": 0.1,
+          "w": 2.3,
+          "h": 1.05
+        },
+        "rooms": [
+          {
+            "id": "room-entry",
+            "cell": {
+              "col": 0,
+              "row": 0
+            },
+            "exits": {
+              "E": "door"
+            },
+            "isEntrance": true
+          },
+          {
+            "id": "room-target",
+            "cell": {
+              "col": 1,
+              "row": 0
+            },
+            "exits": {
+              "W": "door"
+            },
+            "isTarget": true
+          }
+        ]
+      }
+    },
+    "boards": {
+      "shattered-reach": {
+        "id": "shattered-reach",
+        "name": "The Shattered Reach",
+        "imageRef": "board-shattered-reach",
+        "imageInfo": {
+          "width": 2048,
+          "height": 2048,
+          "centerX": 0.5,
+          "centerY": 0.5,
+          "radius": 0.48,
+          "northHeadingDegrees": 135
+        },
+        "locations": [
+          {
+            "name": "Emberfall",
+            "kingdom": "north",
+            "terrain": "Ash Flats",
+            "building": "citadel"
+          },
+          {
+            "name": "Coldwatch",
+            "kingdom": "north",
+            "terrain": "Tundra"
+          },
+          {
+            "name": "Saltmere",
+            "kingdom": "east",
+            "terrain": "Lake",
+            "building": "bazaar"
+          },
+          {
+            "name": "Thornhollow",
+            "kingdom": "south",
+            "terrain": "Forest",
+            "building": "sanctuary"
+          },
+          {
+            "name": "Gravelrun",
+            "kingdom": "west",
+            "terrain": "Hills",
+            "building": "village"
+          }
+        ],
+        "anchors": {
+          "Emberfall": {
+            "building": {
+              "x": 0.31,
+              "y": 0.22
+            },
+            "skull": {
+              "x": 0.34,
+              "y": 0.25
+            },
+            "hero": {
+              "x": 0.28,
+              "y": 0.2
+            },
+            "foe": {
+              "x": 0.3,
+              "y": 0.27
+            },
+            "marker": {
+              "x": 0.33,
+              "y": 0.19
+            }
+          },
+          "Coldwatch": {
+            "hero": {
+              "x": 0.44,
+              "y": 0.12
+            },
+            "foe": {
+              "x": 0.47,
+              "y": 0.15
+            }
+          },
+          "Saltmere": {
+            "building": {
+              "x": 0.78,
+              "y": 0.44
+            },
+            "skull": {
+              "x": 0.81,
+              "y": 0.47
+            },
+            "hero": {
+              "x": 0.75,
+              "y": 0.42
+            }
+          },
+          "Thornhollow": {
+            "building": {
+              "x": 0.5,
+              "y": 0.82
+            },
+            "skull": {
+              "x": 0.53,
+              "y": 0.85
+            },
+            "hero": {
+              "x": 0.47,
+              "y": 0.8
+            }
+          },
+          "Gravelrun": {
+            "building": {
+              "x": 0.18,
+              "y": 0.58
+            },
+            "skull": {
+              "x": 0.21,
+              "y": 0.61
+            },
+            "hero": {
+              "x": 0.15,
+              "y": 0.56
+            }
+          }
+        },
+        "adjacency": {
+          "Emberfall": ["Coldwatch", "Gravelrun"],
+          "Coldwatch": ["Emberfall", "Saltmere"],
+          "Saltmere": ["Coldwatch", "Thornhollow"],
+          "Thornhollow": ["Saltmere", "Gravelrun"],
+          "Gravelrun": ["Thornhollow", "Emberfall"]
+        }
+      }
+    }
+  },
+  "graph": {
+    "entry": "n-start",
+    "nodes": [
+      {
+        "id": "n-start",
+        "kind": "lifecycle.gameStart"
+      },
+      {
+        "id": "n-dungeon",
+        "kind": "dungeon.subflow",
+        "props": {
+          "dungeonId": "test-dungeon"
+        }
+      }
+    ]
+  }
+}

--- a/packages/creator-schema/src/scenario.schema.json
+++ b/packages/creator-schema/src/scenario.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://chessmess.dev/rtdt/schemas/scenario.schema.json",
   "title": "Return to Dark Tower — Custom Scenario",
-  "$comment": "schemaVersion 0.4.0 — first JSON change since 0.3.0: closes the F library sub-deferrals (dormantKingdoms, room.improveOnce/enterRequirement, quest.requirements, foe.strike/movement, battleDefs.cards), adds the closed tradeAsset union (decision #7), and adds MVP-scoped per-kind node props. Battle/foe figures are author-editable DEFAULTS, not constraints (official-app-analysis v0.3 §6). Later 0.4.x addition: optional node.description (author documentation) and closed props for the util.comment / util.group annotation kinds (flow documentation/grouping). 0.4.1: setup.selections.adversaryId / foes (and its tier1/tier2/tier3) / mainGoalId are now OPTIONAL — a backward-compatible relaxation so rule-variant scenarios that don't use the standard adversary fight, tiered foe roster, or a main-goal quest still validate at L1. 0.4.2: library.battleDefs values become a oneOf of the legacy strikes shape and the new official-app card-ladder shape ($defs/battleLadderCard), and a hero.scope effect op is added for multi-hero battle-card targets — additive; every 0.4.0/0.4.1 document validates unchanged. 0.4.3: adds $defs/cardAppearance (presentational card back/template/accent — engine passes through opaque), optional artRef/flavor on generic cards and optional artRef on battle-ladder cards, optional appearance on generic decks and ladder battleDefs, and closed props branches for deck.draw (with reveal/resolve flags)/deck.reshuffle/deck.discard — additive; every 0.4.0–0.4.2 document validates unchanged. 0.4.4: adds optional presentational $defs/room.name (room-card title) and $defs/room.artRef (room-card art resourceKey) for the first-class Dungeon Builder — the engine passes both through opaque (neither enters engine state nor a directive), so every 0.4.0–0.4.3 document validates unchanged and golden/goldenFull digest+directive streams are unaffected. 0.4.5: adds optional presentational $defs/dungeon.bitmapRect (masterBitmap placement rect {x,y,w,h} in grid-cell units; when absent the map fills the grid) so the Dungeon Builder's grab-handle alignment of a map image under the room lattice persists and both apps render the map identically — engine passthrough (never enters state nor a directive), so every 0.4.0–0.4.4 document validates unchanged and golden/goldenFull streams are unaffected.",
+  "$comment": "schemaVersion 0.4.0 — first JSON change since 0.3.0: closes the F library sub-deferrals (dormantKingdoms, room.improveOnce/enterRequirement, quest.requirements, foe.strike/movement, battleDefs.cards), adds the closed tradeAsset union (decision #7), and adds MVP-scoped per-kind node props. Battle/foe figures are author-editable DEFAULTS, not constraints (official-app-analysis v0.3 §6). Later 0.4.x addition: optional node.description (author documentation) and closed props for the util.comment / util.group annotation kinds (flow documentation/grouping). 0.4.1: setup.selections.adversaryId / foes (and its tier1/tier2/tier3) / mainGoalId are now OPTIONAL — a backward-compatible relaxation so rule-variant scenarios that don't use the standard adversary fight, tiered foe roster, or a main-goal quest still validate at L1. 0.4.2: library.battleDefs values become a oneOf of the legacy strikes shape and the new official-app card-ladder shape ($defs/battleLadderCard), and a hero.scope effect op is added for multi-hero battle-card targets — additive; every 0.4.0/0.4.1 document validates unchanged. 0.4.3: adds $defs/cardAppearance (presentational card back/template/accent — engine passes through opaque), optional artRef/flavor on generic cards and optional artRef on battle-ladder cards, optional appearance on generic decks and ladder battleDefs, and closed props branches for deck.draw (with reveal/resolve flags)/deck.reshuffle/deck.discard — additive; every 0.4.0–0.4.2 document validates unchanged. 0.4.4: adds optional presentational $defs/room.name (room-card title) and $defs/room.artRef (room-card art resourceKey) for the first-class Dungeon Builder — the engine passes both through opaque (neither enters engine state nor a directive), so every 0.4.0–0.4.3 document validates unchanged and golden/goldenFull digest+directive streams are unaffected. 0.4.5: adds optional presentational $defs/dungeon.bitmapRect (masterBitmap placement rect {x,y,w,h} in grid-cell units; when absent the map fills the grid) so the Dungeon Builder's grab-handle alignment of a map image under the room lattice persists and both apps render the map identically — engine passthrough (never enters state nor a directive), so every 0.4.0–0.4.4 document validates unchanged and golden/goldenFull streams are unaffected. 0.4.6: adds $defs/boardDef + $defs/anchorPoint and the library.boards registry, plus a third setup.board branch {boardRef} naming a library.boards entry — a creator-authored custom game board (own art, locations, anchors, adjacency) rendered by ultimatedarktowerboard and played in the player. Locations keep the RtDT shape ({name, kingdom, terrain, building?}), so no node kind or effect op changes: locations are opaque strings everywhere. The other setup.board branches remain the implicit built-in RtDT board. Adjacency is authoring metadata — L2 validates its symmetry but nothing enforces movement during play in v1. Additive: every 0.4.0–0.4.5 document validates unchanged and golden/goldenFull digest+directive streams are unaffected (the boardRef branch only activates when authored).",
   "type": "object",
   "required": ["schemaVersion", "meta", "setup", "library", "graph"],
   "additionalProperties": false,
@@ -370,6 +370,12 @@
                   "$comment": "opaque — validated by Board's schema @pins.board"
                 }
               }
+            },
+            {
+              "additionalProperties": false,
+              "required": ["boardRef"],
+              "properties": { "boardRef": { "$ref": "#/$defs/id" } },
+              "$comment": "L2: key in library.boards; other branches = implicit RtDT board"
             }
           ]
         }
@@ -947,6 +953,86 @@
       }
     },
 
+    "anchorPoint": {
+      "type": "object",
+      "required": ["x", "y"],
+      "additionalProperties": false,
+      "properties": {
+        "x": { "type": "number", "minimum": 0, "maximum": 1 },
+        "y": { "type": "number", "minimum": 0, "maximum": 1 }
+      },
+      "$comment": "Normalized [0,1] against the board image — resolution-independent."
+    },
+
+    "boardDef": {
+      "type": "object",
+      "required": ["id", "name", "imageInfo", "locations"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "name": { "type": "string" },
+        "imageRef": {
+          "$ref": "#/$defs/resourceKey",
+          "$comment": "L2: key in library.resources.images; dangling → placeholder art (like deck artRef)"
+        },
+        "imageInfo": {
+          "type": "object",
+          "required": ["width", "height"],
+          "additionalProperties": false,
+          "properties": {
+            "width": { "type": "integer", "minimum": 1 },
+            "height": { "type": "integer", "minimum": 1 },
+            "centerX": { "type": "number", "minimum": 0, "maximum": 1 },
+            "centerY": { "type": "number", "minimum": 0, "maximum": 1 },
+            "radius": { "type": "number", "exclusiveMinimum": 0, "maximum": 1 },
+            "northHeadingDegrees": { "type": "number", "minimum": 0, "exclusiveMaximum": 360 }
+          },
+          "$comment": "width/height are required (2D). centerX/centerY/radius/northHeadingDegrees together make the board 3D-capable; partial calibration stays 2D-only."
+        },
+        "locations": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "required": ["name", "kingdom", "terrain"],
+            "additionalProperties": false,
+            "properties": {
+              "name": { "type": "string", "minLength": 1 },
+              "kingdom": { "$ref": "#/$defs/kingdom" },
+              "terrain": {
+                "type": "string",
+                "minLength": 1,
+                "$comment": "open string — RtDT's own six are Hills, Lake, Desert, Mountains, Grasslands, Forest"
+              },
+              "building": { "$ref": "#/$defs/buildingType" }
+            }
+          },
+          "$comment": "L2: names must be unique within the board"
+        },
+        "anchors": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "building": { "$ref": "#/$defs/anchorPoint" },
+              "skull": { "$ref": "#/$defs/anchorPoint" },
+              "hero": { "$ref": "#/$defs/anchorPoint" },
+              "foe": { "$ref": "#/$defs/anchorPoint" },
+              "marker": { "$ref": "#/$defs/anchorPoint" }
+            }
+          },
+          "$comment": "L2: keys must be location names on this board"
+        },
+        "adjacency": {
+          "type": "object",
+          "additionalProperties": { "type": "array", "items": { "type": "string" } },
+          "$comment": "L2: keys and values must be location names on this board, and the relation must be symmetric. Authoring metadata — not enforced during play in v1."
+        }
+      },
+      "$comment": "0.4.6 — a creator-authored custom game board. Referenced by setup.board.boardRef."
+    },
+
     "dungeon": {
       "type": "object",
       "required": ["id", "name", "trait", "grid", "masterBitmap", "rooms"],
@@ -1150,6 +1236,7 @@
           }
         },
         "dungeons": { "type": "object", "additionalProperties": { "$ref": "#/$defs/dungeon" } },
+        "boards": { "type": "object", "additionalProperties": { "$ref": "#/$defs/boardDef" } },
         "lightSequences": {
           "type": "object",
           "additionalProperties": { "$ref": "#/$defs/lightSequenceAsset" }


### PR DESCRIPTION
Creators can author a game board with their own art, locations, anchors and adjacency in a new **Board Designer**, and that board renders and plays in `@udtc/player`.

The built-in Return to Dark Tower board is unchanged for every existing scenario and app — every new option is optional and defaults to it.

Built on top of #30 (which this work uncovered: both apps were already broken on a cold `.vite` cache). No Vite config changes here.

## Why there are no new node kinds

Locations are opaque strings everywhere — engine state, effect ops, conditions. Keeping the RtDT location shape (`{name, kingdom, terrain, building?}`) means **every existing node kind and effect op works against a custom vocabulary untouched**. The work is re-sourcing the dropdown/validation vocabulary from the active board, not authoring new primitives. `validate:nodes` stays **68/68**.

## What's in it

**`packages/board`** — published, **minor 0.3.1 → 0.4.0** (changeset included)
- New `data/boardDefinition.ts`: `BoardDefinition`, `RTDT_BOARD_DEFINITION`, `resolveBoard`, `isBoardCalibrated`, `boardScaleFactor`.
- Optional `board` option on `BoardMap2D`, `BoardReadout`, `Board3DPlugin`/`attachBoard3D`, `createBoardTower3D`, `BoardRenderView`, `BoardStageView`, `mountBoardUI`, plus `createDefaultBoardState(board?)`.
- Token geometry (tuned in image-space px against the 4096² board) scales by **`min(width, height) / 4096`** — scaling on width alone renders tokens out of proportion on a non-square board.
- 3D remaps anchors onto the disc from the board's circle calibration; an uncalibrated board is 2D-only (`setTowerEnabled` warns and no-ops).

**Schema 0.4.6** — additive; every 0.4.0–0.4.5 document validates unchanged. Adds `$defs/anchorPoint`, `$defs/boardDef`, `library.boards`, and a third `setup.board` branch `{boardRef}`. The other branches remain the implicit built-in board.

**`@udtc/adapters`** — `resolveActiveBoardDef` / `boardDefFromLibrary`; `validate-refs` checks location refs against the *active* board and enforces per-board integrity (duplicate names, anchors/adjacency confined to real locations, adjacency symmetry) for **every** authored board, not just the active one.

**`@udtc/engine`** — setup synthesizes `{home, buildings}` from a `boardRef`: hero homes from each kingdom's first citadel, registry from every building location. **Zero new deps.** The branch only activates when authored, so golden/lockstep streams are byte-identical.

**`apps/creator`** — `src/boards/` Board Designer (list rail | map canvas | editor panel; locations/anchors/adjacency/calibrate modes), RtDT preset clone, and the Inspector + `foe.spawn`/`foe.move` effect fields re-sourced from the active board.

**`apps/player`** — board resolved on load **and session resume**, custom art, 3D gated on calibration with a 2D fallback log line.

## Two traps, both covered by tests

1. **`setup.board` is a `oneOf`** — writing `{boardRef}` destroys a hand-authored inline `{boardState}` (hero homes + buildings registry). `setActiveBoard` stashes the displaced value and restores it on toggle-off, and confirms before overwriting a non-empty one. Reverting to the naive version fails both round-trip tests.
2. **The RtDT preset can't be a spread of `RTDT_BOARD_DEFINITION`** — core spells the building `'Citadel'`, the schema enum is lowercase `'citadel'`, so a clone would fail L1. Mapped through `toLowerCase()`; the preset test asserts **full L1 validity**, not just casing.

## Adjacency is authoring metadata (v1)

Authored, symmetry-validated at L2, BFS-previewed in the editor — but **not enforced during play**, and the Adjacency tab says so in place. This matches the built-in board, where adjacency has always been data plus pure helpers. Runtime enforcement would pull in engine changes and a likely new condition kind; deliberately deferred.

## Verification

`pnpm run ci` green from the committed state. `validate:nodes` **68/68** (unmoved).

| Suite | Result |
| --- | --- |
| `packages/board` jest | 20 suites / **169** (the pre-existing **154 pass untouched**, 3 snapshots intact) |
| schema conformance | 64/64 (+2 new fixtures) |
| `@udtc/adapters` | 65/65 |
| `@udtc/engine` | 12/12 suites — **lockstep 13 + golden 34 unchanged** |
| `apps/creator` | 22/22 |

**Back-compat proof:** the untouched 154 board tests, plus an identity regression — rendering with no `board` option is byte-identical to passing `RTDT_BOARD_DEFINITION`, *and* to a structural clone of it (the clone matters: `resolveBoard` fast-paths the singleton by identity, so without it the assertion would be near-tautological).

**Engine inertness:** `lockstep_test.js` asserts byte-identical per-step state digest + ordered directive stream + status. Green.

## Manual E2E

Creator → Clone RtDT preset (212 anchors, 4096², "3D-ready") → renamed *Broken Lands* → *Emberfall*: anchors and adjacency re-keyed atomically, all 6 reverse edges rewritten, symmetry intact. Uploaded a **1600×1200** non-square board; `imageInfo` picked up the real dims. "Use in game" → Inspector offered **60 names starting with Emberfall, "Broken Lands" absent**; Problems panel green.

Exported (L1-revalidated independently) → player rendered at `0 0 1600 1200` with the custom art, foe at **Emberfall** and hero at **Radiant Mountains** — the hero placement is the live proof of the engine synthesizing the citadel home. Fallback token radius **18.457** = `min(1600,1200)/4096 × 150 × 0.42`; width-based scaling would have given 24.6. Stripping the calibration produced 2D-only with the log line *"Custom board is not calibrated (no centre/radius/north) — using the 2D map."*

**Regressions:** the sample scenario in player and `apps/digital` both render the built-in board identically (4096², static `/assets/board.png`, 3D on, no warning).
