### PR TITLE
chore: monorepo tech-stack alignment follow-up + configuration reference doc

### DIFF
--- a/.changeset/tsconfig-node-lib-shared-base.md
+++ b/.changeset/tsconfig-node-lib-shared-base.md
@@ -1,0 +1,14 @@
+---
+'ultimatedarktower': patch
+'ultimatedarktowerdata': patch
+'ultimatedarktowerrelay-shared': patch
+'ultimatedarktowerrelay-core': patch
+'ultimatedarktowerrelay-client': patch
+'mcp-server-return-to-dark-tower': patch
+---
+
+Internal-only: factor the CJS/Node16 `tsconfig.json` family (this package plus `game-data`, the relay family, and `mcp-server`) into a shared root `tsconfig.node-lib.json`, mirroring the existing `tsconfig.browser-lib.json` pattern for `board`/`display`. Each package keeps only its own path options (`outDir`/`rootDir`/`composite`/`include`/`exclude`); the repeated compiler-options block and its explanatory comment move to the shared file.
+
+No public API or emitted-JS change for `ultimatedarktower`, `ultimatedarktowerdata`, `ultimatedarktowerrelay-shared`, `ultimatedarktowerrelay-core`, or `ultimatedarktowerrelay-client` — verified byte-for-byte identical `dist/` output before/after.
+
+`mcp-server-return-to-dark-tower` additionally gains the `noUnusedLocals`/`noUnusedParameters`/`noFallthroughCasesInSwitch` strictness its five siblings already had (it was missed by an earlier alignment pass), which surfaced two genuinely dead write-only fields (`TowerController`'s `connected`/`calibrated`) — removed; the public `connected`/`calibrated` snapshot fields are unaffected, since they already read from the `isConnected`/`isCalibrated` getters, not these fields.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -9,8 +9,10 @@ Tower_. It was consolidated in July 2026 from three standalone repos
 now archived) into `packages/*` + `apps/*`.
 
 - Package manager: **pnpm** (`packageManager: pnpm@11.9.0`). Toolchain requires
-  **Node >= 22.13** (pnpm 11 loads `node:sqlite`). Published libraries target a
-  **Node >= 18** runtime.
+  **Node >= 22.13** (pnpm 11 loads `node:sqlite`) — published packages declare the
+  same floor (`engines.node: >=22.13.0`), unified in the July 2026 stack-alignment
+  pass after the previous `>=18.0.0` claim on 15 workspaces turned out to have
+  never actually been verified.
 - Workspace config: `pnpm-workspace.yaml` (globs `packages/*`, `apps/*`).
 - Live demos: https://chessmess.github.io/UltimateDarkTower/
 
@@ -175,6 +177,12 @@ the pending version straight back up.
 
 ## Related docs
 
+- **`CONFIGURATION.md`** (repo root) — the monorepo configuration reference:
+  the three `tsconfig*.json` families and who extends which, the pnpm catalog,
+  lint/test conventions, build tooling per package, CI/CD architecture, and a
+  gotchas list. This CLAUDE.md file is about _working_ in the repo; that one is
+  about how the repo's tooling is _wired_ — link to it for configuration detail
+  rather than duplicating it here.
 - **`AGENTS.md`** (repo root) — consumer-facing reference: the two GitHub Copilot
   agents in `.github/agents/`, and the tower layout tables (side/level/corner/glyph
   enums, `setLED` layer index, light-effect and volume values). It is **not** a copy

--- a/.editorconfig
+++ b/.editorconfig
@@ -2,8 +2,9 @@
 # https://editorconfig.org
 #
 # Prettier (.prettierrc) is the source of truth for JS/TS/JSON/MD formatting —
-# these values mirror it (tabWidth 2, printWidth 100) so an editor's default
-# formatting matches before Prettier ever runs, rather than fighting it.
+# indent_size here mirrors its tabWidth (2) so an editor's default formatting
+# matches before Prettier ever runs, rather than fighting it. max_line_length
+# mirrors its printWidth (100) for the same reason.
 root = true
 
 [*]
@@ -13,6 +14,7 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = space
 indent_size = 2
+max_line_length = 100
 
 [*.md]
 # Markdown often uses trailing whitespace intentionally (hard line breaks).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,9 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           # pnpm 11.9.0 requires Node >= 22.13 (it loads the node:sqlite
-          # built-in); Node 20 crashes at `pnpm install`.
-          node-version: 22
+          # built-in); Node 20 crashes at `pnpm install`. Read from .nvmrc so
+          # there's one source of truth instead of a literal to keep in sync.
+          node-version-file: .nvmrc
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -33,8 +33,10 @@ jobs:
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v7
         with:
-          # pnpm 11.9.0 requires Node >= 22.13 (node:sqlite built-in).
-          node-version: 22
+          # pnpm 11.9.0 requires Node >= 22.13 (node:sqlite built-in). Read from
+          # .nvmrc so there's one source of truth instead of a literal to keep
+          # in sync.
+          node-version-file: .nvmrc
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,8 +32,10 @@ jobs:
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v7
         with:
-          # pnpm 11.9.0 requires Node >= 22.13 (node:sqlite built-in).
-          node-version: 22
+          # pnpm 11.9.0 requires Node >= 22.13 (node:sqlite built-in). Read from
+          # .nvmrc so there's one source of truth instead of a literal to keep
+          # in sync.
+          node-version-file: .nvmrc
           cache: pnpm
           registry-url: https://registry.npmjs.org
 

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -1,0 +1,253 @@
+# Monorepo Configuration
+
+A single reference for how this pnpm monorepo is wired together: workspace layout, dependency
+management, TypeScript/lint/test setup, build tooling, CI/CD, and the gotchas that go with each.
+Written for whoever touches tooling/config next — human or AI agent — without having to
+reverse-engineer it from 24 `package.json` files.
+
+For narrative/task-oriented docs see [README.md](README.md) (what each package/app is),
+[CONTRIBUTING.md](CONTRIBUTING.md) (how to submit a change), and
+[docs/local-development.md](docs/local-development.md) (per-app dev commands). This doc is the
+configuration reference those point back to.
+
+## Workspace layout
+
+`pnpm-workspace.yaml` globs `packages/*` and `apps/*`. `packages/` is libraries (7 published to
+npm, 6 private `@udtc/*` Creator libraries); `apps/` is runnable leaf apps (all private except
+`apps/mcp-server`, which publishes since `npx` is how an MCP server is consumed). Publishing is a
+per-package `private` flag, not a property of the directory — see [Releasing](#releasing).
+
+**There is no monorepo task-runner** (no Turborepo, Nx, or Lerna) — task ordering across packages
+comes purely from pnpm's own recursive commands (`pnpm -r <script>`) respecting `workspace:^`
+dependency order, plus explicit `--filter "pkg..."` graphs where a workflow needs one. There is no
+build cache beyond each package's own `dist/` and `.tsbuildinfo`.
+
+## Package manager & Node
+
+- **pnpm 11.9.0**, pinned via root `package.json`'s `packageManager` field.
+- **Node ≥ 22.13** everywhere (`engines.node` on all 23 workspace packages + root) — pnpm 11 loads
+  the `node:sqlite` built-in, which doesn't exist before 22.13; `pnpm install` fails outright on
+  Node 20. `.nvmrc` pins `22` and CI reads it via `node-version-file: .nvmrc` (not a hardcoded
+  literal) in every workflow except the `relay-native` job, which deliberately matrixes
+  `node: [22, 24]`.
+- **Published packages declare the same `>=22.13.0` floor** — there is no lower "runtime" claim
+  for npm consumers. This was itself a correction: 15 workspaces previously claimed `>=18.0.0`
+  while never actually being tested below Node 22, so the stack-alignment pass raised the
+  declared floor to match reality rather than leave an unverified claim in place.
+- `nodeLinker: hoisted` in `pnpm-workspace.yaml` — a single flat `node_modules`, not pnpm's default
+  strict symlink structure.
+
+## Dependency management (pnpm catalog)
+
+Any dependency declared in 3+ workspaces is hoisted into `pnpm-workspace.yaml`'s `catalog:` block
+and referenced as `"pkg": "catalog:"`, so the version lives in one place instead of drifting across
+package.json files. Currently: `typescript`, `vitest` + `@vitest/coverage-v8`, `vite`, `jsdom`,
+`@vitejs/plugin-react`, `@types/node`, `three` + `@types/three`, `gsap`,
+`@dimforge/rapier3d-compat`, `react`/`react-dom` + their `@types`, `ws` + `@types/ws`,
+`ajv`/`ajv-formats`, `zustand`, `fake-indexeddb`.
+
+- **`three` is the load-bearing entry.** `.npmrc`'s `public-hoist-pattern[]=*three*` force-hoists it
+  so `display`/`board`/`creator` share exactly one copy — multiple copies break `instanceof`
+  checks. A drifting `three` range across packages is exactly what would defeat that hoist, so
+  cataloguing it makes the invariant structural instead of a convention someone has to remember.
+- **`typescript` is pinned to `^5.9.3`, not 6.0** — TS 6.0 drops the automatic
+  `node_modules/@types` inclusion the packages rely on (vitest globals, `web-bluetooth`, `three`,
+  `node` ambient types all come in this way).
+- **`peerDependencies` are deliberately NOT catalogued.** A peer range should be _wider_ than the
+  version a package builds against (`board`/`display` declare `three: ">=0.185.0"`, narrower than
+  `catalog:`'s caret range would allow) — cataloguing would defeat the point of a peer range.
+- `.npmrc` also sets `strict-peer-dependencies=false`: UDT packages peer-range each other, and the
+  workspace may carry a newer minor than an older peer names — kept non-fatal.
+- `overrides` in `pnpm-workspace.yaml` collapse stale transitive `tar`/`tmp` copies (pulled in by
+  the electron packaging toolchain) onto already-patched versions, clearing several Dependabot
+  alerts on deps nothing in the workspace requires directly.
+- **`allowBuilds`** allow-lists which deps may run native `postinstall` scripts (pnpm 11 blocks this
+  by default): `esbuild`, `electron`, the `@stoprocent/*` BLE natives, `@serialport/bindings-cpp`,
+  `usb`, macOS packaging helpers, and `unrs-resolver` (ESLint's import resolver). Audit with
+  `pnpm approve-builds`.
+
+## TypeScript configuration
+
+Every real (non solution-style) `tsconfig.json` in the repo extends one of three root configs,
+with one exception (below). None are extended blindly — each leaf keeps only its own path options
+(`outDir`/`rootDir`/`composite`/`include`/`exclude`/`references`) plus any options genuinely
+specific to that package.
+
+| Root config                 | target / module / moduleResolution        | Who extends it                                                                                                                                                                           | Why it's separate                                                                                                                                                                                                                                                                                                                                                           |
+| --------------------------- | ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `tsconfig.base.json`        | `ES2022` / `ESNext` / `bundler`           | Vite-bundled apps (`controller`, `game`, `seed`, `relay-electron`, and the `creator`/`digital`/`player`/`sync` app+node pairs) and all six private `@udtc/*` + `scenario-store` packages | The default — browser/Vite-consumed TS, strict + `noUnusedLocals`/`noUnusedParameters`/`noFallthroughCasesInSwitch`.                                                                                                                                                                                                                                                        |
+| `tsconfig.browser-lib.json` | `ES2020` / `ESNext` / `bundler`, DOM libs | `packages/board`, `packages/display`                                                                                                                                                     | Ships ES2020+DOM for these two renderer libs specifically; **does not extend base** — `display` has pre-existing code that fails base's `noUnusedLocals`/`noUnusedParameters`.                                                                                                                                                                                              |
+| `tsconfig.node-lib.json`    | `ES2022` / `Node16` / `Node16`            | `packages/core`, `packages/game-data`, `packages/relay-{shared,core,client}`, `apps/relay-cli`, `apps/mcp-server`                                                                        | These are `require()`-consumed CJS (or, for `mcp-server`, Node16-conditioned ESM under its own `"type": "module"`). Base's `module: "ESNext"` + `moduleResolution: "bundler"` would make `tsc` emit ESM/bundler-only syntax that breaks a `require()` consumer outright (verified directly: Node's loader throws `ERR_MODULE_NOT_FOUND` resolving emitted ESM as CommonJS). |
+
+Two packages override `lib` on top of `tsconfig.node-lib.json` to add `DOM`: `core` (genuinely
+dual-platform — `WebBluetoothAdapter`, the optional browser debug logger, `IndexedDBSink` all use
+real DOM globals) and `relay-client` (isomorphic — the injectable `WebSocket` type needs it).
+Neither is a copy/paste mistake; both say so inline.
+
+Two `@udtc/*`-adjacent packages extend base but aren't source-only like their siblings:
+`creator-engine` ships a real `dist/` (the traditional way — see [Build tooling](#build-tooling)),
+and `creator-schema` ships its `main` straight from `src/`. Extending `tsconfig.base.json` is about
+compiler options, not about whether a package has a real build step — the two are independent.
+
+**Standalone exception:** `packages/board/example/tsconfig.json` (the package's demo site) hand-
+duplicates its own compiler options rather than extending `tsconfig.browser-lib.json` like the
+package's own `tsconfig.json` does. Not yet unified — low-stakes since it's a demo, not shipped code.
+
+The four apps using the solution-style `tsconfig.json` (references) → `tsconfig.app.json` +
+`tsconfig.node.json` split (`creator`, `digital`, `player`, `sync`) all have compilerOptions-free
+top-level files — just `{ "files": [], "references": [...] }` — with the real config in the two
+leaves, both of which extend `tsconfig.base.json`.
+
+**`packages/core`'s own `tsconfig.json`** is the one file with an unusual comment worth knowing
+about up front: `outDir` is set with no `rootDir`, so `tsc` infers `rootDir` from the common root
+of `src` + `tests` — which is what puts the build at `dist/src/` (where `main`/`types`/`exports`
+and several consumers' Vite configs all point). **Do not exclude `tests` from that config** — it
+would collapse the output to `dist/` and silently break every one of those references.
+
+## Linting & formatting
+
+- **One root ESLint 9 flat config** (`eslint.config.js`) covers the entire workspace — global
+  ignores, a base TS block, a React-surfaces override (scoped to `apps/creator`, `apps/player`,
+  `apps/digital`, and `packages/*/example/**`), a test-files override (vitest globals), and a
+  demo/reference-apps override that relaxes `@typescript-eslint/no-explicit-any`.
+- **Never add a per-package `eslint`/`@typescript-eslint`/`eslint-plugin-*` devDependency.** A
+  nested v8 config shadows the root v9 flat config and crashes lint. This happened once
+  (`apps/digital`) under a mistaken belief that local copies were needed to "satisfy the React
+  plugins" — they were exact-range duplicates of what the root already declares and imports.
+- Every package **may** carry its own `"lint": "eslint ."` script (all 23 now do) so
+  `pnpm --filter <pkg> lint` scopes to just that directory — this calls the same root config via
+  ESLint's upward config discovery, it does not need its own config file.
+- **One root `.prettierrc` + `.prettierignore`** — no per-package Prettier config or devDep exists
+  or should exist. `format`/`format:check` run from the root over the whole tree.
+- **`.editorconfig`** mirrors Prettier's `indent_size`/`max_line_length` (2 / 100) so an editor's
+  default formatting doesn't fight Prettier before it ever runs.
+
+## Testing
+
+**Vitest is the standard test runner** across the workspace, with two deliberate exceptions:
+`packages/creator-engine` (`node test/run-all.js`, which spawns each of ~13 suites as a separate
+child process because they call `process.exit()`) and `packages/creator-schema`
+(`node test/conformance_test.js`, a hand-rolled Ajv conformance check). Neither was ever on Jest —
+both predate the workspace's Jest→vitest migration and were out of scope for it.
+
+- Test environment splits `jsdom` (browser-facing: `board`, `display`, `controller`, `creator`,
+  `digital`, `player`) vs `node` (`core`, `game-data`, `relay-{shared,core,client}`, `sync`) — no
+  `happy-dom` anywhere.
+- `globals: true` is set only where suites genuinely use bare `describe`/`it`/`expect` with no
+  `vitest` import (`core`, `game-data`, `relay-core`, `relay-client`, `board`, `display`) —
+  everywhere else, tests import explicitly from `'vitest'` and the flag is absent.
+- A `test` script with **zero test files** (`vitest run --passWithNoTests`) is a deliberate
+  placeholder in a handful of packages (`relay-shared`, `creator-card-render`, `creator-theme`,
+  and several apps) — it exists so `pnpm -r test` actually picks up a first real test file later,
+  instead of relying on someone remembering to add the script then.
+- `test:coverage` (`@vitest/coverage-v8`) is wired up only for `core`, `board`, `display`,
+  `game-data` — selective by choice; no CI gate enforces a coverage threshold anywhere.
+
+## Build tooling
+
+| Pattern                                   | Packages/apps                                                                 | Notes                                                                                                                                                                                                                                                                                                                                    |
+| ----------------------------------------- | ----------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Vite app build                            | `controller`, `game`, `seed`, `sync`                                          | Plain `vite build`.                                                                                                                                                                                                                                                                                                                      |
+| `tsc --build && vite build`               | `creator`, `digital`, `player`                                                | Typecheck via project references, then bundle.                                                                                                                                                                                                                                                                                           |
+| `vite build && tsc --emitDeclarationOnly` | `board`, `display`                                                            | Vite produces the real dual CJS+ESM output; `tsc` only emits `.d.ts`. `board`'s build additionally runs `scripts/check-three-free.mjs` afterward, enforcing that its `.`/`./stage` entries never statically import `three` (dynamic `import()` is fine) — a real check for the three force-hoist invariant above, not just a convention. |
+| Plain `tsc --build`                       | `game-data`, `relay-{shared,core,client}`, `apps/relay-cli`, `creator-engine` | CJS library builds via project references.                                                                                                                                                                                                                                                                                               |
+| `tsc` + hand-rolled `esbuild`             | `core`                                                                        | The only package combining a `tsc` CJS build with a separate `esbuild --bundle` ESM bundle (`dist/esm/index.mjs`).                                                                                                                                                                                                                       |
+| No-op / source-only                       | `creator-adapters`, `creator-card-render`, `creator-theme`, `scenario-store`  | `exports` point straight at `.ts` source; `build` is a placeholder `echo`.                                                                                                                                                                                                                                                               |
+| Electron Forge                            | `relay-electron`                                                              | `build` is **`tsc --noEmit`** — typecheck-only, on purpose, so `pnpm -r build` doesn't package a full Electron app with native BLE deps on every CI run. Real packaging is the separate `package`/`make` scripts, exercised only by the `relay-native` CI job.                                                                           |
+
+`packages/creator-engine`'s `dist/` is gitignored and built the traditional way (`"main":
+"dist/index.js"`, no source-fallback `exports`), unlike its `@udtc/*` siblings — which is why the
+root `postinstall` runs `pnpm --filter @udtc/engine build` before anything else: a fresh clone has
+no `dist/` for it, and three direct consumers need it to resolve at all.
+
+## CI/CD
+
+Three workflows, all triggered on `push` to `main` (plus PRs for `ci.yml`):
+
+- **`ci.yml`** — `checks` job runs the full `pnpm run ci` pipeline (see below) on Node 22.
+  `relay-native` job (matrix: `ubuntu`/`macos` × Node `22`/`24`) builds the relay packages + CLI
+  and smoke-tests `electron-forge package` on the Node 22 leg only — it does **not** re-run
+  lint/test, relying on `checks` for that.
+- **`deploy-pages.yml`** — builds every package + the GitHub Pages demo bundle, then deploys. Its
+  landing page is generated by `node scripts/pages/build-landing.mjs` (the same script the root
+  `pages:landing` convenience script runs locally for a preview via `preview:site`).
+- **`release.yml`** — Changesets flow (see [Releasing](#releasing)).
+
+**No local pre-commit enforcement exists** — no Husky, no `lint-staged`, no other git hook (checked
+directly: `.git/hooks/` has only the default `*.sample` files, and no `husky`/`lint-staged` devDep
+exists anywhere in the tree). `pnpm run ci` in the `checks` job is the **only** gate; a commit or
+even a push to a non-`main` branch has nothing stopping it locally. Don't assume a pre-commit hook
+will catch a lint/format violation before CI does.
+
+**Known gap:** `deploy-pages.yml` and `release.yml` are **not gated** on `ci.yml`'s `checks` job —
+they trigger independently off the same `push` event with no `needs:`/`workflow_run` coupling. A
+red `main` does not currently block a Pages deploy or an npm publish attempt. This is a known,
+accepted tradeoff, not an oversight to silently "fix" — changing it is a release-architecture
+decision, not a config alignment.
+
+`pnpm run ci` (the pipeline every gate ultimately calls) is:
+
+```
+validate:nodes → lint → format:check → build → typecheck → test
+```
+
+**Build runs before typecheck on purpose** — cross-package typechecks resolve workspace imports
+against each dependency's _built_ `dist/`, so the dependency graph has to exist first.
+`validate:nodes` (`scripts/creator/validate-node-catalog.mjs`) cross-checks the Creator node
+catalog across `apps/creator`, `packages/creator-schema`, and `packages/creator-engine` for drift.
+
+## Releasing
+
+[Changesets](.changeset/) drives independent versioning. `pnpm changeset` records a change;
+pushing to `main` opens/updates a "Version Packages" PR; merging it bumps versions and publishes
+via `release.yml`.
+
+- **Publishing is driven purely by each package's `private` flag** — `.changeset/config.json` has
+  an empty `ignore` list, so any package with `private: false` opts into the release flow
+  automatically. Currently 8 packages publish: the 7 under `packages/*` in the README's table, plus
+  `apps/mcp-server`.
+- `updateInternalDependencies: "patch"` in `.changeset/config.json` means a changeset bumping, say,
+  `game-data` also patch-bumps every `workspace:^` consumer of it (e.g. `core`) even if nothing in
+  the consumer itself changed — expected Changesets behavior, not a bug if you see an
+  unrelated-looking package show up in a Version Packages PR.
+- `access: "public"` in `.changeset/config.json` is a no-op for today's unscoped package names, but
+  becomes load-bearing the moment any scoped `@udtc/*`/`@dark-tower-sync/*` package flips
+  `private: false` — scoped packages default to `restricted` without it.
+- `changeset:publish` is `pnpm -r build && changeset publish` — the recursive build already builds
+  every workspace package in dependency order, so **no package should carry its own
+  `prepack`/`prepublishOnly` hook**. Six packages used to; the redundant hooks raced each other and
+  broke a real release (2026-07-17). `NPM_CONFIG_IGNORE_SCRIPTS=true` in `release.yml` stays as
+  defense-in-depth against this class of bug recurring.
+
+## Gotchas
+
+- **A failed publish reports the wrong error.** Changesets' own error classifier crashes
+  (`TypeError: Cannot read properties of undefined (reading 'includes')`) before it can surface
+  npm's actual rejection reason. See the root `.claude/CLAUDE.md` "Releasing (Changesets)" section
+  for the full triage playbook (packaging vs. token-liveness vs. provenance vs. the npm token's
+  package allow-list — the most common real cause).
+- **Adding a newly-published package?** Add it to the `NPM_TOKEN` secret's package allow-list on
+  npmjs.com **before** merging its first Version Packages PR — the token is a fixed allow-list that
+  does not learn about new package names, and the failure mode is the masked-error gotcha above.
+- **Dependabot's `minimumReleaseAge` gate**: `pnpm install --frozen-lockfile` in CI rejects package
+  versions published within roughly the last 24h. A Dependabot PR that's red on a just-published
+  version is not broken — it ages out on its own, or re-run after `@dependabot rebase`.
+- **`dependabot.yml` ignores `typescript`** (the deliberate 5.9.x pin) and
+  `version-update:semver-major` generally (major bumps are taken by hand). A major-only _security_
+  fix therefore won't auto-PR — it still shows in the Security tab for manual handling. Full
+  playbook: the `dependabot-triage` skill.
+- **pnpm 11 blocks native `postinstall` scripts by default.** If a new native dependency's install
+  silently no-ops, it's probably missing from `allowBuilds` in `pnpm-workspace.yaml` — audit with
+  `pnpm approve-builds`.
+- **`blockExoticSubdeps: false`** is set because `electron-forge`'s `@electron/rebuild` depends on
+  a git-hosted `@electron/node-gyp` fork, which pnpm 11 blocks by default otherwise.
+- **Bumping `typescript` to 6.0, or `vite` to a new major?** Don't — TS 6.0 drops automatic
+  `@types` inclusion (breaks ambient types workspace-wide); a `vite` major has previously broken
+  `display`'s CJS `dist` `require()` path. Re-check the `dependabot-triage` skill's
+  `references/repo-gotchas.md` before taking either bump.
+- **`packages/core`'s `tsconfig.json` build note** — see [TypeScript configuration](#typescript-configuration)
+  above; excluding `tests` there silently breaks the package's own output path.
+- **`git blame` on an unexpectedly huge range of lines?** Check `.git-blame-ignore-revs` (enable
+  locally with `git config blame.ignoreRevsFile .git-blame-ignore-revs`; GitHub applies it
+  automatically) — it hides bulk mechanical Prettier-reformat commits from blame so they don't
+  bury the real last-touched-by history.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,15 +1,17 @@
 # Contributing
 
 Thanks for helping improve Ultimate Dark Tower! This is a pnpm monorepo — see the
-[README](README.md) for the package/app map.
+[README](README.md) for the package/app map and [CONFIGURATION.md](CONFIGURATION.md) for how the
+workspace tooling is set up (TypeScript config families, lint/test conventions, CI/CD, gotchas).
 
 ## Setup
 
-Requires **Node ≥ 20** and **pnpm ≥ 10**.
+Requires **Node ≥ 22.13** and **pnpm ≥ 11** (`packageManager` pins pnpm 11.9.0 — pnpm 11 loads the
+built-in `node:sqlite`, so install fails outright on Node 20).
 
 ```bash
 pnpm install
-pnpm run ci   # validate:nodes → build → typecheck → test
+pnpm run ci   # validate:nodes → lint → format:check → build → typecheck → test
 ```
 
 On Linux, the relay BLE native deps need system headers:
@@ -22,8 +24,10 @@ On Linux, the relay BLE native deps need system headers:
 3. Keep changes green: `pnpm run ci` (or `pnpm --filter <pkg> {build,test,typecheck}` while iterating).
 4. Format: `pnpm run format`.
 5. If you changed a **published** package (`ultimatedarktower`, `ultimatedarktowerdisplay`,
-   `ultimatedarktowerboard`, `ultimatedarktowerrelay-{shared,core,client}`), add a changeset:
-   `pnpm changeset` — pick the packages, bump type, and a summary. Commit the generated file.
+   `ultimatedarktowerboard`, `ultimatedarktowerdata`, `ultimatedarktowerrelay-{shared,core,client}`,
+   or `apps/mcp-server`), add a changeset: `pnpm changeset` — pick the packages, bump type, and a
+   summary. Commit the generated file. (Publishing is driven by each package's `private` flag, not
+   this list — see CONFIGURATION.md if a package's status is unclear.)
 6. Open a PR against `main`. CI runs `pnpm run ci` plus the relay-native matrix.
 
 ## Conventions
@@ -31,8 +35,9 @@ On Linux, the relay BLE native deps need system headers:
 - **One TypeScript version** for the whole workspace via the `catalog:` entry in
   `pnpm-workspace.yaml`. Reference it as `"typescript": "catalog:"`.
 - **Cross-package deps** use the `workspace:^` protocol; `peerDependencies` stay as semver ranges.
-- **Formatting/lint:** single root `.prettierrc` and `eslint.config.js`. (Lint has known
-  pre-existing debt and is not yet a CI gate — don't add new violations.)
+- **Formatting/lint:** single root `.prettierrc` and `eslint.config.js`. Both `lint` and
+  `format:check` are `pnpm run ci` gates — don't add per-package `eslint`/Prettier devDeps or
+  configs (see CONFIGURATION.md for why that breaks lint workspace-wide).
 - **Don't commit build output** (`dist/`) — it is gitignored and built in CI.
 
 ## Merging

--- a/README.md
+++ b/README.md
@@ -98,7 +98,10 @@ AGENTS.md-standard tools (Cursor, Aider, Zed, etc.).
 
 ## Development
 
-Day-to-day commands, once you've followed [Getting Started](#getting-started):
+Day-to-day commands, once you've followed [Getting Started](#getting-started). For the full
+breakdown of how the workspace is configured — TypeScript config families, the pnpm catalog,
+lint/test setup, CI/CD architecture, and known gotchas — see
+[`CONFIGURATION.md`](CONFIGURATION.md).
 
 ```bash
 pnpm --filter <pkg> build        # build one package/app

--- a/apps/controller/src/TowerEmulatorAdapter.ts
+++ b/apps/controller/src/TowerEmulatorAdapter.ts
@@ -48,8 +48,6 @@ interface TowerEmulatorAdapterOptions {
 export class TowerEmulatorAdapter implements IBluetoothAdapter {
   private connected = false;
   private rxCallback?: (data: Uint8Array) => void;
-  private disconnectCallback?: () => void;
-  private availabilityCallback?: (available: boolean) => void;
   private batteryInterval?: ReturnType<typeof setInterval>;
 
   // Set while a calibration command is awaiting its completion reply. The reply
@@ -170,12 +168,16 @@ export class TowerEmulatorAdapter implements IBluetoothAdapter {
     this.rxCallback = callback;
   }
 
-  onDisconnect(callback: () => void): void {
-    this.disconnectCallback = callback;
+  onDisconnect(_callback: () => void): void {
+    // This emulator only disconnects via an explicit disconnect()/cleanup() call
+    // the controller already knows about — it never loses connection or drops
+    // out spontaneously, so the callback is accepted (to satisfy
+    // IBluetoothAdapter) but never fires.
   }
 
-  onBluetoothAvailabilityChanged(callback: (available: boolean) => void): void {
-    this.availabilityCallback = callback;
+  onBluetoothAvailabilityChanged(_callback: (available: boolean) => void): void {
+    // This emulator has no underlying radio to go unavailable — the callback is
+    // accepted (to satisfy IBluetoothAdapter) but never fires.
   }
 
   async readDeviceInformation(): Promise<DeviceInformation> {
@@ -191,8 +193,6 @@ export class TowerEmulatorAdapter implements IBluetoothAdapter {
     this.cancelCalibration();
     this.lastStatePacket = new Uint8Array(20);
     this.rxCallback = undefined;
-    this.disconnectCallback = undefined;
-    this.availabilityCallback = undefined;
   }
 
   private stopBatteryHeartbeat(): void {

--- a/apps/controller/tsconfig.json
+++ b/apps/controller/tsconfig.json
@@ -1,18 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ESNext",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "sourceMap": true,
-    "resolveJsonModule": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "skipLibCheck": true,
-    "strict": true,
     "noEmit": true,
-    "isolatedModules": true,
-    "useDefineForClassFields": true
+    "isolatedModules": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/apps/creator/vite.config.ts
+++ b/apps/creator/vite.config.ts
@@ -36,7 +36,6 @@ export default defineConfig({
   },
   test: {
     environment: 'jsdom',
-    globals: true,
     include: ['src/**/*.{test,spec}.{ts,tsx}'],
   },
 });

--- a/apps/digital/tsconfig.app.json
+++ b/apps/digital/tsconfig.app.json
@@ -1,28 +1,16 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "useDefineForClassFields": true,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
-    "module": "ESNext",
-    "skipLibCheck": true,
-
-    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "noEmit": true,
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
     "moduleDetection": "force",
-    "noEmit": true,
-    "jsx": "react-jsx",
-
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
-
     "paths": {
       "@/*": ["./src/*"]
     },
-
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo"
   },
   "include": ["src"]

--- a/apps/digital/tsconfig.node.json
+++ b/apps/digital/tsconfig.node.json
@@ -1,22 +1,11 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "lib": ["ES2022"],
-    "module": "ESNext",
-    "skipLibCheck": true,
-
-    "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
     "moduleDetection": "force",
-    "noEmit": true,
-
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
-
+    "noEmit": true,
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo"
   },
   "include": ["vite.config.ts"]

--- a/apps/digital/vite.config.ts
+++ b/apps/digital/vite.config.ts
@@ -36,7 +36,6 @@ export default defineConfig({
   },
   test: {
     environment: 'jsdom',
-    globals: true,
     setupFiles: [],
     include: ['src/**/*.{test,spec}.{ts,tsx}'],
   },

--- a/apps/game/tsconfig.json
+++ b/apps/game/tsconfig.json
@@ -1,18 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ESNext",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "sourceMap": true,
-    "resolveJsonModule": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "skipLibCheck": true,
-    "strict": true,
     "noEmit": true,
-    "isolatedModules": true,
-    "useDefineForClassFields": true
+    "isolatedModules": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/apps/mcp-server/package.json
+++ b/apps/mcp-server/package.json
@@ -36,6 +36,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
+    "lint": "eslint .",
     "clean": "rm -rf dist"
   },
   "keywords": [

--- a/apps/mcp-server/src/tower-controller.ts
+++ b/apps/mcp-server/src/tower-controller.ts
@@ -93,8 +93,6 @@ export class TowerController {
   private lastDeviceInfo: DeviceInformation | null = null;
   private lastConnectionStatus: ConnectionStatus | null = null;
   private skullCount = 0;
-  private connected = false;
-  private calibrated = false;
   private pendingCalibration: PendingCalibration | null = null;
   private bufferOutput: BufferOutputType;
 
@@ -128,16 +126,7 @@ export class TowerController {
 
       this.tower = new UltimateDarkTower(config);
 
-      this.tower.onTowerConnect = () => {
-        this.connected = true;
-      };
-
-      this.tower.onTowerDisconnect = () => {
-        this.connected = false;
-      };
-
       this.tower.onCalibrationComplete = () => {
-        this.calibrated = true;
         this.settlePendingCalibration();
       };
 
@@ -199,7 +188,6 @@ export class TowerController {
   async connect(): Promise<void> {
     const t = this.ensureTower();
     await t.connect();
-    this.connected = true;
     this.lastDeviceInfo = t.getDeviceInformation();
     this.lastConnectionStatus = t.getConnectionStatus();
   }
@@ -207,14 +195,12 @@ export class TowerController {
   async disconnect(): Promise<void> {
     if (this.tower) {
       await this.tower.disconnect();
-      this.connected = false;
     }
   }
 
   async cleanup(): Promise<void> {
     if (this.tower) {
       await this.tower.cleanup();
-      this.connected = false;
     }
   }
 

--- a/apps/mcp-server/tsconfig.json
+++ b/apps/mcp-server/tsconfig.json
@@ -1,15 +1,13 @@
 {
+  // Extends the shared tsconfig.node-lib.json — see that file for the full
+  // CJS/Node16 rationale. This app ships "type": "module" (Node16-conditioned
+  // ESM), unlike its six CJS siblings, but the compiler-options family is the
+  // same either way; Node's module format follows package.json's "type" field,
+  // not this config.
+  "extends": "../../tsconfig.node-lib.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "Node16",
-    "moduleResolution": "Node16",
     "outDir": "dist",
     "rootDir": "src",
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true

--- a/apps/player/vite.config.ts
+++ b/apps/player/vite.config.ts
@@ -36,7 +36,6 @@ export default defineConfig({
   },
   test: {
     environment: 'jsdom',
-    globals: true,
     include: ['src/**/*.{test,spec}.{ts,tsx}'],
   },
 });

--- a/apps/relay-cli/package.json
+++ b/apps/relay-cli/package.json
@@ -10,6 +10,7 @@
     "test": "vitest run --passWithNoTests",
     "dev": "tsc --build --watch",
     "typecheck": "tsc --noEmit",
+    "lint": "eslint .",
     "start": "node dist/index.js",
     "replay": "node dist/replayEvents.js",
     "analyze": "node dist/analyzeLogs.js",

--- a/apps/relay-cli/tsconfig.json
+++ b/apps/relay-cli/tsconfig.json
@@ -1,29 +1,16 @@
 {
-  // Does not extend the ES2022 workspace base. Unlike the three relay packages
-  // it depends on, this app is private (not published) — but it's still invoked
-  // as `node dist/index.js` with no "type" field, so Node treats it as CommonJS.
-  // The base's module:"ESNext"+moduleResolution:"bundler" would make tsc emit
-  // ESM syntax into that same entry point, which Node's CJS loader can't run.
-  // target matches the base; module/moduleResolution stay Node16/Node16.
+  // Unlike the three relay packages it depends on, this app is private (not
+  // published) — but it's still invoked as `node dist/index.js` with no "type"
+  // field, so Node treats it as CommonJS. Extends the shared
+  // tsconfig.node-lib.json for the same CJS/Node16 rationale as its dependencies.
+  "extends": "../../tsconfig.node-lib.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "Node16",
-    "moduleResolution": "Node16",
-    "lib": ["ES2022"],
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
     "outDir": "./dist",
     "rootDir": "./src",
-    "composite": true,
-    "resolveJsonModule": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "composite": true
   },
   "references": [
     {

--- a/apps/relay-electron/package.json
+++ b/apps/relay-electron/package.json
@@ -8,6 +8,7 @@
     "dev": "electron-forge start",
     "build": "tsc --noEmit",
     "typecheck": "tsc --noEmit",
+    "lint": "eslint .",
     "package": "electron-forge package",
     "make": "electron-forge make",
     "publish": "electron-forge publish",

--- a/apps/relay-electron/tsconfig.json
+++ b/apps/relay-electron/tsconfig.json
@@ -1,15 +1,8 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ESNext",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "sourceMap": true,
-    "resolveJsonModule": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "skipLibCheck": true,
-    "strict": true,
     "noEmit": true,
     "isolatedModules": true
   },

--- a/apps/seed/tsconfig.json
+++ b/apps/seed/tsconfig.json
@@ -1,18 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ESNext",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "sourceMap": true,
-    "resolveJsonModule": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "skipLibCheck": true,
-    "strict": true,
     "noEmit": true,
-    "isolatedModules": true,
-    "useDefineForClassFields": true
+    "isolatedModules": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/apps/sync/package.json
+++ b/apps/sync/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview",
     "test": "vitest run",
     "typecheck": "tsc --build --noEmit",
+    "lint": "eslint .",
     "clean": "rm -rf dist"
   },
   "author": "ChessMess",

--- a/apps/sync/tsconfig.app.json
+++ b/apps/sync/tsconfig.app.json
@@ -1,19 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ESNext",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "sourceMap": true,
-    "resolveJsonModule": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "skipLibCheck": true,
-    "strict": true,
     "noEmit": true,
     "isolatedModules": true,
-    "useDefineForClassFields": true,
-
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo"
   },
   "include": ["src/**/*"],

--- a/apps/sync/tsconfig.node.json
+++ b/apps/sync/tsconfig.node.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ESNext",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "lib": ["ESNext"],
+    "lib": ["ES2022"],
     "types": ["node"],
     "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "skipLibCheck": true,
-    "strict": true,
     "noEmit": true,
-
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo"
   },
   "include": ["vite.config.ts"]

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -88,6 +88,8 @@ controller specifically, `dev:controller` already rebuilds core examples on save
 
 ## Related
 
+- [`CONFIGURATION.md`](../CONFIGURATION.md) (repo root) — how the workspace tooling behind these
+  commands is actually configured: TypeScript config families, build tooling per package, CI/CD.
 - The deployed Pages site assembles these same apps/demos under a base path
   (`/creator/`, `/display/`, `/controller/`, …) via
   [`.github/workflows/deploy-pages.yml`](../.github/workflows/deploy-pages.yml) —

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -35,8 +35,9 @@ enums, LED layer index, light/volume values) live in the repo-root `AGENTS.md`.
 
 - `build` is a chain: `clean && typecheck && tsc && esbuild …` — it ships a `tsc` CJS
   build (`dist/src/`) **and** a hand-rolled esbuild ESM bundle (`dist/esm/index.mjs`).
-  `tsconfig.json` targets `es2017`/CommonJS on purpose (broadest consumer compat) and
-  does not extend the workspace ES2022 base.
+  `tsconfig.json` extends the shared `tsconfig.node-lib.json` (target `ES2022`,
+  `module`/`moduleResolution` `Node16`/`Node16` for CommonJS emission) rather than the
+  workspace's browser-targeted `tsconfig.base.json`.
 - Tests are **vitest** (`tests/`, not colocated). Mocks in `tests/mocks/`,
   adapter tests in `tests/adapters/`. Config in `vitest.config.ts` (`globals: true`,
   so no `from 'vitest'` imports needed); ambient globals are declared for tsc by

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,39 +1,21 @@
 {
   // core ships a CommonJS build (`main`) alongside an esbuild ESM bundle
-  // (`module`, hand-built separately — see package.json's `build` script). It
-  // does not extend the ES2022 workspace base: the base's `module: "ESNext"` +
-  // `moduleResolution: "bundler"` would make tsc emit `export`/`import` syntax,
-  // which breaks every `require()` consumer of this CJS package outright
-  // (verified directly: Node's loader throws ERR_MODULE_NOT_FOUND trying to
-  // resolve the emitted ESM as CommonJS). `target` is aligned with the base
-  // (ES2022) since that's a pure syntax-level choice with no effect on module
-  // format; `module`/`moduleResolution` stay Node16/Node16 — CJS emission
-  // (no "type" field means Node treats it as CommonJS) with exports-map-aware
-  // resolution, which `commonjs`+implicit-node10 (the pre-2026-07 setting)
-  // did not have.
+  // (`module`, hand-built separately — see package.json's `build` script).
+  // Extends the shared tsconfig.node-lib.json (see that file for the full
+  // CJS/Node16 rationale) with one override below.
+  "extends": "../../tsconfig.node-lib.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "Node16",
-    "moduleResolution": "Node16",
-    // Explicit, not the target-implied default (which also includes DOM). This
-    // package genuinely is dual-platform — WebBluetoothAdapter, the optional
-    // browser debug logger (udtLogger.ts), and IndexedDBSink all use real DOM
-    // globals (document/window/indexedDB) by design, unlike e.g. relay-shared
-    // (Node/protocol-only), which excludes DOM on purpose. Confirmed by removing
-    // DOM experimentally: 29 errors surface across exactly those three files.
+    // Explicit, not the shared base's Node-only default. This package genuinely
+    // is dual-platform — WebBluetoothAdapter, the optional browser debug logger
+    // (udtLogger.ts), and IndexedDBSink all use real DOM globals (document/
+    // window/indexedDB) by design, unlike e.g. relay-shared (Node/protocol-only),
+    // which excludes DOM on purpose. Confirmed by removing DOM experimentally:
+    // 29 errors surface across exactly those three files.
     "lib": ["ES2022", "DOM"],
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "outDir": "./dist",
-    "resolveJsonModule": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true,
-    "skipLibCheck": true
+    "outDir": "./dist"
   },
   // NOTE: `tests` is deliberately NOT excluded. This config sets `outDir` with no
   // `rootDir`, so tsc infers rootDir from the common root of all inputs — src +

--- a/packages/creator-engine/package.json
+++ b/packages/creator-engine/package.json
@@ -9,7 +9,8 @@
     "test": "node test/run-all.js",
     "pretest": "tsc --build",
     "build": "tsc --build",
-    "typecheck": "tsc --build"
+    "typecheck": "tsc --build",
+    "lint": "eslint ."
   },
   "devDependencies": {
     "ajv": "catalog:",

--- a/packages/game-data/CLAUDE.md
+++ b/packages/game-data/CLAUDE.md
@@ -20,8 +20,9 @@ exists because v6 had the same entity spelled 2–3 ways ("Isa the Exile" vs "Is
 
 ## Build & test
 
-- `build` = `tsc --build` (composite project, `"composite": true`), `es2017`/CommonJS.
-- No package-local `lint`/`ci` scripts — relies on the root `eslint .` and `pnpm -r` fan-out.
+- `build` = `tsc --build` (composite project, `"composite": true`), `ES2022`/CommonJS.
+- `lint` = `eslint .` (root flat config); no package-local `ci` script — relies on the
+  root `pnpm -r` fan-out for that.
 - Tests are **vitest** (`tests/`, not colocated), one file per data module. Config lives in
   `vitest.config.ts` with `globals: true`, so the suites keep using bare
   `describe`/`it`/`expect` with no imports.

--- a/packages/game-data/package.json
+++ b/packages/game-data/package.json
@@ -28,6 +28,7 @@
   "scripts": {
     "build": "tsc --build",
     "typecheck": "tsc --noEmit",
+    "lint": "eslint .",
     "test": "vitest run",
     "clean": "rm -rf dist *.tsbuildinfo",
     "test:watch": "vitest",

--- a/packages/game-data/tsconfig.json
+++ b/packages/game-data/tsconfig.json
@@ -1,27 +1,14 @@
 {
-  // Does not extend the ES2022 workspace base — see packages/relay-shared/tsconfig.json
-  // for the full rationale. Short version: base's module:"ESNext"+moduleResolution:"bundler"
-  // would emit ESM syntax, which breaks require() for this published CJS package's
-  // consumers. target matches the base; module/moduleResolution stay Node16/Node16.
+  // Does not extend the ES2022 workspace base directly — extends the shared
+  // tsconfig.node-lib.json instead. See that file for the full CJS/Node16 rationale.
+  "extends": "../../tsconfig.node-lib.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "Node16",
-    "moduleResolution": "Node16",
-    "lib": ["ES2022"],
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
     "outDir": "./dist",
     "rootDir": "./src",
-    "composite": true,
-    "resolveJsonModule": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "composite": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "tests"]

--- a/packages/relay-client/package.json
+++ b/packages/relay-client/package.json
@@ -21,6 +21,7 @@
     "build": "tsc --build",
     "dev": "tsc --build --watch",
     "typecheck": "tsc --noEmit",
+    "lint": "eslint .",
     "test": "vitest run",
     "clean": "rm -rf dist *.tsbuildinfo"
   },

--- a/packages/relay-client/tsconfig.json
+++ b/packages/relay-client/tsconfig.json
@@ -1,27 +1,18 @@
 {
-  // Does not extend the ES2022 workspace base — see packages/relay-shared/tsconfig.json
-  // for the full rationale. Short version: base's module:"ESNext"+moduleResolution:"bundler"
-  // would emit ESM syntax, which breaks require() for this published CJS package's
-  // consumers. target matches the base; module/moduleResolution stay Node16/Node16.
+  // Does not extend the ES2022 workspace base directly — extends the shared
+  // tsconfig.node-lib.json instead. See that file for the full CJS/Node16 rationale.
+  "extends": "../../tsconfig.node-lib.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "Node16",
-    "moduleResolution": "Node16",
+    // Isomorphic (browser or Node): RelayClient takes an injectable WebSocket
+    // implementation typed against the DOM lib's global, unlike relay-core
+    // (Node-only, no DOM override needed).
     "lib": ["ES2022", "DOM"],
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
     "outDir": "./dist",
     "rootDir": "./src",
-    "composite": true,
-    "resolveJsonModule": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "composite": true
   },
   "references": [
     {

--- a/packages/relay-core/package.json
+++ b/packages/relay-core/package.json
@@ -28,6 +28,7 @@
     "build": "tsc --build",
     "dev": "tsc --build --watch",
     "typecheck": "tsc --noEmit",
+    "lint": "eslint .",
     "test": "vitest run",
     "clean": "rm -rf dist *.tsbuildinfo"
   },

--- a/packages/relay-core/tsconfig.json
+++ b/packages/relay-core/tsconfig.json
@@ -1,27 +1,14 @@
 {
-  // Does not extend the ES2022 workspace base — see packages/relay-shared/tsconfig.json
-  // for the full rationale. Short version: base's module:"ESNext"+moduleResolution:"bundler"
-  // would emit ESM syntax, which breaks require() for this published CJS package's
-  // consumers. target matches the base; module/moduleResolution stay Node16/Node16.
+  // Does not extend the ES2022 workspace base directly — extends the shared
+  // tsconfig.node-lib.json instead. See that file for the full CJS/Node16 rationale.
+  "extends": "../../tsconfig.node-lib.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "Node16",
-    "moduleResolution": "Node16",
-    "lib": ["ES2022"],
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
     "outDir": "./dist",
     "rootDir": "./src",
-    "composite": true,
-    "resolveJsonModule": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "composite": true
   },
   "references": [
     {

--- a/packages/relay-shared/package.json
+++ b/packages/relay-shared/package.json
@@ -15,6 +15,7 @@
     "build": "tsc --build",
     "test": "vitest run --passWithNoTests",
     "typecheck": "tsc --noEmit",
+    "lint": "eslint .",
     "clean": "rm -rf dist *.tsbuildinfo"
   },
   "keywords": [

--- a/packages/relay-shared/tsconfig.json
+++ b/packages/relay-shared/tsconfig.json
@@ -1,31 +1,14 @@
 {
-  // Does not extend the ES2022 workspace base: the base's `module: "ESNext"` +
-  // `moduleResolution: "bundler"` would make tsc emit `export`/`import` syntax,
-  // which breaks every `require()` consumer of this published CJS package
-  // outright (verified directly: Node's loader throws ERR_MODULE_NOT_FOUND
-  // trying to resolve emitted ESM as CommonJS). `target` matches the base
-  // (ES2022) — a pure syntax choice, no effect on module format.
-  // `module`/`moduleResolution` stay Node16/Node16: CJS emission (no "type"
-  // field means Node treats it as CommonJS) with exports-map-aware resolution.
+  // Does not extend the ES2022 workspace base directly — extends the shared
+  // tsconfig.node-lib.json instead. See that file for the full CJS/Node16 rationale.
+  "extends": "../../tsconfig.node-lib.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "Node16",
-    "moduleResolution": "Node16",
-    "lib": ["ES2022"],
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
     "outDir": "./dist",
     "rootDir": "./src",
-    "composite": true,
-    "resolveJsonModule": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "composite": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/tsconfig.node-lib.json
+++ b/tsconfig.node-lib.json
@@ -1,0 +1,30 @@
+{
+  // Shared compiler flags for the CommonJS/Node16-published libraries (packages/core,
+  // packages/game-data, packages/relay-shared, packages/relay-core, packages/relay-client,
+  // apps/relay-cli, apps/mcp-server). Holds only non-path options so it can be extended
+  // safely; each package keeps its own outDir/rootDir/declarationDir/composite/
+  // references/include/exclude (those resolve relative to the file that declares them).
+  //
+  // Intentionally does NOT extend tsconfig.base.json: these packages are require()-
+  // consumed CJS (or, for apps/mcp-server, Node16-conditioned ESM under its own
+  // "type": "module") and the base's module:"ESNext"+moduleResolution:"bundler" would
+  // make tsc emit ESM/bundler-only syntax that breaks a require() consumer outright
+  // (verified directly: Node's loader throws ERR_MODULE_NOT_FOUND resolving emitted
+  // ESM as CommonJS). target matches the base (a pure syntax-level choice with no
+  // effect on module format); module/moduleResolution stay Node16/Node16 for
+  // exports-map-aware CJS resolution.
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2022"],
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  }
+}


### PR DESCRIPTION
## Summary

Follow-up to #38 (the July 2026 stack-alignment pass), closing out the residual config drift a fresh audit turned up, plus a new configuration reference doc.

- Add `"lint"` script to the 9 packages missing it (`game-data`, `relay-client`, `relay-core`, `relay-shared`, `creator-engine`, `relay-cli`, `relay-electron`, `sync`, `mcp-server`), matching the other 14 workspaces.
- Factor the CJS/Node16 tsconfig family (`core`, `game-data`, `relay-shared`, `relay-core`, `relay-client`, `relay-cli`, `mcp-server`) into a shared root `tsconfig.node-lib.json`, mirroring the existing `tsconfig.browser-lib.json` pattern. Verified byte-identical `dist/` output for 6 of 7 packages via a before/after build diff.
- Extend `tsconfig.base.json` in 6 Vite app configs (`controller`, `game`, `seed`, `relay-electron`, `digital` app+node, `sync` app+node) that were hand-duplicating it, closing a `target: ESNext` vs `ES2022` drift.
- Fix two real dead-code issues the new strictness surfaced: unused write-only fields in `mcp-server`'s `TowerController`, and in `apps/controller`'s `TowerEmulatorAdapter` (the latter following the exact `NoopBluetoothAdapter` precedent already established in `packages/core`).
- Point `ci.yml`/`deploy-pages.yml`/`release.yml` at `.nvmrc` instead of a duplicated `node-version` literal (leaving the `relay-native` Node 22/24 matrix alone).
- Fix a couple of doc lines left stale by the July 2026 alignment pass (`core` and `game-data` `CLAUDE.md` both still said `es2017`), plus a couple of smaller cleanups (`.editorconfig`'s overclaimed `printWidth` mirroring, vestigial `globals: true` in three vitest configs).
- Add `CONFIGURATION.md`: a root-level reference for how the whole monorepo is configured (TypeScript config families, pnpm catalog, lint/test/build tooling, CI/CD architecture, and a gotchas list), linked in from README, CONTRIBUTING, `docs/local-development.md`, and `.claude/CLAUDE.md`.
- Adds a changeset covering the 6 published/public packages touched by the tsconfig consolidation.

## Test plan

- [x] `pnpm run ci` (validate:nodes → lint → format:check → build → typecheck → test) green locally, both before and after rebasing onto latest `main`
- [x] Before/after `dist/` diff confirms zero emit change for `core`, `game-data`, `relay-shared`, `relay-core`, `relay-client`, `relay-cli`
- [x] `apps/mcp-server` and `apps/controller` typecheck + test clean after removing the newly-surfaced dead fields
- [ ] CI (this PR): `checks` + `relay-native` matrix