### PR TITLE
fix(deps): remove duplicated ip-address lockfile entry (broken lockfile on main)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3320,10 +3320,6 @@ packages:
     resolution: {integrity: sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==}
     engines: {node: '>= 12'}
 
-  ip-address@10.3.1:
-    resolution: {integrity: sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==}
-    engines: {node: '>= 12'}
-
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
@@ -8327,8 +8323,6 @@ snapshots:
   ini@2.0.0: {}
 
   interpret@3.1.1: {}
-
-  ip-address@10.3.1: {}
 
   ip-address@10.3.1: {}
 


### PR DESCRIPTION
## Summary

`main` is currently red: PR #61's squash-merge produced an invalid
`pnpm-lock.yaml` — `ip-address@10.3.1` was duplicated (byte-identical) in
both the `packages` and `snapshots` sections. pnpm's strict lockfile
validation rejects this outright (`ERR_PNPM_BROKEN_LOCKFILE`), so
`pnpm install --frozen-lockfile` fails on all 5 CI jobs.

The rest of that merge commit's lockfile was correct — `@hono/node-server`
was already resolving to the patched `2.0.12` (confirmed: Dependabot alert
#72 is marked `fixed` as of that commit). So this removes only the 6
duplicate lines rather than regenerating the file. That distinction matters:
a plain `pnpm install` against the broken lockfile silently *re-resolves*
`@hono/node-server` back down to the vulnerable `1.19.14`, since `1.19.14`
still satisfies the SDK's now-widened `"^1.19.9 || ^2.0.5"` range — pnpm
prefers keeping an existing satisfying resolution over jumping to the
newest one. Verified that trap firsthand before switching to a surgical
line removal instead.

## Test plan

- [x] No duplicate keys remain (`grep` for any package appearing >2 times
      across packages+snapshots sections — none)
- [x] `pnpm install --frozen-lockfile` — "Lockfile is up to date, resolution
      step is skipped" (confirms the edit didn't trigger any re-resolution)
- [x] Confirmed `@hono/node-server@2.0.12`, `brace-expansion@5.0.8`,
      `tar@7.5.22`, `fast-uri@3.1.4` all still resolve correctly
- [x] `pnpm run ci` — full gate green locally
- [ ] CI checks green on this PR