### PR TITLE
feat(digital): resume game across a page refresh

### DIFF
--- a/.changeset/resume-game-on-refresh.md
+++ b/.changeset/resume-game-on-refresh.md
@@ -1,0 +1,10 @@
+---
+'ultimatedarktowerdigital': minor
+---
+
+Resume the game automatically after a page refresh (PRD-04 FR-04.7). The game
+now autosaves to localStorage a beat after any change and reloads it on boot,
+so a refresh mid-game restores the tower, board, player boards, and turn/month
+exactly where you left off. An incompatible old save (a `schemaVersion`
+mismatch) now surfaces a blocking dialog offering a download before starting
+fresh, instead of failing silently.

--- a/apps/digital/src/app/App.tsx
+++ b/apps/digital/src/app/App.tsx
@@ -10,11 +10,13 @@ import { BoardInspector } from '@/features/board/BoardInspector';
 import { PlayerBoardPane } from '@/features/player-board/PlayerBoardPane';
 import { SessionBar } from '@/features/session/SessionBar';
 import { TurnTracker } from '@/features/session/TurnTracker';
+import { StaleSessionDialog } from '@/features/session/StaleSessionDialog';
 import './App.css';
 
 export function App() {
   return (
     <div className="app">
+      <StaleSessionDialog />
       <header className="app-header">
         <div className="app-title">
           <h1>UltimateDarkTowerDigital</h1>

--- a/apps/digital/src/features/session/StaleSessionDialog.tsx
+++ b/apps/digital/src/features/session/StaleSessionDialog.tsx
@@ -1,0 +1,45 @@
+/**
+ * Blocks on a save `loadSession` refused to read (PRD-04 FR-04.7's refuse-don't-migrate
+ * policy) — most often an older `GAME_SESSION_SCHEMA_VERSION`. There is no dismiss: closing
+ * without downloading or discarding would leave `staleSession` set, which blocks autosave
+ * indefinitely to protect the very bytes this dialog exists to save.
+ */
+import { useGameStore } from '@/state/gameStore';
+import { downloadJson } from '@/session';
+
+export function StaleSessionDialog() {
+  const stale = useGameStore((s) => s.staleSession);
+  const discardStaleSession = useGameStore((s) => s.discardStaleSession);
+
+  if (!stale) return null;
+
+  return (
+    <div
+      className="wizard-backdrop"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Incompatible saved game"
+    >
+      <div className="wizard">
+        <header className="wizard-head">
+          <h2>Saved game can&rsquo;t be opened</h2>
+        </header>
+        <div className="wizard-body">
+          <p>
+            Your saved game is from an older version of this app and can&rsquo;t be loaded. Download
+            a copy if you want to keep it, then start fresh.
+          </p>
+        </div>
+        <div className="wizard-actions">
+          <button onClick={() => downloadJson(stale.raw, 'rtdt-game-unreadable.json')}>
+            Download it
+          </button>
+          <span className="wizard-spacer" />
+          <button className="wizard-start" onClick={discardStaleSession}>
+            Start fresh
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/digital/src/main.tsx
+++ b/apps/digital/src/main.tsx
@@ -2,10 +2,16 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { App } from '@/app/App';
 import { ErrorBoundary } from '@/app/ErrorBoundary';
+import { startAutosave, useGameStore } from '@/state/gameStore';
 import './index.css';
 
 const root = document.getElementById('root');
 if (!root) throw new Error('Root element #root not found');
+
+// Resume the last game on refresh (PRD-04 FR-04.7): loads before the first paint, and a
+// missing/malformed save can't crash boot — `loadSession` returns false or sets `staleSession`.
+useGameStore.getState().loadSession();
+startAutosave();
 
 createRoot(root).render(
   <StrictMode>

--- a/apps/digital/src/session/storage.ts
+++ b/apps/digital/src/session/storage.ts
@@ -30,9 +30,9 @@ export function sessionFileName(session: GameSession): string {
   return `${base || 'rtdt-game'}-${stamp}.json`;
 }
 
-/** Trigger a browser download of the session as a .json file. */
-export function downloadSession(session: GameSession, fileName = sessionFileName(session)): void {
-  const blob = new Blob([serializeSession(session)], { type: 'application/json' });
+/** Trigger a browser download of arbitrary JSON text — the shared half of `downloadSession`. */
+export function downloadJson(text: string, fileName: string): void {
+  const blob = new Blob([text], { type: 'application/json' });
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
   a.href = url;
@@ -41,6 +41,11 @@ export function downloadSession(session: GameSession, fileName = sessionFileName
   a.click();
   a.remove();
   URL.revokeObjectURL(url);
+}
+
+/** Trigger a browser download of the session as a .json file. */
+export function downloadSession(session: GameSession, fileName = sessionFileName(session)): void {
+  downloadJson(serializeSession(session), fileName);
 }
 
 /** Copy the session JSON to the clipboard (for paste-sharing). */

--- a/apps/digital/src/session/sync.ts
+++ b/apps/digital/src/session/sync.ts
@@ -29,12 +29,17 @@ export function captureSession(
   return next;
 }
 
-/** Push a loaded session's tower & board into the live sources (hydration). */
+/**
+ * Push a loaded session's tower & board into the live sources (hydration).
+ * `board` may be null when the stage hasn't mounted yet (e.g. a boot-time restore) —
+ * the tower still hydrates; the caller is responsible for applying `session.board`
+ * once a board source becomes available.
+ */
 export function applyGameSession(
   session: GameSession,
   tower: TowerStateSource,
-  board: BoardStateSource,
+  board: BoardStateSource | null,
 ): void {
   tower.load(session.tower.state, session.tower.brokenSeals);
-  board.load(session.board);
+  board?.load(session.board);
 }

--- a/apps/digital/src/state/gameStore.test.ts
+++ b/apps/digital/src/state/gameStore.test.ts
@@ -29,7 +29,7 @@ vi.mock('@/session', async (importOriginal) => {
 });
 
 // Imported AFTER the mock so the store picks up the mocked persistence functions.
-const { useGameStore } = await import('./gameStore');
+const { useGameStore, startAutosave } = await import('./gameStore');
 const sessionMod = await import('@/session');
 
 function emptyBoardState(): BoardState {
@@ -111,6 +111,9 @@ describe('useGameStore', () => {
     useGameStore.getState().unregisterBoard();
     useGameStore.setState({
       session: sessionMod.createNewGameSession(sessionMod.createDefaultConfig()),
+      // `unregisterBoard` above just parked the previous test's board state; without this
+      // reset it leaks into this test's first `registerBoard` as a stray `load` call.
+      pendingBoardState: null,
     });
   });
 
@@ -314,6 +317,47 @@ describe('useGameStore', () => {
       expect(board.calls.some((c) => c.method === 'load')).toBe(true);
     });
 
+    it('loadSession hydrates the tower even with no board registered, and parks the board state', () => {
+      const base = useGameStore.getState().session;
+      const loaded: GameSession = {
+        ...base,
+        meta: { ...base.meta, name: 'Loaded Game' },
+        tower: { state: base.tower.state, brokenSeals: [{ level: 'top', side: 'north' }] },
+        board: { tokens: { 'foe:ghost': { typeId: 'foe', location: 'Narrow Vale' } } } as never,
+      };
+      localStorage.setItem(sessionMod.STORAGE_KEY, sessionMod.serializeSession(loaded));
+
+      const ok = useGameStore.getState().loadSession();
+
+      expect(ok).toBe(true);
+      expect(useGameStore.getState().session.meta.name).toBe('Loaded Game');
+      expect(useGameStore.getState().towerSource.getBrokenSeals()).toEqual([
+        { level: 'top', side: 'north' },
+      ]);
+      expect(useGameStore.getState().pendingBoardState).toEqual(loaded.board);
+
+      // Registering a board afterwards adopts the parked state.
+      const board = new FakeBoardSource();
+      useGameStore.getState().registerBoard(board, {} as never, {} as never);
+      expect(board.calls).toEqual([{ method: 'load', args: [loaded.board] }]);
+      expect(useGameStore.getState().pendingBoardState).toBeNull();
+    });
+
+    it('unregisterBoard parks the board state so a remounted board is re-hydrated', () => {
+      const first = new FakeBoardSource();
+      useGameStore.getState().registerBoard(first, {} as never, {} as never);
+      first.state = { tokens: { 'hero:h1': { typeId: 'hero', location: 'Delmsmire' } } } as never;
+      for (const l of first.listeners) l(first.state);
+      expect(useGameStore.getState().boardState).toEqual(first.state);
+
+      useGameStore.getState().unregisterBoard();
+      expect(useGameStore.getState().pendingBoardState).toEqual(first.state);
+
+      const second = new FakeBoardSource();
+      useGameStore.getState().registerBoard(second, {} as never, {} as never);
+      expect(second.calls).toEqual([{ method: 'load', args: [first.state] }]);
+    });
+
     it('loadSession refuses a save with an incompatible schemaVersion, surfacing it as staleSession', () => {
       const current = useGameStore.getState().session;
       const stale = {
@@ -410,6 +454,77 @@ describe('useGameStore', () => {
       expect(boards.find((b) => b.heroId === 'h2')?.warriors).toBe(
         sessionMod.createPlayerBoard('h2', 'south').warriors,
       );
+    });
+  });
+
+  describe('startAutosave', () => {
+    it('debounce-saves after a change, once a board is registered', () => {
+      vi.useFakeTimers();
+      try {
+        const board = new FakeBoardSource();
+        useGameStore.getState().registerBoard(board, {} as never, {} as never);
+        const stop = startAutosave(750);
+
+        useGameStore.getState().dropSkull();
+        vi.advanceTimersByTime(749);
+        expect(sessionMod.saveToLocalStorage).not.toHaveBeenCalled();
+        vi.advanceTimersByTime(1);
+        expect(sessionMod.saveToLocalStorage).toHaveBeenCalledTimes(1);
+
+        stop();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('does not save while no board is registered', () => {
+      vi.useFakeTimers();
+      try {
+        const stop = startAutosave(750);
+        useGameStore.getState().dropSkull();
+        vi.advanceTimersByTime(750);
+        expect(sessionMod.saveToLocalStorage).not.toHaveBeenCalled();
+        stop();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('does not save while a stale session is pending', () => {
+      vi.useFakeTimers();
+      try {
+        const board = new FakeBoardSource();
+        useGameStore.getState().registerBoard(board, {} as never, {} as never);
+        useGameStore.setState({
+          staleSession: { raw: '{}', error: new sessionMod.GameSessionLoadError('stale') },
+        });
+        const stop = startAutosave(750);
+
+        useGameStore.getState().dropSkull();
+        vi.advanceTimersByTime(750);
+
+        expect(sessionMod.saveToLocalStorage).not.toHaveBeenCalled();
+        stop();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('stops saving once unsubscribed', () => {
+      vi.useFakeTimers();
+      try {
+        const board = new FakeBoardSource();
+        useGameStore.getState().registerBoard(board, {} as never, {} as never);
+        const stop = startAutosave(750);
+
+        stop();
+        useGameStore.getState().dropSkull();
+        vi.advanceTimersByTime(750);
+
+        expect(sessionMod.saveToLocalStorage).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 });

--- a/apps/digital/src/state/gameStore.ts
+++ b/apps/digital/src/state/gameStore.ts
@@ -55,6 +55,14 @@ interface GameStore {
   boardState: BoardState | null;
 
   /**
+   * A session's board state waiting for a board to mount (boot restore, or the gap
+   * left by `unregisterBoard` during a stage remount). Distinct from `boardState`,
+   * which means "the live board's current state" and gates `BoardPalette`'s ready
+   * check — leaving a stale value there would report a dead board as ready.
+   */
+  pendingBoardState: BoardState | null;
+
+  /**
    * The non-live parts of the game (meta / config / progress / playerBoards) are the
    * authoritative copy here; its `tower`/`board` fields are a last snapshot and are
    * ignored when capturing (live tower/board come from the sources). PRD-03/04 will add
@@ -152,171 +160,196 @@ function withProgress(session: GameSession, progress: GameSession['progress']): 
   };
 }
 
-export const useGameStore = create<GameStore>((set, get) => ({
-  towerSource,
-  boardSource: null,
-  boardSelection: null,
-  boardLocationPick: null,
+export const useGameStore = create<GameStore>((set, get) => {
+  /**
+   * Hydrate the live sources from a session and install it as the base. When the board
+   * isn't mounted yet (boot restore, or between an unmount and remount), park its state
+   * in `pendingBoardState` so `registerBoard` can apply it the moment a board exists.
+   */
+  const applySession = (session: GameSession) => {
+    const board = get().boardSource;
+    applyGameSession(session, towerSource, board);
+    set(board ? { session } : { session, pendingBoardState: session.board });
+  };
 
-  skullDropCount: towerSource.getSkullDropCount(),
-  brokenSeals: towerSource.getBrokenSeals(),
-  drumPositions: [
-    towerSource.getState().drum[0].position,
-    towerSource.getState().drum[1].position,
-    towerSource.getState().drum[2].position,
-  ],
-  boardState: null,
+  return {
+    towerSource,
+    boardSource: null,
+    boardSelection: null,
+    boardLocationPick: null,
 
-  session: createNewGameSession(createDefaultConfig()),
-  staleSession: null,
+    skullDropCount: towerSource.getSkullDropCount(),
+    brokenSeals: towerSource.getBrokenSeals(),
+    drumPositions: [
+      towerSource.getState().drum[0].position,
+      towerSource.getState().drum[1].position,
+      towerSource.getState().drum[2].position,
+    ],
+    boardState: null,
+    pendingBoardState: null,
 
-  dismissStaleSession() {
-    set({ staleSession: null });
-  },
-  discardStaleSession() {
-    clearLocalStorage();
-    set({ staleSession: null });
-  },
+    session: createNewGameSession(createDefaultConfig()),
+    staleSession: null,
 
-  registerBoard(source, selection, locationPick) {
-    boardUnsub?.();
-    boardUnsub = source.subscribe((state) => set({ boardState: state }));
-    set({ boardSource: source, boardSelection: selection, boardLocationPick: locationPick });
-  },
-  unregisterBoard() {
-    boardUnsub?.();
-    boardUnsub = null;
-    get().boardSource?.dispose();
-    set({ boardSource: null, boardState: null, boardSelection: null, boardLocationPick: null });
-  },
+    dismissStaleSession() {
+      set({ staleSession: null });
+    },
+    discardStaleSession() {
+      clearLocalStorage();
+      set({ staleSession: null });
+    },
 
-  dropSkull: () => towerSource.dropSkull(),
-  breakSeal: (seal) => towerSource.breakSeal(seal),
-  restoreSeal: (seal) => towerSource.restoreSeal(seal),
-  rotateDrum: (drumIndex, position) => towerSource.rotateDrum(drumIndex, position),
+    registerBoard(source, selection, locationPick) {
+      // Read before subscribing: `subscribe` calls its listener synchronously with the
+      // source's (empty) starting state, which would otherwise stomp what we're restoring.
+      const pending = get().pendingBoardState;
+      boardUnsub?.();
+      boardUnsub = source.subscribe((state) => set({ boardState: state }));
+      set({
+        boardSource: source,
+        boardSelection: selection,
+        boardLocationPick: locationPick,
+        pendingBoardState: null,
+      });
+      if (pending) source.load(pending);
+    },
+    unregisterBoard() {
+      boardUnsub?.();
+      boardUnsub = null;
+      get().boardSource?.dispose();
+      set({
+        boardSource: null,
+        boardState: null,
+        boardSelection: null,
+        boardLocationPick: null,
+        // Survive a remount (StrictMode's dev double-mount, HMR) — a fresh
+        // ManualBoardSource starts empty and needs this to come back.
+        pendingBoardState: get().boardState,
+      });
+    },
 
-  relayStatus: towerSource.status,
-  connectRelay: (url) => towerSource.connect(url),
-  disconnectRelay: () => towerSource.disconnect(),
+    dropSkull: () => towerSource.dropSkull(),
+    breakSeal: (seal) => towerSource.breakSeal(seal),
+    restoreSeal: (seal) => towerSource.restoreSeal(seal),
+    rotateDrum: (drumIndex, position) => towerSource.rotateDrum(drumIndex, position),
 
-  placeFoe: (foeId, foe, location, status) =>
-    get().boardSource?.placeFoe(foeId, foe, location, status),
-  removeFoe: (foeId) => get().boardSource?.removeFoe(foeId),
-  setFoeStatus: (foeId, status) => get().boardSource?.setFoeStatus(foeId, status),
-  placeHero: (heroId, location) => {
-    const owner = get().session.config.heroes.find((h) => h.heroId === heroId)?.homeKingdom;
-    get().boardSource?.placeHero(heroId, location, owner);
-  },
-  removeHero: (heroId) => get().boardSource?.removeHero(heroId),
-  setAdversary: (id, location) => get().boardSource?.setAdversary(id, location),
-  clearAdversary: () => get().boardSource?.clearAdversary(),
-  moveToken: (id, location) => get().boardSource?.moveToken(id, location),
-  addSkull: (location, n) => get().boardSource?.addSkull(location, n),
-  removeSkull: (location, n) => get().boardSource?.removeSkull(location, n),
-  setSpaceMarker: (location, marker, on) => get().boardSource?.setSpaceMarker(location, marker, on),
+    relayStatus: towerSource.status,
+    connectRelay: (url) => towerSource.connect(url),
+    disconnectRelay: () => towerSource.disconnect(),
 
-  captureSession() {
-    const { session, boardSource } = get();
-    if (!boardSource) throw new Error('Board not ready — cannot capture session yet.');
-    return captureSession(session, towerSource, boardSource);
-  },
+    placeFoe: (foeId, foe, location, status) =>
+      get().boardSource?.placeFoe(foeId, foe, location, status),
+    removeFoe: (foeId) => get().boardSource?.removeFoe(foeId),
+    setFoeStatus: (foeId, status) => get().boardSource?.setFoeStatus(foeId, status),
+    placeHero: (heroId, location) => {
+      const owner = get().session.config.heroes.find((h) => h.heroId === heroId)?.homeKingdom;
+      get().boardSource?.placeHero(heroId, location, owner);
+    },
+    removeHero: (heroId) => get().boardSource?.removeHero(heroId),
+    setAdversary: (id, location) => get().boardSource?.setAdversary(id, location),
+    clearAdversary: () => get().boardSource?.clearAdversary(),
+    moveToken: (id, location) => get().boardSource?.moveToken(id, location),
+    addSkull: (location, n) => get().boardSource?.addSkull(location, n),
+    removeSkull: (location, n) => get().boardSource?.removeSkull(location, n),
+    setSpaceMarker: (location, marker, on) =>
+      get().boardSource?.setSpaceMarker(location, marker, on),
 
-  newGame(config, name) {
-    const fresh = createNewGameSession(config, name);
-    const { boardSource } = get();
-    if (boardSource) applyGameSession(fresh, towerSource, boardSource);
-    set({ session: fresh });
-  },
+    captureSession() {
+      const { session, boardSource } = get();
+      if (!boardSource) throw new Error('Board not ready — cannot capture session yet.');
+      return captureSession(session, towerSource, boardSource);
+    },
 
-  resetSession() {
-    const { session, boardSource } = get();
-    const fresh = createNewGameSession(session.config, session.meta.name);
-    // Keep the session's identity; only the play state is wiped.
-    fresh.meta.id = session.meta.id;
-    fresh.meta.createdAt = session.meta.createdAt;
-    if (boardSource) applyGameSession(fresh, towerSource, boardSource);
-    set({ session: fresh });
-  },
+    newGame(config, name) {
+      applySession(createNewGameSession(config, name));
+    },
 
-  advanceTurn() {
-    const { session } = get();
-    set({ session: withProgress(session, nextTurn(session.progress, session.config.playerCount)) });
-  },
-  retreatTurn() {
-    const { session } = get();
-    set({
-      session: withProgress(session, previousTurn(session.progress, session.config.playerCount)),
-    });
-  },
-  goToMonth(month) {
-    const { session } = get();
-    set({ session: withProgress(session, setMonthOnProgress(session.progress, month)) });
-  },
-  dismissReminder(id) {
-    const { session } = get();
-    const dismissed = session.progress.dismissedReminders ?? [];
-    if (dismissed.includes(id)) return;
-    set({
-      session: withProgress(session, {
-        ...session.progress,
-        dismissedReminders: [...dismissed, id],
-      }),
-    });
-  },
+    resetSession() {
+      const { session } = get();
+      const fresh = createNewGameSession(session.config, session.meta.name);
+      // Keep the session's identity; only the play state is wiped.
+      fresh.meta.id = session.meta.id;
+      fresh.meta.createdAt = session.meta.createdAt;
+      applySession(fresh);
+    },
 
-  updatePlayerBoard(heroId, fn) {
-    const { session } = get();
-    const playerBoards = session.playerBoards.map((pb) => (pb.heroId === heroId ? fn(pb) : pb));
-    set({
-      session: {
-        ...session,
-        playerBoards,
-        meta: { ...session.meta, updatedAt: new Date().toISOString() },
-      },
-    });
-  },
+    advanceTurn() {
+      const { session } = get();
+      set({
+        session: withProgress(session, nextTurn(session.progress, session.config.playerCount)),
+      });
+    },
+    retreatTurn() {
+      const { session } = get();
+      set({
+        session: withProgress(session, previousTurn(session.progress, session.config.playerCount)),
+      });
+    },
+    goToMonth(month) {
+      const { session } = get();
+      set({ session: withProgress(session, setMonthOnProgress(session.progress, month)) });
+    },
+    dismissReminder(id) {
+      const { session } = get();
+      const dismissed = session.progress.dismissedReminders ?? [];
+      if (dismissed.includes(id)) return;
+      set({
+        session: withProgress(session, {
+          ...session.progress,
+          dismissedReminders: [...dismissed, id],
+        }),
+      });
+    },
 
-  saveSession() {
-    saveToLocalStorage(get().captureSession());
-  },
+    updatePlayerBoard(heroId, fn) {
+      const { session } = get();
+      const playerBoards = session.playerBoards.map((pb) => (pb.heroId === heroId ? fn(pb) : pb));
+      set({
+        session: {
+          ...session,
+          playerBoards,
+          meta: { ...session.meta, updatedAt: new Date().toISOString() },
+        },
+      });
+    },
 
-  loadSession() {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (raw == null) return false;
-    let loaded: GameSession;
-    try {
-      loaded = deserializeSession(raw);
-    } catch (err) {
-      // Refuse, don't migrate: an older save (most often GAME_SESSION_SCHEMA_VERSION) can't be
-      // read by this build. Surface the raw bytes via staleSession so the dialog can offer a
-      // download before the user's only remaining option is to discard it.
-      if (err instanceof GameSessionLoadError) {
-        set({ staleSession: { raw, error: err } });
-        return false;
+    saveSession() {
+      saveToLocalStorage(get().captureSession());
+    },
+
+    loadSession() {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (raw == null) return false;
+      let loaded: GameSession;
+      try {
+        loaded = deserializeSession(raw);
+      } catch (err) {
+        // Refuse, don't migrate: an older save (most often GAME_SESSION_SCHEMA_VERSION) can't be
+        // read by this build. Surface the raw bytes via staleSession so the dialog can offer a
+        // download before the user's only remaining option is to discard it.
+        if (err instanceof GameSessionLoadError) {
+          set({ staleSession: { raw, error: err } });
+          return false;
+        }
+        throw err;
       }
-      throw err;
-    }
-    const { boardSource } = get();
-    if (boardSource) applyGameSession(loaded, towerSource, boardSource);
-    set({ session: loaded });
-    return true;
-  },
+      applySession(loaded);
+      return true;
+    },
 
-  exportSession() {
-    downloadSession(get().captureSession());
-  },
+    exportSession() {
+      downloadSession(get().captureSession());
+    },
 
-  copySession() {
-    return copySessionToClipboard(get().captureSession());
-  },
+    copySession() {
+      return copySessionToClipboard(get().captureSession());
+    },
 
-  importSessionText(text) {
-    const loaded = parseSessionText(text);
-    const { boardSource } = get();
-    if (boardSource) applyGameSession(loaded, towerSource, boardSource);
-    set({ session: loaded });
-  },
-}));
+    importSessionText(text) {
+      applySession(parseSessionText(text));
+    },
+  };
+});
 
 // Project tower changes into primitive snapshots after the store exists.
 towerSource.subscribe((state) => {
@@ -328,3 +361,40 @@ towerSource.subscribe((state) => {
 });
 
 towerSource.onStatus((relayStatus) => useGameStore.setState({ relayStatus }));
+
+/**
+ * Debounce-persist the game to localStorage on every change, so a refresh resumes where
+ * the player left off (PRD-04 FR-04.7). Not started automatically on import — `main.tsx`
+ * calls this once at boot — so importing the store in a test never spins up a background
+ * timer that writes to localStorage.
+ */
+export function startAutosave(delayMs = 750): Unsubscribe {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const save = () => {
+    const s = useGameStore.getState();
+    // No board yet → captureSession throws. A stale save on disk must never be
+    // clobbered — the dialog needs those exact bytes to offer a download.
+    if (!s.boardSource || s.staleSession) return;
+    try {
+      saveToLocalStorage(s.captureSession());
+    } catch (err) {
+      // Quota exceeded / private browsing — manual Save still surfaces a failure to the user.
+      console.warn('Autosave failed:', err);
+    }
+  };
+  const flush = () => {
+    clearTimeout(timer);
+    save();
+  };
+  const unsub = useGameStore.subscribe(() => {
+    clearTimeout(timer);
+    timer = setTimeout(save, delayMs);
+  });
+  // A refresh inside the debounce window would otherwise lose the most recent action.
+  window.addEventListener('pagehide', flush);
+  return () => {
+    unsub();
+    window.removeEventListener('pagehide', flush);
+    clearTimeout(timer);
+  };
+}


### PR DESCRIPTION
## Summary
- Autosave the `GameSession` to localStorage (debounced ~750ms, flushed on `pagehide`) and reload it on boot, so refreshing mid-game resumes the tower, board, player boards, and turn/month exactly where you left off.
- Fixes a latent bug where `newGame`/`resetSession`/`loadSession`/`importSessionText` skipped hydrating the tower whenever the board hadn't mounted yet — `applyGameSession` was incorrectly gated on the board being ready, even though the tower source is always available.
- Adds `StaleSessionDialog`, referenced in a doc comment in `gameStore.ts` but never implemented — a blocking dialog for the refuse-don't-migrate path (an old, incompatible save), offering a download before starting fresh.
- Changeset added (`ultimatedarktowerdigital`: minor) even though the app is private — matches existing precedent in its `CHANGELOG.md`.

## Test plan
- [x] `pnpm --filter ultimatedarktowerdigital test` — 93 tests passing, including new coverage for tower-without-board restore, board remount rehydration, and autosave debounce/guard behavior.
- [x] `pnpm run ci` from repo root — lint, format, build, typecheck, and all workspace test suites green.
- [ ] Manual browser check: start a game, rotate a drum, break a seal, place a foe/hero, advance a turn, refresh the tab, confirm everything is restored. (Not yet done in a live browser — worth doing before merge.)
- [ ] Manual stale-save check: edit `localStorage['utdd.gameSession.v1']`'s `schemaVersion` to an old value, refresh, confirm the dialog appears and both buttons work.