### PR TITLE
feat(digital): make foe threat status per-level, not per-instance

### DIFF
--- a/apps/digital/docs/prd/prd-02-game-board.md
+++ b/apps/digital/docs/prd/prd-02-game-board.md
@@ -33,8 +33,9 @@ this manually).
 - _As a player_, I can move a hero from one location to an adjacent one, so I can take my movement.
 - _As a player_, I can add skulls to a building and see it become destroyed at the 4th skull, so the
   board reflects skull emergence.
-- _As a player_, I can place the adversary when it spawns and advance a foe's status, so the board
-  tracks escalation.
+- _As a player_, I can place the adversary when it spawns and advance a foe level's threat status,
+  so the board tracks escalation the way the official game does — as a whole level, not one foe
+  at a time.
 - _As a player_, I can switch between 2D map and 3D disc, so I can use whichever view I prefer.
 
 ## 4. Functional Requirements
@@ -55,10 +56,14 @@ this manually).
    movement is **not enforced** (the app/player owns rules).
 6. **FR-02.6** The player MUST be able to add/remove **skulls on a building**; reaching 4 skulls MUST
    mark the building destroyed (per `BoardState` building semantics).
-7. **FR-02.7** The player MUST be able to set a foe's **status** to any of the game's five values:
-   `panicked | unsteady | ready | savage | lethal` (lowest → highest threat). The `ultimatedarktower`
-   lib's `FOE_STATUSES`/`FoeStatus` was extended from 3 to these 5 to match the official game's
-   foe-status track (resolved — see [assumptions-and-open-questions.md](assumptions-and-open-questions.md#known-discrepancies--risks)).
+7. **FR-02.7** The player MUST be able to set a foe **level's status** (2–4) to any of the game's five
+   values: `panicked | unsteady | ready | savage | lethal` (lowest → highest threat). Status is a
+   property of the **level**, not a single placed foe — matching the official rule that every foe of
+   a level (e.g. all placed Brigands at level 2) advances together — so setting it cascades to every
+   currently-placed foe of that level and is remembered (`BoardState.meta.levelStatus`) for the next
+   one placed, independent of what's currently on the board. The `ultimatedarktower` lib's
+   `FOE_STATUSES`/`FoeStatus` was extended from 3 to these 5 to match the official game's foe-status
+   track (resolved — see [assumptions-and-open-questions.md](assumptions-and-open-questions.md#known-discrepancies--risks)).
 8. **FR-02.8** The player MUST be able to place/remove **space markers** at locations (e.g. wasteland,
    power-skull). Space markers and **quest markers** are both placed via the unified `tokens`
    collection, using the `marker`/`quest` accepts vocabulary (there is no dedicated quest-marker field).
@@ -116,12 +121,16 @@ Implemented and verified (unit tests + in-browser): the board renders all 60 loc
 buildings via `BoardStageView` in 2D + the shared 3D scene (FR-02.1), with its built-in mode pills
 (`2d | 3d | 2d3d | pip`) and N/E/S/W focus covering FR-02.10. All board content is owned by the
 `BoardStateSource`; the stage's selection + armed-placement stores are kept separate from
-`BoardState` (FR-02.2). The **placement palette** places foes (L2–4, with status), heroes,
-the adversary (L5), skulls on buildings, and space/quest markers — each via a grouped location
-dropdown **or** by arming "pick on board" and clicking a space in 2D/3D (FR-02.3–02.8). Adding a
-building's 4th skull marks it destroyed (FR-02.6). The **inspector** reflects the clicked token and
-offers its actions — foe status/move/remove, hero move/remove, adversary move/clear, building
-skull ±, marker removal (FR-02.9). Token art degrades to the stage's programmatic fallback
+`BoardState` (FR-02.2). The **placement palette** places foes (L2–4, inheriting that level's current
+status), heroes, the adversary (L5), skulls on buildings, and space/quest markers — each via a
+grouped location dropdown **or** by arming "pick on board" and clicking a space in 2D/3D
+(FR-02.3–02.8). The palette also has a **threat status** control per foe level (2–4), labeled with
+that game's actual foe name (e.g. "Brigands") once setup has assigned one — changing it cascades to
+every placed foe of that level (FR-02.7). Adding a building's 4th skull marks it destroyed (FR-02.6).
+The **inspector** reflects the clicked token and offers its actions — foe level-status/move/remove
+(status here is the same level-wide control as the palette's), hero move/remove, adversary
+move/clear, building skull ±, marker removal (FR-02.9). Token art degrades to the stage's
+programmatic fallback
 (FR-02.11). Code: `src/sources/ManualBoardSource.ts` (+ the expanded `BoardStateSource`), the
 `gameStore` board actions + selection/locationPick wiring, `useBoardSelection`/`useBoardActions`
 hooks, and `src/features/board/{BoardPalette,BoardInspector,LocationSelect,boardData}.tsx`.

--- a/apps/digital/src/features/board/BoardInspector.tsx
+++ b/apps/digital/src/features/board/BoardInspector.tsx
@@ -8,9 +8,16 @@ import { useState } from 'react';
 import { FOE_STATUSES } from '@/lib/udtData';
 import type { BoardState, FoeStatus, TokenSelection } from 'ultimatedarktowerboard';
 import { adversaryOf, buildingAt, markersAt, skullsAt } from 'ultimatedarktowerboard';
-import { useBoardActions, useBoardSelection, useBoardState } from '@/lib/hooks';
+import { useBoardActions, useBoardSelection, useBoardState, useSession } from '@/lib/hooks';
 import { SKULLS_TO_DESTROY } from '@/sources/ManualBoardSource';
-import { adversaryName, foeName, heroName } from './boardData';
+import {
+  adversaryName,
+  foeLevelOf,
+  foeName,
+  heroName,
+  levelLabel,
+  statusForLevel,
+} from './boardData';
 import { LocationSelect } from './LocationSelect';
 
 type BoardActions = ReturnType<typeof useBoardActions>;
@@ -80,11 +87,13 @@ function TokenDetail({
   actions: BoardActions;
 }) {
   const { kind, id, location } = selection;
+  const session = useSession();
 
   if (kind === 'foe') {
     const foe = boardState.tokens[id];
     if (!foe || foe.typeId !== 'foe') return <Gone />;
-    const status = (foe.data?.status as FoeStatus | undefined) ?? 'ready';
+    const level = foeLevelOf(foe.art ?? '');
+    const status = level ? statusForLevel(boardState, level) : 'ready';
     return (
       <>
         <h3 className="board-detail-title">
@@ -96,7 +105,14 @@ function TokenDetail({
             <span>{foe.location}</span>
           </li>
         </ul>
-        <StatusRow status={status} onChange={(s) => actions.setFoeStatus(id, s)} />
+        {level && (
+          <>
+            <StatusRow status={status} onChange={(s) => actions.setLevelStatus(level, s)} />
+            <p className="muted">
+              Applies to every {levelLabel(session.config.foes, level)}, placed or not yet placed.
+            </p>
+          </>
+        )}
         <MoveRow from={foe.location} onMove={(to) => actions.moveToken(id, to)} />
         <button className="board-remove" onClick={() => actions.removeFoe(id)}>
           Remove foe

--- a/apps/digital/src/features/board/BoardPalette.tsx
+++ b/apps/digital/src/features/board/BoardPalette.tsx
@@ -16,8 +16,11 @@ import {
   LOCATIONS,
   MARKER_PRESETS,
   adversaryName,
+  foeLevelOf,
   foeName,
   heroName,
+  levelLabel,
+  statusForLevel,
 } from './boardData';
 import { LocationSelect } from './LocationSelect';
 
@@ -39,13 +42,13 @@ export function BoardPalette() {
   const boardState = useBoardState();
   const session = useSession();
   const locationPick = useBoardLocationPick();
-  const { placeFoe, placeHero, setAdversary, addSkull, setSpaceMarker } = useBoardActions();
+  const { placeFoe, placeHero, setAdversary, addSkull, setSpaceMarker, setLevelStatus } =
+    useBoardActions();
 
   const heroes = session.config.heroes;
 
   const [kind, setKind] = useState<PlaceKind>('foe');
   const [foeType, setFoeType] = useState(FOE_LEVELS[0]?.foes[0]?.id ?? '');
-  const [foeStatus, setFoeStatus] = useState<FoeStatus>('ready');
   const [heroId, setHeroId] = useState(heroes[0]?.heroId ?? '');
   const [advId, setAdvId] = useState(session.config.adversary ?? ADVERSARY_ROSTER[0]?.id ?? '');
   const [marker, setMarker] = useState<string>(MARKER_PRESETS[0]);
@@ -69,9 +72,13 @@ export function BoardPalette() {
   const placeAt = (loc: string) => {
     if (!loc) return;
     switch (kind) {
-      case 'foe':
-        if (foeType) placeFoe(`${foeType}-${++foeSeq}`, foeType, loc, foeStatus);
+      case 'foe': {
+        if (!foeType) break;
+        const level = foeLevelOf(foeType);
+        const status = level && boardState ? statusForLevel(boardState, level) : undefined;
+        placeFoe(`${foeType}-${++foeSeq}`, foeType, loc, status);
         break;
+      }
       case 'hero':
         if (effectiveHeroId) placeHero(effectiveHeroId, loc);
         break;
@@ -155,32 +162,20 @@ export function BoardPalette() {
       </label>
 
       {kind === 'foe' && (
-        <>
-          <label>
-            Foe
-            <select value={foeType} onChange={(e) => setFoeType(e.target.value)}>
-              {FOE_LEVELS.map((group) => (
-                <optgroup key={group.level} label={`Level ${group.level}`}>
-                  {group.foes.map((f) => (
-                    <option key={f.id} value={f.id}>
-                      {f.name}
-                    </option>
-                  ))}
-                </optgroup>
-              ))}
-            </select>
-          </label>
-          <label>
-            Status
-            <select value={foeStatus} onChange={(e) => setFoeStatus(e.target.value as FoeStatus)}>
-              {FOE_STATUSES.map((s) => (
-                <option key={s} value={s}>
-                  {s}
-                </option>
-              ))}
-            </select>
-          </label>
-        </>
+        <label>
+          Foe
+          <select value={foeType} onChange={(e) => setFoeType(e.target.value)}>
+            {FOE_LEVELS.map((group) => (
+              <optgroup key={group.level} label={`Level ${group.level}`}>
+                {group.foes.map((f) => (
+                  <option key={f.id} value={f.id}>
+                    {f.name}
+                  </option>
+                ))}
+              </optgroup>
+            ))}
+          </select>
+        </label>
       )}
 
       {kind === 'hero' &&
@@ -248,6 +243,28 @@ export function BoardPalette() {
           </button>
         )}
       </div>
+
+      {boardState && (
+        <>
+          <h3>Threat status</h3>
+          <p className="muted">Applies to every foe of that level, placed or not yet placed.</p>
+          {FOE_LEVELS.map((group) => (
+            <label key={group.level}>
+              {levelLabel(session.config.foes, group.level)}
+              <select
+                value={statusForLevel(boardState, group.level)}
+                onChange={(e) => setLevelStatus(group.level, e.target.value as FoeStatus)}
+              >
+                {FOE_STATUSES.map((s) => (
+                  <option key={s} value={s}>
+                    {s}
+                  </option>
+                ))}
+              </select>
+            </label>
+          ))}
+        </>
+      )}
 
       {boardState && (
         <p className="muted board-counts">

--- a/apps/digital/src/features/board/boardData.test.ts
+++ b/apps/digital/src/features/board/boardData.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import type { BoardState } from 'ultimatedarktowerboard';
+import { foeLevelOf, statusForLevel } from './boardData';
+
+describe('statusForLevel', () => {
+  it('defaults to ready when nothing has been set for that level', () => {
+    const state: BoardState = { tokens: {} };
+    expect(statusForLevel(state, 2)).toBe('ready');
+  });
+
+  it('reads a stored level status regardless of what is placed', () => {
+    const state: BoardState = { tokens: {}, meta: { levelStatus: { 2: 'savage' } } };
+    expect(statusForLevel(state, 2)).toBe('savage');
+  });
+
+  it('ignores other levels stored in meta', () => {
+    const state: BoardState = { tokens: {}, meta: { levelStatus: { 3: 'lethal' } } };
+    expect(statusForLevel(state, 2)).toBe('ready');
+  });
+});
+
+describe('foeLevelOf', () => {
+  it('resolves a known foe id to its level', () => {
+    expect(foeLevelOf('brigands')).toBe(2);
+    expect(foeLevelOf('frost-trolls')).toBe(3);
+  });
+
+  it('returns undefined for an unknown id', () => {
+    expect(foeLevelOf('not-a-real-foe')).toBeUndefined();
+  });
+});

--- a/apps/digital/src/features/board/boardData.ts
+++ b/apps/digital/src/features/board/boardData.ts
@@ -3,7 +3,15 @@
  * (PRD-02). Rosters and the 60 locations come from `ultimatedarktower`; nothing here mutates
  * state — these are display helpers only.
  */
-import { ADVERSARY_ROSTER, BOARD_LOCATIONS, FOES, FOE_BY_ID, HERO_BY_ID } from '@/lib/udtData';
+import type { BoardState, FoeStatus } from 'ultimatedarktowerboard';
+import {
+  ADVERSARY_ROSTER,
+  BOARD_LOCATIONS,
+  FOES,
+  FOE_BY_ID,
+  HERO_BY_ID,
+  type FoeLevel,
+} from '@/lib/udtData';
 
 export const KINGDOMS = ['north', 'east', 'south', 'west'] as const;
 
@@ -30,3 +38,30 @@ export const foeName = (id: string): string => FOE_BY_ID[id]?.name ?? id;
 export const adversaryName = (id: string): string =>
   ADVERSARY_ROSTER.find((a) => a.id === id)?.name ?? id;
 export const heroName = (id: string): string => HERO_BY_ID[id]?.name ?? id;
+
+/** A foe's identity level (2–4), or `undefined` for an unknown/legacy art id. */
+export const foeLevelOf = (id: string): FoeLevel | undefined => FOE_BY_ID[id]?.level;
+
+/**
+ * The stored threat status for `level` (defaults to `'ready'` until explicitly set). Real
+ * Return to Dark Tower rule: status applies to a whole level, not a single placed foe — see
+ * `setLevelStatus` in the game store, which is the only thing that writes this.
+ */
+export function statusForLevel(state: BoardState, level: FoeLevel): FoeStatus {
+  const levelStatus = state.meta?.levelStatus as Partial<Record<FoeLevel, FoeStatus>> | undefined;
+  return levelStatus?.[level] ?? 'ready';
+}
+
+/** This game's foe (levels 2–4 only — level 5 is the adversary, picked separately). */
+export type LevelFoes = { level2: string | null; level3: string | null; level4: string | null };
+
+/**
+ * The name of whichever foe this game's setup assigned to `level` (e.g. "Brigands"), or a
+ * generic "Level N" fallback before setup picks one. Only one foe occupies a level for a given
+ * game, so this is more useful than the bare level number once setup is complete.
+ */
+export function levelLabel(foes: LevelFoes, level: FoeLevel): string {
+  const id =
+    level === 2 ? foes.level2 : level === 3 ? foes.level3 : level === 4 ? foes.level4 : null;
+  return id ? foeName(id) : `Level ${level}`;
+}

--- a/apps/digital/src/lib/hooks.ts
+++ b/apps/digital/src/lib/hooks.ts
@@ -67,6 +67,7 @@ export function useBoardActions() {
       placeFoe: s.placeFoe,
       removeFoe: s.removeFoe,
       setFoeStatus: s.setFoeStatus,
+      setLevelStatus: s.setLevelStatus,
       placeHero: s.placeHero,
       removeHero: s.removeHero,
       setAdversary: s.setAdversary,

--- a/apps/digital/src/lib/udtData.ts
+++ b/apps/digital/src/lib/udtData.ts
@@ -22,6 +22,7 @@ export {
   FOE_BY_NAME,
   ADVERSARY_ROSTER,
   FOE_STATUSES,
+  type FoeLevel,
 
   // Box inventory (card names) — keyed by expansion name.
   EXPANSIONS,

--- a/apps/digital/src/state/gameStore.test.ts
+++ b/apps/digital/src/state/gameStore.test.ts
@@ -143,6 +143,7 @@ describe('useGameStore', () => {
     it('no-ops without throwing when no board is registered', () => {
       expect(() => useGameStore.getState().placeFoe('f1', 'Brigands', 'Delmsmire')).not.toThrow();
       expect(() => useGameStore.getState().moveToken('f1', 'Narrow Vale')).not.toThrow();
+      expect(() => useGameStore.getState().setLevelStatus(2, 'savage')).not.toThrow();
     });
 
     it('delegates board actions to the registered BoardStateSource', () => {
@@ -172,6 +173,58 @@ describe('useGameStore', () => {
         'removeSkull',
         'setSpaceMarker',
       ]);
+    });
+
+    it('setLevelStatus cascades only to same-level placed foes and records the level status', () => {
+      const board = new FakeBoardSource();
+      board.state = {
+        tokens: {
+          'brigands-1': {
+            id: 'brigands-1',
+            typeId: 'foe',
+            art: 'brigands',
+            location: 'Delmsmire',
+            data: { status: 'ready' },
+          },
+          'oreks-1': {
+            id: 'oreks-1',
+            typeId: 'foe',
+            art: 'oreks',
+            location: 'Narrow Vale',
+            data: { status: 'ready' },
+          },
+          'frost-trolls-1': {
+            id: 'frost-trolls-1',
+            typeId: 'foe',
+            art: 'frost-trolls',
+            location: 'Ollow',
+            data: { status: 'ready' },
+          },
+        },
+      };
+      useGameStore.getState().registerBoard(board, {} as never, {} as never);
+
+      useGameStore.getState().setLevelStatus(2, 'savage');
+
+      const loadCall = board.calls.find((c) => c.method === 'load');
+      expect(loadCall).toBeDefined();
+      const next = loadCall!.args[0] as BoardState;
+      expect(next.tokens['brigands-1'].data?.status).toBe('savage');
+      expect(next.tokens['oreks-1'].data?.status).toBe('savage');
+      expect(next.tokens['frost-trolls-1'].data?.status).toBe('ready');
+      expect((next.meta?.levelStatus as Record<number, string>)[2]).toBe('savage');
+    });
+
+    it('setLevelStatus records the level status even with nothing of that level placed', () => {
+      const board = new FakeBoardSource();
+      useGameStore.getState().registerBoard(board, {} as never, {} as never);
+
+      useGameStore.getState().setLevelStatus(3, 'lethal');
+
+      const loadCall = board.calls.find((c) => c.method === 'load');
+      expect(loadCall).toBeDefined();
+      const next = loadCall!.args[0] as BoardState;
+      expect((next.meta?.levelStatus as Record<number, string>)[3]).toBe('lethal');
     });
 
     it('placeHero looks up the owning kingdom from session config before delegating', () => {

--- a/apps/digital/src/state/gameStore.ts
+++ b/apps/digital/src/state/gameStore.ts
@@ -7,10 +7,12 @@
 import { create } from 'zustand';
 import type {
   BoardState,
+  FoeLevel,
   FoeStatus,
   LocationPickStore,
   SelectionStore,
 } from 'ultimatedarktowerboard';
+import { FOE_BY_ID } from 'ultimatedarktowerboard';
 import { ManualTowerSource } from '@/sources/ManualTowerSource';
 import { BridgeTowerSource, type RelayStatus } from '@/sources/BridgeTowerSource';
 import type { BoardStateSource, SealRef, TowerStateSource, Unsubscribe } from '@/sources/types';
@@ -130,6 +132,13 @@ interface GameStore {
   placeFoe(foeId: string, foe: string, location: string, status?: FoeStatus): void;
   removeFoe(foeId: string): void;
   setFoeStatus(foeId: string, status: FoeStatus): void;
+  /**
+   * Cascade a status to every currently-placed foe of `level` and remember it for the next
+   * placement (real-rules: threat status applies to a whole level, not a single foe). Stored in
+   * `BoardState.meta.levelStatus` so it's settable independent of what's currently placed, and
+   * round-trips with the session for free.
+   */
+  setLevelStatus(level: FoeLevel, status: FoeStatus): void;
   /** Place a hero; the owning kingdom is looked up from the session config for token color. */
   placeHero(heroId: string, location: string): void;
   removeHero(heroId: string): void;
@@ -241,6 +250,22 @@ export const useGameStore = create<GameStore>((set, get) => {
       get().boardSource?.placeFoe(foeId, foe, location, status),
     removeFoe: (foeId) => get().boardSource?.removeFoe(foeId),
     setFoeStatus: (foeId, status) => get().boardSource?.setFoeStatus(foeId, status),
+    setLevelStatus: (level, status) => {
+      const board = get().boardState;
+      const source = get().boardSource;
+      if (!board || !source) return;
+      const tokens = { ...board.tokens };
+      for (const [id, token] of Object.entries(tokens)) {
+        if (token.typeId === 'foe' && FOE_BY_ID[token.art ?? '']?.level === level) {
+          tokens[id] = { ...token, data: { ...token.data, status } };
+        }
+      }
+      const levelStatus = {
+        ...(board.meta?.levelStatus as Partial<Record<FoeLevel, FoeStatus>> | undefined),
+        [level]: status,
+      };
+      source.load({ ...board, tokens, meta: { ...board.meta, levelStatus } });
+    },
     placeHero: (heroId, location) => {
       const owner = get().session.config.heroes.find((h) => h.heroId === heroId)?.homeKingdom;
       get().boardSource?.placeHero(heroId, location, owner);


### PR DESCRIPTION
## Summary
- Threat status (`panicked`→`unsteady`→`ready`→`savage`→`lethal`) now lives per foe **level** (2-4), not per placed foe instance — matching the real rule that every foe of a level advances together (e.g. all placed Brigands at level 2).
- New per-level status control in the placement palette (removed from foe placement itself) and repurposed in the token inspector; both cascade a change to every currently-placed foe of that level.
- Status is stored in `BoardState.meta.levelStatus`, so it's settable independent of what's currently placed (e.g. to reflect the official companion app announcing a status change before you've placed a matching foe) and round-trips through session save/load for free — no session schema changes.
- Level rows are labeled with the game's actual configured foe name (e.g. "Brigands") once setup has assigned one, instead of a bare "Level 2".
- No changes to `packages/board` (published package) — the cascade is built entirely from its existing `load()`/`setFoeStatus` primitives, per its "no game rules, hosts own the rules" invariant.
- Updated PRD-02 doc (FR-02.7, implementation status) to match.

## Test plan
- [x] `pnpm run ci` (validate:nodes → lint → format:check → build → typecheck → test) passes clean across the monorepo
- [x] New/updated unit tests: `boardData.test.ts` (statusForLevel/foeLevelOf), `gameStore.test.ts` (setLevelStatus cascade, including with zero foes of that level placed)
- [ ] Manual: place two level-2 foes, set Level 2 (labeled with the configured foe name) to `savage` from the palette, confirm both update; confirm a level-3 foe is unaffected; confirm the inspector shows/edits the same level-wide status; refresh the page and confirm it survives