### PR TITLE
fix(deps): scope brace-expansion override to the vulnerable minimatch path

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,7 @@ overrides:
   tar: ^7.5.22
   tmp: ^0.2.7
   fast-uri: ^3.1.4
+  minimatch@10.2.5>brace-expansion: ^5.0.8
 
 importers:
 
@@ -2292,9 +2293,9 @@ packages:
   brace-expansion@2.1.2:
     resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -7119,7 +7120,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -8707,7 +8708,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimatch@3.1.5:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -63,10 +63,21 @@ catalog:
 #    range (^3.0.1) already permits the GHSA-v2hh-gcrm-f6hx fix in 3.1.4 — this
 #    is a stale resolution, not a parent waiting to catch up. Stay in the 3.x
 #    line (4.x is outside ajv's declared range).
+#  - brace-expansion: 3 copies resolve in-tree (1.1.16, 2.1.2, 5.0.7). GHSA-mh99-
+#    v99m-4gvg's range ("<=5.0.7") reads as vulnerable against all three by plain
+#    semver comparison, but this package maintains parallel major lines (1.x
+#    through 5.x each patched independently) — 1.1.16 and 2.1.2 already ship the
+#    EXPANSION_MAX_LENGTH fix (backported ahead of the 5.x line's own 5.0.8).
+#    Only 5.0.7 (via minimatch@10.2.5 ← @typescript-eslint/typescript-estree,
+#    root devDependency) actually lacks it. Scoped to that one path so the two
+#    already-fixed copies — used by minimatch@3.1.5/5.1.9/9.0.9 in the
+#    electron-forge toolchain, which expect the old 1.x/2.x API — aren't forced
+#    onto an unrelated major for no security benefit.
 overrides:
   tar: ^7.5.22
   tmp: ^0.2.7
   fast-uri: ^3.1.4
+  "minimatch@10.2.5>brace-expansion": ^5.0.8
 
 # electron-forge's @electron/rebuild depends on a git-hosted @electron/node-gyp
 # fork; pnpm 11 blocks git-hosted subdeps by default. Allow them so the electron


### PR DESCRIPTION
## Summary

Clears Dependabot alert **#75** (`brace-expansion`, HIGH, GHSA-mh99-v99m-4gvg —
DoS via unbounded expansion length / OOM crash).

Three copies of `brace-expansion` resolve in-tree: `1.1.16`, `2.1.2`, `5.0.7`.
GHSA's advisory range (`<=5.0.7`) reads as vulnerable against all three by
plain semver comparison, but this package maintains parallel major lines
(1.x through 5.x, each patched independently). Downloaded and inspected each
tarball directly:

- `1.1.16` and `2.1.2` **already ship the fix** (`EXPANSION_MAX_LENGTH` guard
  present) — backported to those maintenance lines on 2026-07-08, ahead of the
  5.x line's own fix and the advisory's public disclosure (2026-07-24).
- `5.0.7` **lacks the fix** — pulled in via `minimatch@10.2.5` ←
  `@typescript-eslint/typescript-estree@8.64.0` ← root `ultimate-dark-tower`
  devDependency (ESLint tooling only; never shipped, not reachable via any
  published package).

Scoped the override (`"minimatch@10.2.5>brace-expansion": ^5.0.8`) to that one
path rather than a blanket override, so the two already-fixed copies — used by
`minimatch@3.1.5`/`5.1.9`/`9.0.9` in the electron-forge toolchain, which expect
the old 1.x/2.x API — aren't forced onto an unrelated major for no security
benefit.

`brace-expansion@5.0.8` was published 2026-07-23 (5 days old), clear of the
`minimumReleaseAge` gate.

## Test plan

- [x] `pnpm install` — confirmed `brace-expansion@5.0.7` gone from
      `pnpm-lock.yaml`, replaced by `5.0.8`; `1.1.16`/`2.1.2` untouched
- [x] `pnpm install --frozen-lockfile` — clean
- [x] `pnpm run ci` — full gate green (validate:nodes → lint → format:check →
      build → typecheck → test)
- [ ] CI checks green on this PR