### PR TITLE
docs(pages): list ultimatedarktowerdata on the landing page

### DIFF
--- a/docs/pages/index.html
+++ b/docs/pages/index.html
@@ -47,11 +47,11 @@
       <h1>Ultimate Dark Tower<span class="sub">Ecosystem</span></h1>
       <p class="tagline">A TypeScript ecosystem for Restoration Games’ Return to Dark Tower — one monorepo of libraries, renderers, and companion apps.</p>
 
-      <div class="stats"><a href="#libraries"><b>3</b> libraries</a>
+      <div class="stats"><a href="#libraries"><b>4</b> libraries</a>
         <span class="sep">·</span>
         <a href="#apps"><b>10</b> apps</a>
         <span class="sep">·</span>
-        <span><b>4</b> published to npm</span></div>
+        <span><b>5</b> published to npm</span></div>
 
       <a class="scroll-cue" href="#apps" aria-label="Scroll to the ecosystem">
         Explore <span>▾</span>
@@ -108,7 +108,7 @@
               <h3>Tower Controller</h3>
               <code>ultimatedarktowercontroller</code>
             </span>
-            <span class="ver">v3.5.1</span>
+            <span class="ver">v3.5.2</span>
           </div>
           <p class="blurb">Connect over Bluetooth and drive a real tower — rotate drums, light seals, play sounds. Includes a 3D emulator for hardware-free exploration.</p>
           <div class="links">
@@ -130,7 +130,7 @@
               <h3>Scenario Creator</h3>
               <code>@udtc/creator</code>
             </span>
-            <span class="ver">v0.2.0</span>
+            <span class="ver">v0.2.1</span>
           </div>
           <p class="blurb">Create custom Return To Dark Tower Scenarios with simple drag-n-drop! Build custom decks, dungeons, quests, rules, and events. Design the game you want to play!</p>
           <div class="links">
@@ -151,7 +151,7 @@
               <h3>Scenario Player</h3>
               <code>@udtc/player</code>
             </span>
-            <span class="ver">v0.2.0</span>
+            <span class="ver">v0.2.1</span>
           </div>
           <p class="blurb">Plays custom Return to Dark Tower scenarios! Scenarios authored with the creator come to life here in the player!</p>
           <div class="links">
@@ -172,7 +172,7 @@
               <h3>Digital Play</h3>
               <code>ultimatedarktowerdigital</code>
             </span>
-            <span class="ver">v0.0.0</span>
+            <span class="ver">v0.0.1</span>
           </div>
           <p class="blurb">Wish you could play the game without having to set it up? Play Return to Dark Tower completely digitally with this! </p>
           <div class="links">
@@ -194,7 +194,7 @@
               <h3>Seed Decoder</h3>
               <code>ultimatedarktowerseed</code>
             </span>
-            <span class="ver">v0.1.0</span>
+            <span class="ver">v0.1.1</span>
           </div>
           <p class="blurb">This utility app lets you decode Return to Dark Tower game seeds and tower state.</p>
           <div class="links">
@@ -216,7 +216,7 @@
               <h3>Dark Tower Sync</h3>
               <code>@dark-tower-sync/client</code>
             </span>
-            <span class="ver">v0.3.0</span>
+            <span class="ver">v0.3.1</span>
           </div>
           <p class="blurb">Browser client for the relay — mirror relayed commands onto your physical tower.</p>
           <div class="links">
@@ -238,7 +238,7 @@
               <h3>Tower Game</h3>
               <code>ultimatedarktowergame</code>
             </span>
-            <span class="ver">v0.1.0</span>
+            <span class="ver">v0.1.1</span>
           </div>
           <p class="blurb">The Tower's Challenge — an example web game: outguess the tower's glyph picks across six months to save the kingdom.</p>
           <div class="links">
@@ -259,7 +259,7 @@
               <h3>Relay CLI</h3>
               <code>ultimatedarktowerrelay-cli</code>
             </span>
-            <span class="ver">v0.1.0</span>
+            <span class="ver">v0.1.1</span>
           </div>
           <p class="blurb">An always-on background service that connects your tower to the network — built for a Raspberry Pi, server, or Docker container with no screen attached.</p>
           <div class="links">
@@ -279,7 +279,7 @@
               <h3>Relay Console</h3>
               <code>ultimatedarktowerrelay-electron</code>
             </span>
-            <span class="ver">v0.1.0</span>
+            <span class="ver">v0.1.1</span>
           </div>
           <p class="blurb">The point-and-click way to run a tower relay — pick a source, watch its status, and send manual commands without touching a terminal.</p>
           <div class="links">
@@ -300,7 +300,7 @@
               <h3>Tower MCP Server</h3>
               <code>mcp-server-return-to-dark-tower</code>
             </span>
-            <span class="ver">v1.0.0</span>
+            <span class="ver">v1.0.2</span>
           </div>
           <p class="blurb">Point Claude, ChatGPT, or any MCP client at your tower — 34 tools for lights, sounds, drums, and seals, with the game rules bundled as context.</p>
           <div class="links">
@@ -318,7 +318,7 @@
           <span class="glyph g-battle" aria-hidden="true"></span>
           <h2>The <span class="accent">Libraries</span></h2>
           <span class="rule"></span>
-          <span class="count">3 packages</span>
+          <span class="count">4 packages</span>
         </div>
         <div class="grid">
       <article class="card status-released reveal" style="--d: 0ms">
@@ -333,7 +333,7 @@
               <h3>Tower Core</h3>
               <code>ultimatedarktower</code>
             </span>
-            <span class="ver">v5.0.2</span>
+            <span class="ver">v6.0.0</span>
           </div>
           <p class="blurb">The TypeScript library that connects to a real tower over Bluetooth — rotate drums, light seals, play sounds, and track glyphs from your own app.</p>
           <div class="links">
@@ -356,7 +356,7 @@
               <h3>Tower Display</h3>
               <code>ultimatedarktowerdisplay</code>
             </span>
-            <span class="ver">v0.10.4</span>
+            <span class="ver">v0.11.0</span>
           </div>
           <p class="blurb">Turns your tower's live state into visuals — plain text, a 2D diagram, or a full 3D model, skull physics included.</p>
           <div class="links">
@@ -379,7 +379,7 @@
               <h3>Tower Board</h3>
               <code>ultimatedarktowerboard</code>
             </span>
-            <span class="ver">v0.3.1</span>
+            <span class="ver">v0.4.0</span>
           </div>
           <p class="blurb">Renders the whole game board in 2D or 3D — heroes, foes, quest markers, and more — straight from a JSON game state.</p>
           <div class="links">
@@ -387,6 +387,27 @@
             <a href="https://www.npmjs.com/package/ultimatedarktowerboard" target="_blank" rel="noopener">npm</a>
             <a href="https://github.com/ChessMess/UltimateDarkTower/tree/main/packages/board/docs" target="_blank" rel="noopener">Docs</a>
             <a href="https://github.com/ChessMess/UltimateDarkTower/tree/main/packages/board" target="_blank" rel="noopener">Source</a>
+          </div>
+        </div>
+      </article>
+      <article class="card status-released reveal" style="--d: 180ms">
+        <a class="card-media tile" href="https://github.com/ChessMess/UltimateDarkTower/tree/main/packages/game-data" target="_blank" rel="noopener" aria-label="Tower Data source">
+          <span class="glyph g-banner"></span><span class="ribbon"><span class="dot"></span>Released</span>
+        </a>
+        <div class="card-body">
+          <div class="card-head">
+            <span class="card-badge"><span class="glyph g-banner"></span></span>
+            <span class="card-title">
+              <h3>Tower Data</h3>
+              <code>ultimatedarktowerdata</code>
+            </span>
+            <span class="ver">v1.0.0</span>
+          </div>
+          <p class="blurb">Board locations, foes, heroes, monuments, and seed encode/decode — the canonical Return to Dark Tower reference data, with zero dependencies and no Bluetooth required.</p>
+          <div class="links">
+            <a href="https://www.npmjs.com/package/ultimatedarktowerdata" target="_blank" rel="noopener">npm</a>
+            <a href="https://github.com/ChessMess/UltimateDarkTower/tree/main/packages/game-data/docs" target="_blank" rel="noopener">Docs</a>
+            <a href="https://github.com/ChessMess/UltimateDarkTower/tree/main/packages/game-data" target="_blank" rel="noopener">Source</a>
           </div>
         </div>
       </article>
@@ -406,7 +427,7 @@
         Built from the <code>UltimateDarkTower</code> monorepo ·
         <a href="https://github.com/ChessMess/UltimateDarkTower">Source on GitHub</a>
       </p>
-      <p class="built">Regenerated 15 Jul 2026 · <code>d31e242</code></p>
+      <p class="built">Regenerated 17 Jul 2026 · <code>9a8606e</code></p>
       <p class="built" style="opacity: 0.7">
         A fan project for Restoration Games’ Return to Dark Tower. Not affiliated with Restoration Games.
       </p>

--- a/docs/pages/landing.data.mjs
+++ b/docs/pages/landing.data.mjs
@@ -162,4 +162,14 @@ export const components = [
     image: 'board.jpg',
     status: 'beta',
   },
+  {
+    dir: 'packages/game-data',
+    title: 'Tower Data',
+    blurb:
+      'Board locations, foes, heroes, monuments, and seed encode/decode — the canonical Return to Dark Tower reference data, with zero dependencies and no Bluetooth required.',
+    category: 'library',
+    demo: null,
+    glyph: 'banner',
+    image: null,
+  },
 ];


### PR DESCRIPTION
## Summary

- Adds `ultimatedarktowerdata` to the Libraries section of `docs/pages/landing.data.mjs` — it was split out of `ultimatedarktower` in the v6 release but never added to the landing page. Demo-less card (glyph tile, no screenshot) matching the existing `relay-cli`/`relay-electron` pattern, since it's reference data with no UI.
- Regenerates `docs/pages/index.html` via `pnpm pages:landing`, which also picks up every version bump from the release completed alongside this (controller 3.5.2, core 6.0.0, display 0.11.0, board 0.4.0, mcp-server 1.0.2, etc.) since the committed copy was stale relative to `main`.

No workflow/build changes — content only.

## Test plan

- [x] `pnpm pages:landing` ran clean locally, reports "4 libraries · 10 apps · 5 on npm" (was 3/10/4)
- [x] Verified the new card's rendered links (npm → `ultimatedarktowerdata`, docs → `packages/game-data/docs`, source → `packages/game-data`) resolve to real, currently-live targets