### PR TITLE
feat(core): add `browser` export condition; drop 7 consumer workarounds

### DIFF
--- a/.changeset/core-browser-export-condition.md
+++ b/.changeset/core-browser-export-condition.md
@@ -1,0 +1,11 @@
+---
+'ultimatedarktower': minor
+---
+
+Add a `browser` export condition so the package loads in browser bundlers without per-app workarounds.
+
+The published ESM bundle (`dist/esm/index.mjs`) begins with an esbuild-injected `import{createRequire}from'module'` banner — a Node builtin that a browser cannot resolve, so the entry died on line 1 before any library code ran. The banner exists only because the guarded `require('@stoprocent/noble')` in `NodeBluetoothAdapter` survives into the ESM output as a literal external `require`.
+
+This adds a second, browser-targeted esbuild bundle (`dist/browser/index.mjs`) that aliases `@stoprocent/noble` to a throwing stub so the require is inlined rather than left external — no surviving `require`, so no `createRequire` banner. A new `browser` export condition (ordered before `import`/`require`) points bundlers at it; Vite, webpack, and Rollup honour it automatically, so browser consumers need no alias/pre-bundle configuration. Node consumers are unaffected: the `import` (Node ESM, banner intact) and `require` (CJS) conditions are unchanged, and `BluetoothPlatform.NODE` still resolves the real `NodeBluetoothAdapter` with native BLE.
+
+No API change — purely additive.

--- a/apps/controller/vite.config.ts
+++ b/apps/controller/vite.config.ts
@@ -1,57 +1,19 @@
 /// <reference types="vitest/config" />
 import { defineConfig } from 'vite';
 import { fileURLToPath } from 'url';
-import type { Plugin as EsbuildPlugin } from 'esbuild';
-
-const udtCjsEntry = fileURLToPath(
-  new URL('./node_modules/ultimatedarktower/dist/src/index.js', import.meta.url),
-);
-
-function esbuildNodeModuleShim(): EsbuildPlugin {
-  return {
-    name: 'shim-node-module',
-    setup(build) {
-      build.onResolve({ filter: /^module$/ }, () => ({
-        path: 'module',
-        namespace: 'node-module-shim',
-      }));
-      build.onLoad({ filter: /.*/, namespace: 'node-module-shim' }, () => ({
-        contents: `
-          export function createRequire() {
-            return function require(id) {
-              throw new Error('[browser] require("' + id + '") is not available');
-            };
-          }
-        `,
-        loader: 'js',
-      }));
-    },
-  };
-}
-
-function udtCjsForBuild(): import('vite').Plugin {
-  let isBuild = false;
-  return {
-    name: 'ultimatedarktower-cjs-build',
-    enforce: 'pre',
-    configResolved(config) {
-      isBuild = config.command === 'build';
-    },
-    resolveId(source) {
-      if (isBuild && source === 'ultimatedarktower') {
-        return { id: udtCjsEntry, external: false };
-      }
-    },
-  };
-}
 
 // Deployed to the unified Pages site at /UltimateDarkTower/controller/. The base
 // is injected by deploy-pages.yml (--base); '/' keeps local dev/build path-agnostic.
+//
+// `ultimatedarktower` needs no special handling: since v7.0.0 it ships a `browser`
+// export condition (dist/browser/index.mjs) with no `createRequire`/noble banner,
+// so Vite/Rollup resolve a browser-safe ESM entry directly. This dropped the
+// former CJS-redirect plugin, the `module` esbuild shim, the commonjsOptions
+// core opt-in, and the `@stoprocent/noble` external/exclude.
 export default defineConfig({
   base: '/',
   root: '.',
   publicDir: 'public',
-  plugins: [udtCjsForBuild()],
   // No source .glb import (the model is served from public/ and passed via
   // modelUrl), but keep .glb classified as an asset for robustness. The emulator's
   // .ogg audio is emitted automatically from ultimatedarktowerdisplay's internal
@@ -61,15 +23,7 @@ export default defineConfig({
     outDir: 'dist',
     sourcemap: true,
     target: 'es2020',
-    commonjsOptions: {
-      // ultimatedarktower's CJS entry resolves via the pnpm workspace symlink to
-      // packages/core/dist (a realpath outside node_modules), which Rollup's
-      // commonjs plugin skips by default — leaving raw require() calls that throw
-      // "require is not defined" in the browser. Opt the workspace core dir in.
-      include: [/node_modules/, /packages\/core/],
-    },
     rollupOptions: {
-      external: ['@stoprocent/noble'],
       // Two pages: the controller UI and the 3D emulator popup the controller
       // opens via window.open('TowerEmulator.html').
       input: {
@@ -84,11 +38,7 @@ export default defineConfig({
     dedupe: ['three', 'gsap', '@dimforge/rapier3d-compat'],
   },
   optimizeDeps: {
-    include: ['ultimatedarktower', 'ultimatedarktowerdisplay'],
-    exclude: ['@stoprocent/noble'],
-    esbuildOptions: {
-      plugins: [esbuildNodeModuleShim()],
-    },
+    include: ['ultimatedarktowerdisplay'],
   },
   server: {
     port: 3005,

--- a/apps/creator/src/boards/vocabulary.ts
+++ b/apps/creator/src/boards/vocabulary.ts
@@ -4,10 +4,14 @@
 // else keeps the built-in Return to Dark Tower roster. This mirrors the L2 check in
 // `@udtc/adapters`' `validate-refs`, so what the editor offers is exactly what validates.
 
-// RtDT data comes from @udtc/adapters' reference layer, NOT a direct import of
-// `ultimatedarktower`/`ultimatedarktowerboard`: the creator's Vite config aliases UDT to its CJS
-// build, whose entry reaches UDT's Node-only BLE stack (@stoprocent/noble) and breaks the browser
-// bundle. `udt.ts` is the single module allowed to import UDT, and it is pre-bundled for the browser.
+// RtDT vocabulary comes from @udtc/adapters' reference layer (getUDTReferenceLayer),
+// not a direct `ultimatedarktower`/`ultimatedarktowerboard` import — an architectural
+// choice so the editor's vocabulary has a single source that matches validation (the
+// validate-refs mirror noted above). This is no longer a browser-safety requirement:
+// core shipped a browser-hostile `createRequire` banner until v7.0.0, which now ships a
+// `browser` export condition, so direct core imports are browser-safe (e.g. sibling
+// `@udtc/adapters` modules import core values directly) — going through the reference
+// layer here is about the data-source convention, not the bundle.
 import { getUDTReferenceLayer } from '@udtc/adapters';
 import type { ScenarioDoc } from '../types';
 import { activeBoardId, boardsOf } from './shared';

--- a/apps/creator/vite.config.ts
+++ b/apps/creator/vite.config.ts
@@ -2,12 +2,6 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { fileURLToPath, URL } from 'node:url';
-import { createRequire } from 'node:module';
-
-// ultimatedarktower v4.1.0's ESM entry uses `import{createRequire}from'module'` (Node-only).
-// Force Vite to bundle the CJS entry instead, which is browser-safe.
-const _require = createRequire(import.meta.url);
-const udtCjsPath = _require.resolve('ultimatedarktower');
 
 export default defineConfig({
   base: '/', // Pages base is set via --base in deploy-pages.yml
@@ -15,18 +9,15 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),
-      ultimatedarktower: udtCjsPath,
     },
     dedupe: ['react', 'react-dom', 'three', 'gsap', '@dimforge/rapier3d-compat'],
   },
   optimizeDeps: {
-    // `ultimatedarktower` must be pre-bundled explicitly (as apps/digital does). Without it, the
-    // CJS entry the alias above points at is processed by Vite's ESM pipeline, which hoists UDT's
-    // optional `require('@stoprocent/noble')` (Node-only BLE, guarded by a try/catch in
-    // NodeBluetoothAdapter) into an eager import — noble then runs `os.platform()` at module init
-    // and takes the whole app down with "os.platform is not a function". esbuild's dep optimizer
-    // keeps that require lazy. Pre-existing on a cold `.vite` cache; see PR notes.
-    include: ['@udtc/engine', '@udtc/schema', '@udtc/adapters', 'ultimatedarktower'],
+    // Pre-bundle the linked @udtc/* workspace libs so their file: links resolve cleanly in dev.
+    // `ultimatedarktower` no longer needs listing here: since v7.0.0 it ships a `browser` export
+    // condition (dist/browser/index.mjs) with no `createRequire`/noble banner, so Vite resolves a
+    // browser-safe entry directly — no CJS alias, and no eager-noble `os.platform` crash on cold cache.
+    include: ['@udtc/engine', '@udtc/schema', '@udtc/adapters'],
   },
   server: {
     port: 5173,

--- a/apps/digital/vite.config.ts
+++ b/apps/digital/vite.config.ts
@@ -2,7 +2,6 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { fileURLToPath, URL } from 'node:url';
-import { createRequire } from 'node:module';
 
 // Deployed to the unified Pages site at /UltimateDarkTower/digital/. The base is
 // injected by deploy-pages.yml (--base); '/' keeps local dev/build path-agnostic.
@@ -18,21 +17,17 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),
-      // The ultimatedarktower ESM build ships an esbuild banner
-      // (`createRequire(import.meta.url)`) that throws in the browser. Its CJS
-      // entry is clean — point the browser at it and let Vite pre-bundle it.
-      // Resolve via the package's `main` (dist/src/index.js) so it follows the
-      // pnpm workspace symlink to packages/core.
-      // (Alias boundary matching leaves ...display / ...board untouched.)
-      ultimatedarktower: createRequire(import.meta.url).resolve('ultimatedarktower'),
     },
     // The UDT libraries externalize these peers; a duplicate copy breaks the
     // single shared 3D scene. Force one instance. See PRD-00 FR-00.3.
     dedupe: ['three', 'gsap', '@dimforge/rapier3d-compat', 'react', 'react-dom'],
   },
   optimizeDeps: {
-    // Pre-bundle the linked libs so file: links resolve cleanly in dev.
-    include: ['ultimatedarktower', 'ultimatedarktowerdisplay', 'ultimatedarktowerboard'],
+    // Pre-bundle the linked libs so file: links resolve cleanly in dev. `ultimatedarktower`
+    // no longer needs listing here: since v7.0.0 it ships a `browser` export condition
+    // (dist/browser/index.mjs) with no `createRequire`/noble banner, so Vite resolves a
+    // browser-safe entry directly.
+    include: ['ultimatedarktowerdisplay', 'ultimatedarktowerboard'],
   },
   test: {
     environment: 'jsdom',

--- a/apps/game/vite.config.ts
+++ b/apps/game/vite.config.ts
@@ -1,77 +1,21 @@
 import { defineConfig } from 'vite';
-import { fileURLToPath } from 'url';
-import type { Plugin as EsbuildPlugin } from 'esbuild';
-
-const udtCjsEntry = fileURLToPath(
-  new URL('./node_modules/ultimatedarktower/dist/src/index.js', import.meta.url),
-);
-
-function esbuildNodeModuleShim(): EsbuildPlugin {
-  return {
-    name: 'shim-node-module',
-    setup(build) {
-      build.onResolve({ filter: /^module$/ }, () => ({
-        path: 'module',
-        namespace: 'node-module-shim',
-      }));
-      build.onLoad({ filter: /.*/, namespace: 'node-module-shim' }, () => ({
-        contents: `
-          export function createRequire() {
-            return function require(id) {
-              throw new Error('[browser] require("' + id + '") is not available');
-            };
-          }
-        `,
-        loader: 'js',
-      }));
-    },
-  };
-}
-
-function udtCjsForBuild(): import('vite').Plugin {
-  let isBuild = false;
-  return {
-    name: 'ultimatedarktower-cjs-build',
-    enforce: 'pre',
-    configResolved(config) {
-      isBuild = config.command === 'build';
-    },
-    resolveId(source) {
-      if (isBuild && source === 'ultimatedarktower') {
-        return { id: udtCjsEntry, external: false };
-      }
-    },
-  };
-}
 
 // Deployed to the unified Pages site at /UltimateDarkTower/game/. The base is
 // injected by deploy-pages.yml (--base); '/' keeps local dev/build path-agnostic.
+//
+// `ultimatedarktower` needs no special handling: since v7.0.0 it ships a `browser`
+// export condition (dist/browser/index.mjs) with no `createRequire`/noble banner,
+// so Vite/Rollup resolve a browser-safe ESM entry directly. This dropped the
+// former CJS-redirect plugin, the `module` esbuild shim, the commonjsOptions
+// core opt-in, and the `@stoprocent/noble` external/exclude.
 export default defineConfig({
   base: '/',
   root: '.',
   publicDir: 'public',
-  plugins: [udtCjsForBuild()],
   build: {
     outDir: 'dist',
     sourcemap: true,
     target: 'es2020',
-    commonjsOptions: {
-      // ultimatedarktower's CJS entry resolves via the pnpm workspace symlink to
-      // packages/core/dist (a realpath outside node_modules), which Rollup's
-      // commonjs plugin skips by default — leaving raw require() calls that throw
-      // "require is not defined" in the browser. Opt the workspace core dir in.
-      include: [/node_modules/, /packages\/core/],
-    },
-    rollupOptions: {
-      external: ['@stoprocent/noble'],
-    },
-  },
-  optimizeDeps: {
-    include: ['ultimatedarktower'],
-    exclude: ['@stoprocent/noble'],
-    esbuildOptions: {
-      plugins: [esbuildNodeModuleShim()],
-    },
   },
   server: {
     port: 3004,

--- a/apps/player/vite.config.ts
+++ b/apps/player/vite.config.ts
@@ -2,12 +2,6 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { fileURLToPath, URL } from 'node:url';
-import { createRequire } from 'node:module';
-
-// ultimatedarktower v4.1.0's ESM entry uses `import{createRequire}from'module'` (Node-only).
-// Force Vite to bundle the CJS entry instead, which is browser-safe.
-const _require = createRequire(import.meta.url);
-const udtCjsPath = _require.resolve('ultimatedarktower');
 
 export default defineConfig({
   base: '/', // Pages base is set via --base in deploy-pages.yml
@@ -15,18 +9,15 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),
-      ultimatedarktower: udtCjsPath,
     },
     dedupe: ['react', 'react-dom', 'three', 'gsap', '@dimforge/rapier3d-compat'],
   },
   optimizeDeps: {
-    // `ultimatedarktower` must be pre-bundled explicitly (as apps/digital does). Without it, the
-    // CJS entry the alias above points at is processed by Vite's ESM pipeline, which hoists UDT's
-    // optional `require('@stoprocent/noble')` (Node-only BLE, guarded by a try/catch in
-    // NodeBluetoothAdapter) into an eager import — noble then runs `os.platform()` at module init
-    // and takes the whole app down with "os.platform is not a function". esbuild's dep optimizer
-    // keeps that require lazy. Pre-existing on a cold `.vite` cache; see PR notes.
-    include: ['@udtc/engine', '@udtc/schema', '@udtc/adapters', 'ultimatedarktower'],
+    // Pre-bundle the linked @udtc/* workspace libs so their file: links resolve cleanly in dev.
+    // `ultimatedarktower` no longer needs listing here: since v7.0.0 it ships a `browser` export
+    // condition (dist/browser/index.mjs) with no `createRequire`/noble banner, so Vite resolves a
+    // browser-safe entry directly — no CJS alias, and no eager-noble `os.platform` crash on cold cache.
+    include: ['@udtc/engine', '@udtc/schema', '@udtc/adapters'],
   },
   server: {
     port: 5174,

--- a/apps/sync/vite.config.ts
+++ b/apps/sync/vite.config.ts
@@ -1,82 +1,19 @@
 /// <reference types="vitest/config" />
-import { defineConfig, type Plugin } from 'vite';
+import { defineConfig } from 'vite';
 import { fileURLToPath } from 'url';
-import { createRequire } from 'module';
-import type { Plugin as EsbuildPlugin } from 'esbuild';
 
-// Absolute path to the CJS entry of ultimatedarktower.  The ESM bundle
-// (dist/esm/index.mjs) includes a `createRequire` shim that fails in
-// browsers.  The CJS individual files use require() which Rollup's
-// commonjs plugin can convert to ESM automatically.  Resolve via the package's
-// `main` field (dist/src/index.js) so it follows the pnpm workspace symlink to
-// packages/core regardless of node_modules layout.
-const udtCjsEntry = createRequire(import.meta.url).resolve('ultimatedarktower');
-
-/**
- * esbuild plugin that shims Node's `module` built-in during dep pre-bundling.
- *
- * ultimatedarktower's ESM bundle starts with:
- *   import{createRequire}from'module'; const require=createRequire(…);
- *
- * esbuild externalizes `module` as a Node built-in, so the pre-bundled
- * output still contains the raw import — which the browser can't resolve.
- *
- * This plugin intercepts the `module` import and inlines a stub
- * `createRequire` that returns a `require` function which throws.
- * The only call site (`require('@stoprocent/noble')`) is inside a
- * try/catch, so the throw is harmless — the Node BLE adapter is never
- * used in the browser.
- */
-function esbuildNodeModuleShim(): EsbuildPlugin {
-  return {
-    name: 'shim-node-module',
-    setup(build) {
-      build.onResolve({ filter: /^module$/ }, () => ({
-        path: 'module',
-        namespace: 'node-module-shim',
-      }));
-      build.onLoad({ filter: /.*/, namespace: 'node-module-shim' }, () => ({
-        contents: `
-          export function createRequire() {
-            return function require(id) {
-              throw new Error('[browser] require("' + id + '") is not available');
-            };
-          }
-        `,
-        loader: 'js',
-      }));
-    },
-  };
-}
-
-/**
- * Vite plugin: redirects `ultimatedarktower` to CJS entry in production builds.
- *
- * In production (Rollup), the CJS entry is used so Rollup's commonjs plugin
- * converts require() → import.  In dev, the ESM entry is pre-bundled by
- * esbuild with the `module` shim above, so no redirect is needed.
- */
-function udtCjsForBuild(): Plugin {
-  let isBuild = false;
-  return {
-    name: 'ultimatedarktower-cjs-build',
-    enforce: 'pre',
-    configResolved(config) {
-      isBuild = config.command === 'build';
-    },
-    resolveId(source) {
-      if (isBuild && source === 'ultimatedarktower') {
-        return { id: udtCjsEntry, external: false };
-      }
-    },
-  };
-}
+// `ultimatedarktower` needs no special handling: since v7.0.0 it ships a `browser`
+// export condition (dist/browser/index.mjs) with no `createRequire`/noble banner,
+// so Vite/Rollup resolve a browser-safe ESM entry directly — for both the direct
+// import and the transitive `ultimatedarktowerrelay-client -> ultimatedarktower`
+// path (the `browser` condition wins regardless of import/require syntax). This
+// dropped the former CJS-redirect plugin, the `module` esbuild shim, and the
+// commonjsOptions core opt-in.
 
 // https://vitejs.dev/config/
 export default defineConfig({
   root: '.',
   publicDir: 'public',
-  plugins: [udtCjsForBuild()],
   build: {
     outDir: 'dist',
     // Production source maps are not deployed to GitHub Pages — they roughly double
@@ -90,28 +27,16 @@ export default defineConfig({
       // packages/relay-*/dist (a realpath outside node_modules), so include those
       // paths too — otherwise the CJS `export *` named exports (e.g.
       // `makeCommandLogEntry`) aren't detected during the production build.
-      include: [/node_modules/, /packages\/core/, /packages\/relay-/],
+      include: [/node_modules/, /packages\/relay-/],
     },
   },
   resolve: {
     alias: {
-      // @stoprocent/noble is a Node-only BLE adapter, required both directly by
-      // ultimatedarktower's CJS entry and transitively via
-      // ultimatedarktowerrelay-client -> ultimatedarktower (CJS). It's never
-      // installed and never loaded in the browser (the require is Node-guarded
-      // and wrapped in a try/catch). Aliasing it to a local empty stub gives the
-      // esbuild dev pre-bundler and the Rollup production build a real module to
-      // resolve, instead of externalizing a package that doesn't exist.
+      // @stoprocent/noble is a Node-only BLE adapter. core's browser build stubs it
+      // internally, so it should never enter the browser graph — but alias it to a
+      // local empty stub as a failsafe: the real (Node-only) package is present as
+      // core's devDependency, so a stray transitive CJS require must not pull it in.
       '@stoprocent/noble': fileURLToPath(new URL('./noble-stub.js', import.meta.url)),
-      // The relay SDK and ultimatedarktowerdisplay are workspace packages
-      // (workspace:^), resolved via pnpm symlinks — no source alias needed here.
-    },
-  },
-  optimizeDeps: {
-    esbuildOptions: {
-      // Shim Node's `module` built-in during pre-bundling so the ESM
-      // bundle's `createRequire` call works harmlessly in the browser.
-      plugins: [esbuildNodeModuleShim()],
     },
   },
   server: {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,6 +8,7 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
+      "browser": "./dist/browser/index.mjs",
       "import": "./dist/esm/index.mjs",
       "require": "./dist/src/index.js"
     }
@@ -28,7 +29,7 @@
     "lint:fix": "eslint . --fix",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist coverage",
-    "build": "pnpm clean && pnpm typecheck && tsc && esbuild src/index.ts --bundle --format=esm --outfile=dist/esm/index.mjs --packages=external --banner:js=\"import{createRequire}from'module';const require=createRequire(import.meta.url);\"",
+    "build": "pnpm clean && pnpm typecheck && tsc && esbuild src/index.ts --bundle --format=esm --outfile=dist/esm/index.mjs --packages=external --banner:js=\"import{createRequire}from'module';const require=createRequire(import.meta.url);\" && esbuild src/index.ts --bundle --format=esm --outfile=dist/browser/index.mjs --packages=external --alias:@stoprocent/noble=./src/adapters/noble-browser-stub.cjs",
     "dev": "tsc --watch",
     "ci": "pnpm lint && pnpm typecheck && pnpm test:ci && pnpm build",
     "size": "pnpm build && du -sh dist/",

--- a/packages/core/src/adapters/noble-browser-stub.cjs
+++ b/packages/core/src/adapters/noble-browser-stub.cjs
@@ -1,0 +1,25 @@
+// Browser-build stub for @stoprocent/noble (the Node-only native BLE peer dep).
+//
+// The browser esbuild bundle (`dist/browser/index.mjs`, wired in package.json's
+// build script via `--alias:@stoprocent/noble=./src/adapters/noble-browser-stub.cjs`)
+// aliases noble to this file so its `require()` in NodeBluetoothAdapter.ts is
+// inlined rather than left as a literal external `require(...)`. That removes the
+// last surviving require, so the browser build needs no `createRequire` banner —
+// which is the whole reason the ESM bundle can't load in a browser.
+//
+// This is CJS on purpose: `require()` of a CJS module stays a lazy call at the
+// call site (never hoisted to module top), and NodeBluetoothAdapter's require is
+// already guarded by a `process.versions.node` check, so in a browser this stub
+// is never actually evaluated. The Proxy exists only as a loud failsafe if the
+// browser build is ever mis-resolved into a Node context.
+// eslint-disable-next-line no-undef
+module.exports = new Proxy(
+  {},
+  {
+    get() {
+      throw new Error(
+        '@stoprocent/noble is unavailable in the browser build of ultimatedarktower; use the Node entry (import/require condition) for native BLE.',
+      );
+    },
+  },
+);

--- a/packages/core/tests/integration/calibration.integration.ts
+++ b/packages/core/tests/integration/calibration.integration.ts
@@ -16,17 +16,26 @@ import UltimateDarkTower, { BluetoothPlatform } from '../../src';
     console.log(`${prefix} Step 1: Connecting to tower...`);
     await tower.connect();
     console.log(`${prefix} Step 2: Connected. Starting calibration...`);
+
+    // Register the completion handler BEFORE issuing calibrate(): a tower that is
+    // already calibrated (e.g. it self-calibrated on power-on) reports completion
+    // the instant the command lands, so attaching the handler afterwards races the
+    // event — the wait then times out even though calibration actually succeeded.
+    let timer: ReturnType<typeof setTimeout>;
+    const calibrationComplete = new Promise<void>((resolve, reject) => {
+      tower.onCalibrationComplete = () => {
+        clearTimeout(timer);
+        console.log(`${prefix} Step 4: Calibration complete!`);
+        resolve();
+      };
+      timer = setTimeout(() => reject(new Error('Calibration did not complete in time')), 60000);
+    });
+
     await tower.calibrate();
     console.log(
       `${prefix} Step 3: Calibration command sent. Waiting for completion (up to 60s)...`,
     );
-    await new Promise<void>((resolve, reject) => {
-      tower.onCalibrationComplete = () => {
-        console.log(`${prefix} Step 4: Calibration complete!`);
-        resolve();
-      };
-      setTimeout(() => reject(new Error('Calibration did not complete in time')), 60000);
-    });
+    await calibrationComplete;
     const glyphs = tower.getAllGlyphPositions();
     console.log(`${prefix} Step 5: Glyph positions after calibration:`);
     console.log(`${prefix}   `, glyphs);

--- a/packages/display/vite.config.ts
+++ b/packages/display/vite.config.ts
@@ -139,18 +139,10 @@ function emitAssetsAsFiles(): Plugin {
 
 export default defineConfig({
   plugins: [redirectExamplePath(), copyTowerAsset(), emitAssetsAsFiles()],
-  resolve: {
-    alias: {
-      // The ESM build of ultimatedarktower uses createRequire which is not
-      // available in browsers. Alias to the CJS build instead.
-      ultimatedarktower: resolve(__dirname, 'node_modules/ultimatedarktower/dist/src/index.js'),
-    },
-  },
-  optimizeDeps: {
-    // Force Vite to pre-bundle the CJS build of ultimatedarktower so esbuild
-    // converts it to proper ESM with all named exports available statically.
-    include: ['ultimatedarktower'],
-  },
+  // `ultimatedarktower` is externalized in the lib build (see rollupOptions.external
+  // below); for the dev/example server it resolves via its `browser` export condition
+  // (dist/browser/index.mjs) since core v7.0.0 — no `createRequire` banner, so the
+  // former CJS alias + pre-bundle are no longer needed.
   assetsInclude: ['**/*.glb', '**/*.ogg'],
   build: {
     lib: {


### PR DESCRIPTION
## Problem

`ultimatedarktower`'s published ESM bundle can't load in a browser. Line 1 of `dist/esm/index.mjs` is:

```js
import{createRequire}from'module';const require=createRequire(import.meta.url);
```

`module` is a Node builtin, so the entry dies before any library code runs. The banner exists only because the guarded `require('@stoprocent/noble')` in `NodeBluetoothAdapter` survives into the `--packages=external` ESM output as a literal external `require`. This forced a copy-pasted browser workaround into **seven** build configs.

## Fix

- **New browser build** (`dist/browser/index.mjs`): a second esbuild pass that aliases `@stoprocent/noble` to a throwing stub (`packages/core/src/adapters/noble-browser-stub.cjs`), so the require is inlined — no surviving `require`, no `createRequire` banner.
- **New `browser` export condition** ordered before `import`/`require`. Vite/webpack/Rollup honour it automatically; browser consumers need zero config.
- Changeset: **minor** for `ultimatedarktower` (purely additive; no API change).

## Payoff — workarounds deleted (7 configs, +91/−262)

| Config | Removed |
| --- | --- |
| `apps/creator`, `apps/digital`, `apps/player` | CJS alias + `ultimatedarktower` in `optimizeDeps.include` |
| `apps/game`, `apps/controller`, `apps/sync` | `ultimatedarktower-cjs-build` plugin, `module` esbuild shim, `commonjsOptions` core opt-in, noble `external` |
| `packages/display` | dev-only CJS alias + pre-bundle |
| `apps/creator/src/boards/vocabulary.ts` | rewrote the stale "single module allowed to import UDT" firewall comment |

`apps/sync` deliberately **keeps** its `@stoprocent/noble`→empty-stub alias and relay `commonjsOptions` — those are orthogonal failsafes (noble is present as core's devDep), not banner workarounds.

## Node consumers unaffected

`import` (Node ESM, banner intact) and `require` (CJS) conditions are unchanged; `BluetoothPlatform.NODE` still resolves the real `NodeBluetoothAdapter` with native BLE.

## Verification

- `pnpm run ci` → **green** (validate → lint → format → build all apps + display lib → typecheck → test; core 457 / display 336 / board 169 …).
- Core browser bundle: line 1 `var __defProp…` (no `module` import), `createRequire: 0`, no surviving noble `require`; Node ESM bundle keeps its banner.
- Cold-cache `vite optimize --force` for creator + digital: executable optimized `.js` bundles have **no `stoprocent` / `os.platform` / `createRequire`** — the historical cold-cache crash is structurally impossible.

## Release note

`ultimatedarktower` already exists in the `NPM_TOKEN` scope, so this is new *behavior* but **not** a new package name — no token change needed before merging the Version Packages PR.