### PR TITLE
feat(relay-cli): add Ink live status board to the relay daemon

### DIFF
--- a/.changeset/relay-cli-ink-dashboard.md
+++ b/.changeset/relay-cli-ink-dashboard.md
@@ -1,0 +1,17 @@
+---
+'ultimatedarktowerrelay-cli': minor
+---
+
+Add a live status board (built on [Ink](https://github.com/vadimdemedes/ink)) to the relay CLI,
+replacing the six print-and-go-silent startup lines with a live view of the relay URL (including
+your LAN address, so a phone can connect), tower/BLE state, decoded drum/LED/audio state,
+connected clients, and an activity feed. Keys: `q` quit, `r` resend the last command, `l` toggle
+JSONL logging.
+
+- **This package is now ESM** (`"type": "module"`) — Ink is ESM-only. Nothing in this monorepo
+  imports `ultimatedarktowerrelay-cli`, so this is not a breaking change for any workspace
+  consumer, but it is worth knowing if you depend on it externally as a library rather than via
+  its `bin` entries.
+- The board only mounts when both stdout and stdin are a real terminal; set `RELAY_DASHBOARD=0`
+  to force the previous plain-line output. Piped, Docker, and systemd usage is unaffected — it
+  already falls outside that check and gets the same output as before.

--- a/apps/digital/docs/prd/prd-02-game-board.md
+++ b/apps/digital/docs/prd/prd-02-game-board.md
@@ -33,8 +33,9 @@ this manually).
 - _As a player_, I can move a hero from one location to an adjacent one, so I can take my movement.
 - _As a player_, I can add skulls to a building and see it become destroyed at the 4th skull, so the
   board reflects skull emergence.
-- _As a player_, I can place the adversary when it spawns and advance a foe's status, so the board
-  tracks escalation.
+- _As a player_, I can place the adversary when it spawns and advance a foe level's threat status,
+  so the board tracks escalation the way the official game does — as a whole level, not one foe
+  at a time.
 - _As a player_, I can switch between 2D map and 3D disc, so I can use whichever view I prefer.
 
 ## 4. Functional Requirements
@@ -55,10 +56,14 @@ this manually).
    movement is **not enforced** (the app/player owns rules).
 6. **FR-02.6** The player MUST be able to add/remove **skulls on a building**; reaching 4 skulls MUST
    mark the building destroyed (per `BoardState` building semantics).
-7. **FR-02.7** The player MUST be able to set a foe's **status** to any of the game's five values:
-   `panicked | unsteady | ready | savage | lethal` (lowest → highest threat). The `ultimatedarktower`
-   lib's `FOE_STATUSES`/`FoeStatus` was extended from 3 to these 5 to match the official game's
-   foe-status track (resolved — see [assumptions-and-open-questions.md](assumptions-and-open-questions.md#known-discrepancies--risks)).
+7. **FR-02.7** The player MUST be able to set a foe **level's status** (2–4) to any of the game's five
+   values: `panicked | unsteady | ready | savage | lethal` (lowest → highest threat). Status is a
+   property of the **level**, not a single placed foe — matching the official rule that every foe of
+   a level (e.g. all placed Brigands at level 2) advances together — so setting it cascades to every
+   currently-placed foe of that level and is remembered (`BoardState.meta.levelStatus`) for the next
+   one placed, independent of what's currently on the board. The `ultimatedarktower` lib's
+   `FOE_STATUSES`/`FoeStatus` was extended from 3 to these 5 to match the official game's foe-status
+   track (resolved — see [assumptions-and-open-questions.md](assumptions-and-open-questions.md#known-discrepancies--risks)).
 8. **FR-02.8** The player MUST be able to place/remove **space markers** at locations (e.g. wasteland,
    power-skull). Space markers and **quest markers** are both placed via the unified `tokens`
    collection, using the `marker`/`quest` accepts vocabulary (there is no dedicated quest-marker field).
@@ -116,12 +121,16 @@ Implemented and verified (unit tests + in-browser): the board renders all 60 loc
 buildings via `BoardStageView` in 2D + the shared 3D scene (FR-02.1), with its built-in mode pills
 (`2d | 3d | 2d3d | pip`) and N/E/S/W focus covering FR-02.10. All board content is owned by the
 `BoardStateSource`; the stage's selection + armed-placement stores are kept separate from
-`BoardState` (FR-02.2). The **placement palette** places foes (L2–4, with status), heroes,
-the adversary (L5), skulls on buildings, and space/quest markers — each via a grouped location
-dropdown **or** by arming "pick on board" and clicking a space in 2D/3D (FR-02.3–02.8). Adding a
-building's 4th skull marks it destroyed (FR-02.6). The **inspector** reflects the clicked token and
-offers its actions — foe status/move/remove, hero move/remove, adversary move/clear, building
-skull ±, marker removal (FR-02.9). Token art degrades to the stage's programmatic fallback
+`BoardState` (FR-02.2). The **placement palette** places foes (L2–4, inheriting that level's current
+status), heroes, the adversary (L5), skulls on buildings, and space/quest markers — each via a
+grouped location dropdown **or** by arming "pick on board" and clicking a space in 2D/3D
+(FR-02.3–02.8). The palette also has a **threat status** control per foe level (2–4), labeled with
+that game's actual foe name (e.g. "Brigands") once setup has assigned one — changing it cascades to
+every placed foe of that level (FR-02.7). Adding a building's 4th skull marks it destroyed (FR-02.6).
+The **inspector** reflects the clicked token and offers its actions — foe level-status/move/remove
+(status here is the same level-wide control as the palette's), hero move/remove, adversary
+move/clear, building skull ±, marker removal (FR-02.9). Token art degrades to the stage's
+programmatic fallback
 (FR-02.11). Code: `src/sources/ManualBoardSource.ts` (+ the expanded `BoardStateSource`), the
 `gameStore` board actions + selection/locationPick wiring, `useBoardSelection`/`useBoardActions`
 hooks, and `src/features/board/{BoardPalette,BoardInspector,LocationSelect,boardData}.tsx`.

--- a/apps/digital/public/connecting-the-official-app.html
+++ b/apps/digital/public/connecting-the-official-app.html
@@ -1263,32 +1263,50 @@
 
           <h4>What you should see</h4>
 
-          <pre class="out">
-UltimateDarkTowerRelay v0.2.0 (source: emulator)
-Relay server listening on ws://0.0.0.0:8765
-[TowerEmulator] waiting for poweredOn…
-[TowerEmulator] poweredOn — starting advertising…
-[TowerEmulator] advertising started — setting services…
-<b>[TowerEmulator] services set — tower ready</b>
-Advertising tower emulator — open the companion app to connect.
+          <p>
+            The relay opens on a live status board instead of a wall of scrolling text. It looks
+            roughly like this:
+          </p>
 
-Now open  <b>https://chessmess.github.io/UltimateDarkTower/digital/</b>  and click Connect.
-Relay address for the "Official app" panel: ws://localhost:8765</pre>
+          <pre class="out">
+ Ultimate Dark Tower Relay — v0.2.0 · emulator · up 00:03
+
+ RELAY
+  ws://localhost:8765
+  ws://192.168.1.42:8765 (LAN)
+  Open  <b>https://chessmess.github.io/UltimateDarkTower/digital/</b>
+
+ TOWER
+  <b>● advertising</b>    app: disconnected    BLE: poweredOn
+
+ STATE
+  top north  mid north  bot north   cal · · ·
+  led seq 0 · audio #0 vol 0 · beam 0
+
+ CLIENTS (0)
+  none connected
+
+ COUNTERS  commands 0   skulls 0   last never
+
+ q quit   r resend   l logging (on)</pre>
 
           <p>
-            The line that matters is <strong><code>services set — tower ready</code></strong
-            >. Your computer is now broadcasting itself as a Dark Tower named
-            <code>ReturnToDarkTower</code>. The last two lines are your next step — Sections 4 and 5
-            below just walk through them slowly.
+            The line that matters is <strong>TOWER: <code>● advertising</code></strong>. Your
+            computer is now broadcasting itself as a Dark Tower named <code>ReturnToDarkTower</code>.
+            The <strong>RELAY</strong> panel is your next step — Sections 4 and 5 below just walk
+            through it slowly. That panel also prints a <code>ws://192.168.x.x:8765</code> address
+            when it can detect your LAN IP — that's the one to use if you're connecting from a
+            phone instead of the same machine.
           </p>
 
           <p>
-            On a Mac you will also see this, which is expected — it's the problem from Section 2:
+            On a Mac you will also see a line like this in the <strong>activity</strong> feed near
+            the bottom of the board, which is expected — it's the problem from Section 2:
           </p>
 
           <pre
             class="out"
-          ><i>[TowerEmulator] macOS detected — skipping Device Information Service (0x180A).</i></pre>
+          ><i>12:03:50 event [TowerEmulator] macOS detected — skipping Device Information Service (0x180A).</i></pre>
 
           <div class="callout danger">
             <span class="tag">Leave it running</span>
@@ -1368,11 +1386,15 @@ Relay address for the "Official app" panel: ws://localhost:8765</pre>
 
           <h4>How you know it worked</h4>
 
-          <p>The relay terminal starts printing lines like these:</p>
+          <p>
+            The <strong>TOWER</strong> panel switches to <code>● connected</code>, and lines like
+            these start appearing in the <strong>activity</strong> feed near the bottom of the
+            board:
+          </p>
 
           <pre class="out">
-<b>[TowerEmulator] companion subscribed to state notifications</b>
-[TowerEmulator] command received: 000000000000…</pre>
+<b>12:04:09 event [TowerEmulator] companion subscribed to state notifications</b>
+12:04:11 event [TowerEmulator] command received: 000000000000…</pre>
 
           <p>
             Every <code>command received:</code> line is the app telling the tower to do something.
@@ -1475,8 +1497,9 @@ Access other apps and services on this device
               <strong>"Connected — the official app is driving the tower."</strong>
             </p>
             <p>
-              That green line is your confirmation. The relay terminal stays quiet when a browser
-              connects — it only prints Bluetooth activity — so don't read its silence as a failure.
+              That green line is your confirmation. You can also check the relay's
+              <strong>CLIENTS</strong> panel — your browser should now show up there as one
+              connected client.
             </p>
           </div>
 
@@ -1575,8 +1598,8 @@ Access other apps and services on this device
           <h2><span class="num">Section Seven</span>Finishing up, and next time</h2>
 
           <p>
-            To stop: press <kbd>Ctrl</kbd> + <kbd>C</kbd> in the relay's terminal, and close the
-            browser tab.
+            To stop: press <kbd>q</kbd> or <kbd>Ctrl</kbd> + <kbd>C</kbd> in the relay's terminal,
+            and close the browser tab.
           </p>
 
           <p>Next session, the whole routine is:</p>
@@ -1640,8 +1663,9 @@ Access other apps and services on this device
             <div class="body">
               <ul>
                 <li>
-                  Is the relay terminal still running and showing <code>tower ready</code>? If it
-                  scrolled away, restart it.
+                  Is the relay still running, and does its <strong>TOWER</strong> panel show
+                  <code>● advertising</code> or <code>● connected</code>? If the terminal closed or
+                  the process died, restart it.
                 </li>
                 <li>Is Bluetooth switched on, on both the computer and the phone?</li>
                 <li>
@@ -1744,10 +1768,10 @@ Access other apps and services on this device
               <ul>
                 <li>Is the status line green? If not, work through the cases above.</li>
                 <li>
-                  Look at the relay's terminal. If no <code>command received:</code> lines appear
-                  when you tap in the app, the app isn't really connected to the relay — it may have
-                  silently reconnected to your physical tower. Turn the physical tower off and
-                  reconnect.
+                  Look at the relay's <strong>activity</strong> feed. If no
+                  <code>command received:</code> lines appear when you tap in the app, the app
+                  isn't really connected to the relay — it may have silently reconnected to your
+                  physical tower. Turn the physical tower off and reconnect.
                 </li>
               </ul>
             </div>

--- a/apps/digital/src/features/board/BoardInspector.tsx
+++ b/apps/digital/src/features/board/BoardInspector.tsx
@@ -8,9 +8,16 @@ import { useState } from 'react';
 import { FOE_STATUSES } from '@/lib/udtData';
 import type { BoardState, FoeStatus, TokenSelection } from 'ultimatedarktowerboard';
 import { adversaryOf, buildingAt, markersAt, skullsAt } from 'ultimatedarktowerboard';
-import { useBoardActions, useBoardSelection, useBoardState } from '@/lib/hooks';
+import { useBoardActions, useBoardSelection, useBoardState, useSession } from '@/lib/hooks';
 import { SKULLS_TO_DESTROY } from '@/sources/ManualBoardSource';
-import { adversaryName, foeName, heroName } from './boardData';
+import {
+  adversaryName,
+  foeLevelOf,
+  foeName,
+  heroName,
+  levelLabel,
+  statusForLevel,
+} from './boardData';
 import { LocationSelect } from './LocationSelect';
 
 type BoardActions = ReturnType<typeof useBoardActions>;
@@ -80,11 +87,13 @@ function TokenDetail({
   actions: BoardActions;
 }) {
   const { kind, id, location } = selection;
+  const session = useSession();
 
   if (kind === 'foe') {
     const foe = boardState.tokens[id];
     if (!foe || foe.typeId !== 'foe') return <Gone />;
-    const status = (foe.data?.status as FoeStatus | undefined) ?? 'ready';
+    const level = foeLevelOf(foe.art ?? '');
+    const status = level ? statusForLevel(boardState, level) : 'ready';
     return (
       <>
         <h3 className="board-detail-title">
@@ -96,7 +105,14 @@ function TokenDetail({
             <span>{foe.location}</span>
           </li>
         </ul>
-        <StatusRow status={status} onChange={(s) => actions.setFoeStatus(id, s)} />
+        {level && (
+          <>
+            <StatusRow status={status} onChange={(s) => actions.setLevelStatus(level, s)} />
+            <p className="muted">
+              Applies to every {levelLabel(session.config.foes, level)}, placed or not yet placed.
+            </p>
+          </>
+        )}
         <MoveRow from={foe.location} onMove={(to) => actions.moveToken(id, to)} />
         <button className="board-remove" onClick={() => actions.removeFoe(id)}>
           Remove foe

--- a/apps/digital/src/features/board/BoardPalette.tsx
+++ b/apps/digital/src/features/board/BoardPalette.tsx
@@ -16,8 +16,11 @@ import {
   LOCATIONS,
   MARKER_PRESETS,
   adversaryName,
+  foeLevelOf,
   foeName,
   heroName,
+  levelLabel,
+  statusForLevel,
 } from './boardData';
 import { LocationSelect } from './LocationSelect';
 
@@ -39,13 +42,13 @@ export function BoardPalette() {
   const boardState = useBoardState();
   const session = useSession();
   const locationPick = useBoardLocationPick();
-  const { placeFoe, placeHero, setAdversary, addSkull, setSpaceMarker } = useBoardActions();
+  const { placeFoe, placeHero, setAdversary, addSkull, setSpaceMarker, setLevelStatus } =
+    useBoardActions();
 
   const heroes = session.config.heroes;
 
   const [kind, setKind] = useState<PlaceKind>('foe');
   const [foeType, setFoeType] = useState(FOE_LEVELS[0]?.foes[0]?.id ?? '');
-  const [foeStatus, setFoeStatus] = useState<FoeStatus>('ready');
   const [heroId, setHeroId] = useState(heroes[0]?.heroId ?? '');
   const [advId, setAdvId] = useState(session.config.adversary ?? ADVERSARY_ROSTER[0]?.id ?? '');
   const [marker, setMarker] = useState<string>(MARKER_PRESETS[0]);
@@ -69,9 +72,13 @@ export function BoardPalette() {
   const placeAt = (loc: string) => {
     if (!loc) return;
     switch (kind) {
-      case 'foe':
-        if (foeType) placeFoe(`${foeType}-${++foeSeq}`, foeType, loc, foeStatus);
+      case 'foe': {
+        if (!foeType) break;
+        const level = foeLevelOf(foeType);
+        const status = level && boardState ? statusForLevel(boardState, level) : undefined;
+        placeFoe(`${foeType}-${++foeSeq}`, foeType, loc, status);
         break;
+      }
       case 'hero':
         if (effectiveHeroId) placeHero(effectiveHeroId, loc);
         break;
@@ -155,32 +162,20 @@ export function BoardPalette() {
       </label>
 
       {kind === 'foe' && (
-        <>
-          <label>
-            Foe
-            <select value={foeType} onChange={(e) => setFoeType(e.target.value)}>
-              {FOE_LEVELS.map((group) => (
-                <optgroup key={group.level} label={`Level ${group.level}`}>
-                  {group.foes.map((f) => (
-                    <option key={f.id} value={f.id}>
-                      {f.name}
-                    </option>
-                  ))}
-                </optgroup>
-              ))}
-            </select>
-          </label>
-          <label>
-            Status
-            <select value={foeStatus} onChange={(e) => setFoeStatus(e.target.value as FoeStatus)}>
-              {FOE_STATUSES.map((s) => (
-                <option key={s} value={s}>
-                  {s}
-                </option>
-              ))}
-            </select>
-          </label>
-        </>
+        <label>
+          Foe
+          <select value={foeType} onChange={(e) => setFoeType(e.target.value)}>
+            {FOE_LEVELS.map((group) => (
+              <optgroup key={group.level} label={`Level ${group.level}`}>
+                {group.foes.map((f) => (
+                  <option key={f.id} value={f.id}>
+                    {f.name}
+                  </option>
+                ))}
+              </optgroup>
+            ))}
+          </select>
+        </label>
       )}
 
       {kind === 'hero' &&
@@ -248,6 +243,28 @@ export function BoardPalette() {
           </button>
         )}
       </div>
+
+      {boardState && (
+        <>
+          <h3>Threat status</h3>
+          <p className="muted">Applies to every foe of that level, placed or not yet placed.</p>
+          {FOE_LEVELS.map((group) => (
+            <label key={group.level}>
+              {levelLabel(session.config.foes, group.level)}
+              <select
+                value={statusForLevel(boardState, group.level)}
+                onChange={(e) => setLevelStatus(group.level, e.target.value as FoeStatus)}
+              >
+                {FOE_STATUSES.map((s) => (
+                  <option key={s} value={s}>
+                    {s}
+                  </option>
+                ))}
+              </select>
+            </label>
+          ))}
+        </>
+      )}
 
       {boardState && (
         <p className="muted board-counts">

--- a/apps/digital/src/features/board/boardData.test.ts
+++ b/apps/digital/src/features/board/boardData.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import type { BoardState } from 'ultimatedarktowerboard';
+import { foeLevelOf, statusForLevel } from './boardData';
+
+describe('statusForLevel', () => {
+  it('defaults to ready when nothing has been set for that level', () => {
+    const state: BoardState = { tokens: {} };
+    expect(statusForLevel(state, 2)).toBe('ready');
+  });
+
+  it('reads a stored level status regardless of what is placed', () => {
+    const state: BoardState = { tokens: {}, meta: { levelStatus: { 2: 'savage' } } };
+    expect(statusForLevel(state, 2)).toBe('savage');
+  });
+
+  it('ignores other levels stored in meta', () => {
+    const state: BoardState = { tokens: {}, meta: { levelStatus: { 3: 'lethal' } } };
+    expect(statusForLevel(state, 2)).toBe('ready');
+  });
+});
+
+describe('foeLevelOf', () => {
+  it('resolves a known foe id to its level', () => {
+    expect(foeLevelOf('brigands')).toBe(2);
+    expect(foeLevelOf('frost-trolls')).toBe(3);
+  });
+
+  it('returns undefined for an unknown id', () => {
+    expect(foeLevelOf('not-a-real-foe')).toBeUndefined();
+  });
+});

--- a/apps/digital/src/features/board/boardData.ts
+++ b/apps/digital/src/features/board/boardData.ts
@@ -3,7 +3,15 @@
  * (PRD-02). Rosters and the 60 locations come from `ultimatedarktower`; nothing here mutates
  * state — these are display helpers only.
  */
-import { ADVERSARY_ROSTER, BOARD_LOCATIONS, FOES, FOE_BY_ID, HERO_BY_ID } from '@/lib/udtData';
+import type { BoardState, FoeStatus } from 'ultimatedarktowerboard';
+import {
+  ADVERSARY_ROSTER,
+  BOARD_LOCATIONS,
+  FOES,
+  FOE_BY_ID,
+  HERO_BY_ID,
+  type FoeLevel,
+} from '@/lib/udtData';
 
 export const KINGDOMS = ['north', 'east', 'south', 'west'] as const;
 
@@ -30,3 +38,30 @@ export const foeName = (id: string): string => FOE_BY_ID[id]?.name ?? id;
 export const adversaryName = (id: string): string =>
   ADVERSARY_ROSTER.find((a) => a.id === id)?.name ?? id;
 export const heroName = (id: string): string => HERO_BY_ID[id]?.name ?? id;
+
+/** A foe's identity level (2–4), or `undefined` for an unknown/legacy art id. */
+export const foeLevelOf = (id: string): FoeLevel | undefined => FOE_BY_ID[id]?.level;
+
+/**
+ * The stored threat status for `level` (defaults to `'ready'` until explicitly set). Real
+ * Return to Dark Tower rule: status applies to a whole level, not a single placed foe — see
+ * `setLevelStatus` in the game store, which is the only thing that writes this.
+ */
+export function statusForLevel(state: BoardState, level: FoeLevel): FoeStatus {
+  const levelStatus = state.meta?.levelStatus as Partial<Record<FoeLevel, FoeStatus>> | undefined;
+  return levelStatus?.[level] ?? 'ready';
+}
+
+/** This game's foe (levels 2–4 only — level 5 is the adversary, picked separately). */
+export type LevelFoes = { level2: string | null; level3: string | null; level4: string | null };
+
+/**
+ * The name of whichever foe this game's setup assigned to `level` (e.g. "Brigands"), or a
+ * generic "Level N" fallback before setup picks one. Only one foe occupies a level for a given
+ * game, so this is more useful than the bare level number once setup is complete.
+ */
+export function levelLabel(foes: LevelFoes, level: FoeLevel): string {
+  const id =
+    level === 2 ? foes.level2 : level === 3 ? foes.level3 : level === 4 ? foes.level4 : null;
+  return id ? foeName(id) : `Level ${level}`;
+}

--- a/apps/digital/src/lib/hooks.ts
+++ b/apps/digital/src/lib/hooks.ts
@@ -67,6 +67,7 @@ export function useBoardActions() {
       placeFoe: s.placeFoe,
       removeFoe: s.removeFoe,
       setFoeStatus: s.setFoeStatus,
+      setLevelStatus: s.setLevelStatus,
       placeHero: s.placeHero,
       removeHero: s.removeHero,
       setAdversary: s.setAdversary,

--- a/apps/digital/src/lib/udtData.ts
+++ b/apps/digital/src/lib/udtData.ts
@@ -22,6 +22,7 @@ export {
   FOE_BY_NAME,
   ADVERSARY_ROSTER,
   FOE_STATUSES,
+  type FoeLevel,
 
   // Box inventory (card names) — keyed by expansion name.
   EXPANSIONS,

--- a/apps/digital/src/state/gameStore.test.ts
+++ b/apps/digital/src/state/gameStore.test.ts
@@ -143,6 +143,7 @@ describe('useGameStore', () => {
     it('no-ops without throwing when no board is registered', () => {
       expect(() => useGameStore.getState().placeFoe('f1', 'Brigands', 'Delmsmire')).not.toThrow();
       expect(() => useGameStore.getState().moveToken('f1', 'Narrow Vale')).not.toThrow();
+      expect(() => useGameStore.getState().setLevelStatus(2, 'savage')).not.toThrow();
     });
 
     it('delegates board actions to the registered BoardStateSource', () => {
@@ -172,6 +173,58 @@ describe('useGameStore', () => {
         'removeSkull',
         'setSpaceMarker',
       ]);
+    });
+
+    it('setLevelStatus cascades only to same-level placed foes and records the level status', () => {
+      const board = new FakeBoardSource();
+      board.state = {
+        tokens: {
+          'brigands-1': {
+            id: 'brigands-1',
+            typeId: 'foe',
+            art: 'brigands',
+            location: 'Delmsmire',
+            data: { status: 'ready' },
+          },
+          'oreks-1': {
+            id: 'oreks-1',
+            typeId: 'foe',
+            art: 'oreks',
+            location: 'Narrow Vale',
+            data: { status: 'ready' },
+          },
+          'frost-trolls-1': {
+            id: 'frost-trolls-1',
+            typeId: 'foe',
+            art: 'frost-trolls',
+            location: 'Ollow',
+            data: { status: 'ready' },
+          },
+        },
+      };
+      useGameStore.getState().registerBoard(board, {} as never, {} as never);
+
+      useGameStore.getState().setLevelStatus(2, 'savage');
+
+      const loadCall = board.calls.find((c) => c.method === 'load');
+      expect(loadCall).toBeDefined();
+      const next = loadCall!.args[0] as BoardState;
+      expect(next.tokens['brigands-1'].data?.status).toBe('savage');
+      expect(next.tokens['oreks-1'].data?.status).toBe('savage');
+      expect(next.tokens['frost-trolls-1'].data?.status).toBe('ready');
+      expect((next.meta?.levelStatus as Record<number, string>)[2]).toBe('savage');
+    });
+
+    it('setLevelStatus records the level status even with nothing of that level placed', () => {
+      const board = new FakeBoardSource();
+      useGameStore.getState().registerBoard(board, {} as never, {} as never);
+
+      useGameStore.getState().setLevelStatus(3, 'lethal');
+
+      const loadCall = board.calls.find((c) => c.method === 'load');
+      expect(loadCall).toBeDefined();
+      const next = loadCall!.args[0] as BoardState;
+      expect((next.meta?.levelStatus as Record<number, string>)[3]).toBe('lethal');
     });
 
     it('placeHero looks up the owning kingdom from session config before delegating', () => {

--- a/apps/digital/src/state/gameStore.ts
+++ b/apps/digital/src/state/gameStore.ts
@@ -7,10 +7,12 @@
 import { create } from 'zustand';
 import type {
   BoardState,
+  FoeLevel,
   FoeStatus,
   LocationPickStore,
   SelectionStore,
 } from 'ultimatedarktowerboard';
+import { FOE_BY_ID } from 'ultimatedarktowerboard';
 import { ManualTowerSource } from '@/sources/ManualTowerSource';
 import { BridgeTowerSource, type RelayStatus } from '@/sources/BridgeTowerSource';
 import type { BoardStateSource, SealRef, TowerStateSource, Unsubscribe } from '@/sources/types';
@@ -130,6 +132,13 @@ interface GameStore {
   placeFoe(foeId: string, foe: string, location: string, status?: FoeStatus): void;
   removeFoe(foeId: string): void;
   setFoeStatus(foeId: string, status: FoeStatus): void;
+  /**
+   * Cascade a status to every currently-placed foe of `level` and remember it for the next
+   * placement (real-rules: threat status applies to a whole level, not a single foe). Stored in
+   * `BoardState.meta.levelStatus` so it's settable independent of what's currently placed, and
+   * round-trips with the session for free.
+   */
+  setLevelStatus(level: FoeLevel, status: FoeStatus): void;
   /** Place a hero; the owning kingdom is looked up from the session config for token color. */
   placeHero(heroId: string, location: string): void;
   removeHero(heroId: string): void;
@@ -241,6 +250,22 @@ export const useGameStore = create<GameStore>((set, get) => {
       get().boardSource?.placeFoe(foeId, foe, location, status),
     removeFoe: (foeId) => get().boardSource?.removeFoe(foeId),
     setFoeStatus: (foeId, status) => get().boardSource?.setFoeStatus(foeId, status),
+    setLevelStatus: (level, status) => {
+      const board = get().boardState;
+      const source = get().boardSource;
+      if (!board || !source) return;
+      const tokens = { ...board.tokens };
+      for (const [id, token] of Object.entries(tokens)) {
+        if (token.typeId === 'foe' && FOE_BY_ID[token.art ?? '']?.level === level) {
+          tokens[id] = { ...token, data: { ...token.data, status } };
+        }
+      }
+      const levelStatus = {
+        ...(board.meta?.levelStatus as Partial<Record<FoeLevel, FoeStatus>> | undefined),
+        [level]: status,
+      };
+      source.load({ ...board, tokens, meta: { ...board.meta, levelStatus } });
+    },
     placeHero: (heroId, location) => {
       const owner = get().session.config.heroes.find((h) => h.heroId === heroId)?.homeKingdom;
       get().boardSource?.placeHero(heroId, location, owner);

--- a/apps/relay-cli/CLAUDE.md
+++ b/apps/relay-cli/CLAUDE.md
@@ -25,6 +25,60 @@ Consequences to keep in mind when editing this package:
 - **Adding it to npm was a token change too** — the granular `NPM_TOKEN` is a fixed package
   allow-list; see the root CLAUDE.md's release section.
 
+## This package is ESM — the one exception among its CJS siblings
+
+`package.json` sets `"type": "module"`. Every other package extending `tsconfig.node-lib.json`
+(`relay-core`, `relay-shared`, `relay-client`, `packages/core`, `packages/game-data`) is CJS —
+this one flipped because the live status board (`src/dashboard.tsx`) is built on
+[Ink](https://github.com/vadimdemedes/ink), which is ESM-only as of v7. `module: Node16` in
+`tsconfig.json` follows the package's own `"type"` field, so it now emits real ESM (verified: the
+same pattern `apps/mcp-server` already uses). The shebang still survives into `dist/index.js`
+unchanged. `relay-core`/`relay-shared`/`relay-client` stay CJS — ESM-importing a CJS dep works
+here because their barrels use named `Object.defineProperty` re-exports (not `__exportStar`),
+which `cjs-module-lexer` can see; see `browser-apps-named-import-udt-class` / the display-package
+ESM history for the pattern that does break.
+
+**TypeScript gotcha found in the wild:** narrowing `source: TowerSource` via `instanceof
+TowerEmulator` (to reach `TowerEmulator`-only members like `getBleAdapterState()`) _before_ other
+plain `TowerSource`-typed `.on()` calls corrupts overload resolution for the rest of the
+function — every later `source.on(...)` call fails with a nonsensical "argument of type X is not
+assignable to the last overload" error, because `TowerEmulator`'s `.on()` comes from a generic
+`EventEmitter<TowerEmulatorEventMap>`, a different overload shape than the plain interface
+`TowerSource.on()`. Keep any `instanceof TowerEmulator` narrowing block **last**, after every
+plain-`TowerSource`-typed usage of `source` — this file's `ghost-connection` +
+`ble-adapter-state` wiring live in one combined block at the very end of `main()` for exactly
+this reason. Don't split it back out and move it earlier.
+
+## The Ink dashboard (`src/dashboard.tsx` + `src/format.ts`)
+
+A live status board (relay URLs incl. LAN address, tower/BLE state, decoded drum/LED/audio
+state, connected clients, an activity feed) replaces the old six print-and-go-silent lines.
+`index.ts` owns one mutable `RelayStatus` object and mutates it from the event handlers it
+already has (including two that existed but were never subscribed to before: `relay.on(
+'client-change', ...)` and `TowerEmulator`'s `'ble-adapter-state'`); the component itself
+doesn't subscribe to anything, it just re-renders on a 250 ms tick and reads the object
+directly. Pure formatting helpers (`format.ts`) are deliberately free of any `ink`/`react`
+import so they unit-test without pulling in ink's yoga-layout wasm.
+
+- **`RELAY_DASHBOARD=0`** — force the plain console-line fallback even on a TTY.
+- The board only mounts when **both** `stdout` and `stdin` are TTYs — `useInput`/`setRawMode`
+  throw outright otherwise (Docker `-d`, systemd, a piped `| tee`). Piped/headless users get
+  today's exact plain-line output, untouched.
+- `relay-core` writes ~30 unstructured `console.log`/`warn`/`error` calls directly (TowerEmulator,
+  RealTower, RelayServer, ConnectionManager, ObserverDisplay). With the board mounted, `index.ts`
+  monkey-patches `console.*` to route those into the same activity feed (and still into the
+  JSONL log via `logger.logEvent`) instead of letting ink's own `patchConsole` print them above
+  the live frame — that default would make a full-screen board crawl down the terminal. This
+  patch is applied (and restored) only on the TTY path; the non-dashboard path never touches
+  `console`.
+- **Ctrl-C is handled explicitly, not via ink's default.** `exitOnCtrlC` is `false`; the
+  dashboard's own `useInput` treats `key.ctrl && input === 'c'` exactly like `q`. Needed because
+  raw mode swallows the actual SIGINT — once the board is mounted, `process.on('SIGINT', ...)`
+  will not fire from a terminal Ctrl-C (it still does from an external `kill`/`docker stop`).
+- Mounting order matters on quit: `startDashboard`'s `quit` action wraps the caller-supplied one
+  to call `instance.unmount()` **first**, then the real `shutdown()`. Ink hides the cursor and
+  holds stdin in raw mode; exiting without unmounting first leaks both into the user's shell.
+
 ## Runtime env vars
 
 - **`TOWER_SOURCE`** — `emulator` | `mock` | `real` | `bridge` (picks the `TowerSource` impl).
@@ -33,6 +87,7 @@ Consequences to keep in mind when editing this package:
 - **`LOGGING=0`** — disable JSONL file logging.
 - **`RELAY_LOG_DIR`** — log directory (default `./logs`, **cwd-relative** — under `npx` that's
   wherever the user ran the command, not the package dir).
+- **`RELAY_DASHBOARD=0`** — disable the live Ink status board; see above.
 
 Extra entrypoints beyond `start`: `replay` (`node dist/replayEvents.js`) and `analyze`
 (`node dist/analyzeLogs.js`).
@@ -44,5 +99,6 @@ The `relay-native` CI job builds via `pnpm --filter "./packages/relay-*..." --fi
 deps of deps, so the job must **also** `--filter` in `ultimatedarktower` and
 `ultimatedarktowerdata` by name, or the build fails with "Cannot find module 'ultimatedarktower'".
 
-`test` = `vitest run --passWithNoTests` (currently 0 test files). Depends on all three relay
-packages + `ultimatedarktower` (`workspace:^`) + `ws`.
+`test` = `vitest run --passWithNoTests`, currently exercising `src/format.test.ts` (the pure
+dashboard helpers only — nothing ink/react-rendering is under test). Depends on all three relay
+packages + `ultimatedarktower` (`workspace:^`) + `ws` + `ink`/`react`.

--- a/apps/relay-cli/README.md
+++ b/apps/relay-cli/README.md
@@ -18,9 +18,15 @@ That's the whole install. Needs **Node >= 22.13** and nothing else — the BLE n
 prebuilt binaries for Windows (x64/x86), macOS (Intel/Apple Silicon) and Linux (x64/arm/arm64), so
 there is no compile step. (Windows-on-ARM has no prebuild and will attempt to build from source.)
 
-It prints a URL for the hosted UTDD build on startup; open that and click **Connect**. Full
-player-facing walkthrough:
+It opens on a live status board — relay URLs (including your LAN address, so a phone can
+connect), tower/BLE state, connected clients, and an activity feed — with the URL to open and
+click **Connect** shown in the RELAY panel. Full player-facing walkthrough:
 **[Connecting the official app](https://chessmess.github.io/UltimateDarkTower/digital/connecting-the-official-app.html)**.
+
+Keys: `q` quit, `r` resend the last command, `l` toggle JSONL logging. Set `RELAY_DASHBOARD=0` to
+fall back to plain log lines instead (useful over a dumb pipe, or if you just prefer it) — the
+board also disables itself automatically when stdout/stdin aren't both a real terminal (Docker,
+systemd, a piped log).
 
 ### From a checkout, for development
 
@@ -44,12 +50,15 @@ TOWER_SOURCE=bridge node dist/index.js # app drives the emulator; forward to a r
 
 Other env vars: `RELAY_PORT` (default `8765`), `TOWER_DIS_*` (Device Information Service
 overrides), `LOGGING=0` (disable JSONL file logging), `RELAY_LOG_DIR` (log directory, default
-`./logs` — **relative to the current directory**, which under `npx` is wherever you ran it). See
-the header comment in [`src/index.ts`](src/index.ts) for the full list.
+`./logs` — **relative to the current directory**, which under `npx` is wherever you ran it),
+`RELAY_DASHBOARD=0` (disable the live status board). See the header comment in
+[`src/index.ts`](src/index.ts) for the full list.
 
 ## Files
 
 - `src/index.ts` — daemon entry point (source selection, relay wiring, graceful shutdown).
+- `src/dashboard.tsx` — the Ink status board.
+- `src/format.ts` — pure formatting helpers for the board (unit-tested in `format.test.ts`).
 - `src/replayEvents.ts` — replay a recorded JSONL event log (`pnpm replay`).
 - `src/analyzeLogs.ts` — summarize a recorded session (`pnpm analyze`).
 - `src/mockConsumer.ts` — a minimal WebSocket consumer for manual testing against the relay.

--- a/apps/relay-cli/package.json
+++ b/apps/relay-cli/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.2",
   "private": false,
   "description": "UltimateDarkTowerRelay CLI — headless relay daemon (BLE tower emulator + WebSocket relay) for servers, Raspberry Pi, Docker, or an always-on host.",
+  "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {
@@ -28,6 +29,8 @@
     "clean": "rm -rf dist *.tsbuildinfo"
   },
   "dependencies": {
+    "ink": "^7.1.1",
+    "react": "catalog:",
     "ultimatedarktower": "workspace:^",
     "ultimatedarktowerrelay-client": "workspace:^",
     "ultimatedarktowerrelay-core": "workspace:^",
@@ -35,6 +38,7 @@
     "ws": "catalog:"
   },
   "devDependencies": {
+    "@types/react": "catalog:",
     "@types/ws": "catalog:",
     "vitest": "catalog:"
   },

--- a/apps/relay-cli/src/dashboard.tsx
+++ b/apps/relay-cli/src/dashboard.tsx
@@ -1,0 +1,255 @@
+/**
+ * Live status board for the relay CLI. Ink is ESM-only, which is why this
+ * package ships `"type": "module"` (see tsconfig.json).
+ *
+ * `index.ts` owns one mutable `RelayStatus` object and mutates it from the
+ * event handlers it already has; this component doesn't subscribe to
+ * anything, it just re-renders on a tick and reads the object directly. Ink
+ * diffs its output, so an unchanged tick writes nothing to the terminal.
+ */
+import { useEffect, useState } from 'react';
+import { Box, Text, render, useInput, type Instance } from 'ink';
+import type { TowerEmulatorState, ConnectedClient, LogLevel } from 'ultimatedarktowerrelay-shared';
+import type { TowerState } from 'ultimatedarktower';
+import { drumSide, formatUptime, formatRelativeTime, getLanAddress } from './format.js';
+
+export interface ActivityEntry {
+  ts: number;
+  kind: LogLevel;
+  text: string;
+}
+
+export interface RelayStatus {
+  version: string;
+  sourceMode: string;
+  port: number;
+  startedAt: number;
+  utddUrl: string;
+  loggingEnabled: boolean;
+  towerEmulatorState: TowerEmulatorState;
+  companionConnected: boolean;
+  /** Raw BLE adapter state (e.g. 'poweredOn'); null when the source has no BLE adapter (real mode). */
+  bleAdapterState: string | null;
+  towerState: TowerState;
+  commandCount: number;
+  lastCommandAt: Date | null;
+  /** Skull-drop count from the NotificationSynthesizer; null when there is no synth (real mode). */
+  skullDropCount: number | null;
+  clients: ConnectedClient[];
+  /** Ring buffer, oldest first. index.ts is responsible for capping its length. */
+  activity: ActivityEntry[];
+}
+
+export interface DashboardActions {
+  quit: () => void;
+  resend: () => void;
+  toggleLogging: () => void;
+}
+
+const MAX_CLIENT_ROWS = 5;
+
+function stateColor(state: TowerEmulatorState): string {
+  if (state === 'connected') return 'green';
+  if (state === 'error') return 'red';
+  return 'yellow';
+}
+
+function clientColor(state: ConnectedClient['state']): string {
+  if (state === 'ready') return 'green';
+  if (state === 'connecting') return 'yellow';
+  return 'gray';
+}
+
+function kindColor(kind: LogLevel): string {
+  if (kind === 'error') return 'red';
+  if (kind === 'warn') return 'yellow';
+  if (kind === 'cmd') return 'blue';
+  return 'gray';
+}
+
+function Dashboard({ status, actions }: { status: RelayStatus; actions: DashboardActions }) {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 250);
+    return () => clearInterval(id);
+  }, []);
+
+  useInput((input, key) => {
+    if (input === 'q' || (key.ctrl && input === 'c')) actions.quit();
+    else if (input === 'r') actions.resend();
+    else if (input === 'l') actions.toggleLogging();
+  });
+
+  const rows = process.stdout.rows || 24;
+  const activityMax = Math.max(3, rows - 20);
+  const uptime = formatUptime(now - status.startedAt);
+  const lanAddress = getLanAddress();
+  const [top, middle, bottom] = status.towerState.drum;
+  const visibleClients = status.clients.slice(0, MAX_CLIENT_ROWS);
+  const extraClients = status.clients.length - visibleClients.length;
+  const visibleActivity = status.activity.slice(-activityMax);
+
+  return (
+    <Box flexDirection="column" borderStyle="round" paddingX={1}>
+      <Text>
+        <Text color={stateColor(status.towerEmulatorState)}>●</Text>{' '}
+        <Text bold>
+          Ultimate Dark Tower Relay — v{status.version} · {status.sourceMode} · up {uptime}
+        </Text>
+      </Text>
+
+      <Box marginTop={1} flexDirection="column">
+        <Text bold color="cyan">
+          RELAY
+        </Text>
+        <Text> ws://localhost:{status.port}</Text>
+        {lanAddress && (
+          <Text>
+            {' '}
+            ws://{lanAddress}:{status.port} (LAN)
+          </Text>
+        )}
+        <Text> Open {status.utddUrl}</Text>
+      </Box>
+
+      <Box marginTop={1} flexDirection="column">
+        <Text bold color="cyan">
+          TOWER
+        </Text>
+        <Text>
+          {' '}
+          <Text color={stateColor(status.towerEmulatorState)}>●</Text>{' '}
+          <Text color={stateColor(status.towerEmulatorState)}>{status.towerEmulatorState}</Text>
+          {'    '}
+          app:{' '}
+          <Text color={status.companionConnected ? 'green' : 'gray'}>
+            {status.companionConnected ? 'connected' : 'disconnected'}
+          </Text>
+          {status.bleAdapterState !== null ? `    BLE: ${status.bleAdapterState}` : ''}
+        </Text>
+      </Box>
+
+      <Box marginTop={1} flexDirection="column">
+        <Text bold color="cyan">
+          STATE
+        </Text>
+        <Text>
+          {' '}
+          top {drumSide(top.position)} mid {drumSide(middle.position)} bot{' '}
+          {drumSide(bottom.position)}
+          {'   '}
+          cal {[top, middle, bottom].map((d) => (d.calibrated ? '✓' : '·')).join('')}
+        </Text>
+        <Text>
+          {' '}
+          led seq {status.towerState.led_sequence} · audio #{status.towerState.audio.sample} vol{' '}
+          {status.towerState.audio.volume} · beam {status.towerState.beam.count}
+          {status.towerState.beam.fault ? ' FAULT' : ''}
+        </Text>
+      </Box>
+
+      <Box marginTop={1} flexDirection="column">
+        <Text bold color="cyan">
+          CLIENTS (
+          <Text color={status.clients.length > 0 ? 'green' : 'gray'}>
+            {status.clients.length}
+          </Text>
+          )
+        </Text>
+        {visibleClients.length === 0 && <Text dimColor> none connected</Text>}
+        {visibleClients.map((c) => (
+          <Text key={c.id}>
+            {' '}
+            <Text color={clientColor(c.state)}>●</Text> {(c.label ?? c.id.slice(0, 8)).padEnd(14)}{' '}
+            {c.state.padEnd(11)}
+            {c.towerConnected ? ' tower✓' : ''}
+            {c.observer ? ' observer' : ''} {formatRelativeTime(new Date(c.connectedAt), now)}
+          </Text>
+        ))}
+        {extraClients > 0 && <Text dimColor> +{extraClients} more</Text>}
+      </Box>
+
+      <Box marginTop={1}>
+        <Text>
+          <Text bold color="cyan">
+            COUNTERS
+          </Text>{' '}
+          commands <Text color="cyan">{status.commandCount}</Text> skulls{' '}
+          <Text color={status.skullDropCount ? 'yellow' : 'gray'}>
+            {status.skullDropCount ?? '—'}
+          </Text>{' '}
+          last {formatRelativeTime(status.lastCommandAt, now)}
+        </Text>
+      </Box>
+
+      <Box
+        marginTop={1}
+        flexDirection="column"
+        borderStyle="single"
+        borderColor="gray"
+        paddingX={1}
+      >
+        <Text bold dimColor>
+          activity
+        </Text>
+        {visibleActivity.length === 0 && <Text dimColor> (nothing yet)</Text>}
+        {visibleActivity.map((entry, i) => (
+          <Text key={`${entry.ts}-${i}`}>
+            <Text dimColor>{new Date(entry.ts).toLocaleTimeString()}</Text>{' '}
+            <Text color={kindColor(entry.kind)}>{entry.kind.padEnd(5)}</Text> {entry.text}
+          </Text>
+        ))}
+      </Box>
+
+      <Box marginTop={1}>
+        <Text dimColor>
+          <Text bold color="cyan">
+            q
+          </Text>{' '}
+          quit{'   '}
+          <Text bold color="cyan">
+            r
+          </Text>{' '}
+          resend{'   '}
+          <Text bold color="cyan">
+            l
+          </Text>{' '}
+          logging (
+          <Text color={status.loggingEnabled ? 'green' : 'gray'}>
+            {status.loggingEnabled ? 'on' : 'off'}
+          </Text>
+          )
+        </Text>
+      </Box>
+    </Box>
+  );
+}
+
+/**
+ * Mount the dashboard. Returns a teardown that unmounts ink and restores the
+ * terminal (cursor, raw mode). `actions.quit` is wrapped so a keypress inside
+ * the component unmounts ink *before* running the caller's shutdown — ink
+ * hides the cursor and holds stdin in raw mode, and process.exit() without
+ * unmounting first leaks both into the user's shell.
+ */
+export function startDashboard(status: RelayStatus, actions: DashboardActions): () => void {
+  const wrappedActions: DashboardActions = {
+    ...actions,
+    // References `instance` before its declaration below — fine, since this
+    // closure only runs on a later keypress, by which time render() has
+    // already returned and assigned it.
+    quit: () => {
+      instance.unmount();
+      actions.quit();
+    },
+  };
+  const instance: Instance = render(<Dashboard status={status} actions={wrappedActions} />, {
+    exitOnCtrlC: false,
+    // relay-core writes unstructured console.log from ~30 call sites; ink's
+    // default console patching would print those above the live frame and
+    // make a full-screen board crawl down the terminal. index.ts instead
+    // redirects console output into the activity ring before mounting.
+    patchConsole: false,
+  });
+  return () => instance.unmount();
+}

--- a/apps/relay-cli/src/dashboard.tsx
+++ b/apps/relay-cli/src/dashboard.tsx
@@ -151,10 +151,7 @@ function Dashboard({ status, actions }: { status: RelayStatus; actions: Dashboar
       <Box marginTop={1} flexDirection="column">
         <Text bold color="cyan">
           CLIENTS (
-          <Text color={status.clients.length > 0 ? 'green' : 'gray'}>
-            {status.clients.length}
-          </Text>
-          )
+          <Text color={status.clients.length > 0 ? 'green' : 'gray'}>{status.clients.length}</Text>)
         </Text>
         {visibleClients.length === 0 && <Text dimColor> none connected</Text>}
         {visibleClients.map((c) => (

--- a/apps/relay-cli/src/format.test.ts
+++ b/apps/relay-cli/src/format.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { drumSide, formatUptime, formatRelativeTime, getLanAddress } from './format';
+
+describe('drumSide', () => {
+  it('maps 0-3 to compass names', () => {
+    expect(drumSide(0)).toBe('north');
+    expect(drumSide(1)).toBe('east');
+    expect(drumSide(2)).toBe('south');
+    expect(drumSide(3)).toBe('west');
+  });
+
+  it('returns ? for an out-of-range position', () => {
+    expect(drumSide(4)).toBe('?');
+    expect(drumSide(-1)).toBe('?');
+  });
+});
+
+describe('formatUptime', () => {
+  it('formats under an hour as MM:SS', () => {
+    expect(formatUptime(0)).toBe('00:00');
+    expect(formatUptime(65_000)).toBe('01:05');
+  });
+
+  it('formats an hour or more as H:MM:SS', () => {
+    expect(formatUptime(3_661_000)).toBe('1:01:01');
+  });
+});
+
+describe('formatRelativeTime', () => {
+  const now = 1_000_000;
+
+  it('returns never for null', () => {
+    expect(formatRelativeTime(null, now)).toBe('never');
+  });
+
+  it('returns just now for sub-second deltas', () => {
+    expect(formatRelativeTime(new Date(now - 200), now)).toBe('just now');
+  });
+
+  it('formats seconds, minutes, and hours', () => {
+    expect(formatRelativeTime(new Date(now - 5_000), now)).toBe('5s ago');
+    expect(formatRelativeTime(new Date(now - 65_000), now)).toBe('1m ago');
+    expect(formatRelativeTime(new Date(now - 3_665_000), now)).toBe('1h ago');
+  });
+});
+
+describe('getLanAddress', () => {
+  it('picks the first non-internal IPv4 address', () => {
+    const fake = {
+      lo0: [{ address: '127.0.0.1', family: 'IPv4', internal: true }],
+      en0: [
+        { address: 'fe80::1', family: 'IPv6', internal: false },
+        { address: '192.168.1.42', family: 'IPv4', internal: false },
+      ],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+    expect(getLanAddress(fake)).toBe('192.168.1.42');
+  });
+
+  it('returns null when nothing qualifies', () => {
+    const fake = {
+      lo0: [{ address: '127.0.0.1', family: 'IPv4', internal: true }],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+    expect(getLanAddress(fake)).toBeNull();
+  });
+});

--- a/apps/relay-cli/src/format.ts
+++ b/apps/relay-cli/src/format.ts
@@ -1,0 +1,49 @@
+/**
+ * Pure formatting helpers for the dashboard. Deliberately free of `ink`/`react`
+ * imports so they can be unit-tested without pulling in ink's yoga-layout wasm.
+ */
+import { networkInterfaces } from 'node:os';
+
+const COMPASS = ['north', 'east', 'south', 'west'] as const;
+
+/** Map a drum's raw 2-bit position (0-3) to its compass name, `?` if out of range. */
+export function drumSide(position: number): string {
+  return COMPASS[position] ?? '?';
+}
+
+/** Format a millisecond duration as `H:MM:SS` (or `MM:SS` under an hour). */
+export function formatUptime(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  const mm = String(minutes).padStart(2, '0');
+  const ss = String(seconds).padStart(2, '0');
+  return hours > 0 ? `${hours}:${mm}:${ss}` : `${mm}:${ss}`;
+}
+
+/** Format a past Date as a short relative "Xs ago" / "Xm ago" string, or `never`. */
+export function formatRelativeTime(date: Date | null, now: number = Date.now()): string {
+  if (!date) return 'never';
+  const seconds = Math.max(0, Math.round((now - date.getTime()) / 1000));
+  if (seconds < 1) return 'just now';
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h ago`;
+}
+
+/** First non-internal IPv4 address, for printing a LAN-reachable relay URL. */
+export function getLanAddress(
+  interfaces: ReturnType<typeof networkInterfaces> = networkInterfaces(),
+): string | null {
+  for (const entries of Object.values(interfaces)) {
+    for (const entry of entries ?? []) {
+      if (!entry.internal && entry.family === 'IPv4') {
+        return entry.address;
+      }
+    }
+  }
+  return null;
+}

--- a/apps/relay-cli/src/index.ts
+++ b/apps/relay-cli/src/index.ts
@@ -13,21 +13,24 @@
  *   TOWER_SOURCE=bridge node dist/index.js # app drives TowerEmulator; forward to a real master tower
  *
  * Environment:
- *   RELAY_PORT    TCP port for the WebSocket relay (default 8765).
- *   TOWER_SOURCE  'emulator' (default; legacy 'fake' accepted) → BLE TowerEmulator; 'mock' → MockTower;
- *                 'real' → RealTower; 'bridge' → TowerEmulator (app connects) + RealTower (forwarded to it).
- *   TOWER_DIS_*   Device Information Service overrides for the tower emulator (see readDeviceInfoFromEnv).
- *   LOGGING       '0' disables JSONL file logging (default enabled).
- *   RELAY_LOG_DIR Directory for the JSONL logs (default './logs', relative to the
- *                 current working directory — which under `npx` is wherever the
- *                 player happened to run the command).
+ *   RELAY_PORT       TCP port for the WebSocket relay (default 8765).
+ *   TOWER_SOURCE     'emulator' (default; legacy 'fake' accepted) → BLE TowerEmulator; 'mock' → MockTower;
+ *                    'real' → RealTower; 'bridge' → TowerEmulator (app connects) + RealTower (forwarded to it).
+ *   TOWER_DIS_*      Device Information Service overrides for the tower emulator (see readDeviceInfoFromEnv).
+ *   LOGGING          '0' disables JSONL file logging (default enabled).
+ *   RELAY_LOG_DIR    Directory for the JSONL logs (default './logs', relative to the
+ *                    current working directory — which under `npx` is wherever the
+ *                    player happened to run the command).
+ *   RELAY_DASHBOARD  '0' disables the live Ink status board even on a TTY, falling back
+ *                    to plain console lines (default: board on when stdout+stdin are TTYs).
  *
  * Steps:
  *   1. Construct the logger, the semantic-event log, parser, observer.
  *   2. Select the tower source (emulator / mock / real); build the synthesizer for sink-capable sources.
- *   3. Wire source 'command' → broadcast; lifecycle events → paused/resumed.
+ *   3. Wire source 'command' → broadcast; lifecycle events → paused/resumed; mutate the live
+ *      dashboard status object alongside the existing JSONL logging.
  *   4. Start the relay, then start the source.
- *   5. Gracefully shut down on SIGINT/SIGTERM.
+ *   5. Gracefully shut down on SIGINT/SIGTERM (or 'q'/Ctrl-C in the dashboard).
  */
 
 import {
@@ -51,9 +54,13 @@ import {
   makeAppDisconnectedEvent,
   makeConsumerJoinedEvent,
   makeConsumerLeftEvent,
+  type LogLevel,
 } from 'ultimatedarktowerrelay-shared';
+import { createDefaultTowerState } from 'ultimatedarktower';
+import { startDashboard, type RelayStatus } from './dashboard.js';
 
 const DEFAULT_PORT = 8765;
+const MAX_ACTIVITY_ENTRIES = 200;
 
 /** Hosted UTDD build — the UI this relay drives. Printed on startup. */
 const UTDD_URL = 'https://chessmess.github.io/UltimateDarkTower/digital/';
@@ -78,6 +85,9 @@ function readDeviceInfoFromEnv(): Partial<DeviceInformation> {
   return info;
 }
 
+/** Mounted only when useDashboard is true; unmounted before shutdown/fatal-error output. */
+let stopDashboard: (() => void) | null = null;
+
 async function main(): Promise<void> {
   // TOWER_SOURCE: 'emulator' (default) | 'mock' | 'real' | 'bridge'. The legacy
   // value 'fake' is accepted as a back-compat alias for 'emulator' (anything not
@@ -90,7 +100,6 @@ async function main(): Promise<void> {
         : process.env['TOWER_SOURCE'] === 'bridge'
           ? 'bridge'
           : 'emulator';
-  console.log(`UltimateDarkTowerRelay v${PROTOCOL_VERSION} (source: ${sourceMode})`);
 
   const port = Number(process.env['RELAY_PORT'] ?? DEFAULT_PORT);
   const loggingEnabled = process.env['LOGGING'] !== '0';
@@ -98,6 +107,46 @@ async function main(): Promise<void> {
   // command, not the package directory — RELAY_LOG_DIR is the escape hatch for
   // anyone who'd rather not have a logs/ folder appear next to them.
   const logDir = process.env['RELAY_LOG_DIR'] ?? './logs';
+
+  // useInput()/setRawMode() throw outright when stdin isn't a TTY (piped, Docker
+  // -d, systemd), so both streams must be checked, not just stdout.
+  const useDashboard =
+    process.stdout.isTTY === true &&
+    process.stdin.isTTY === true &&
+    process.env['RELAY_DASHBOARD'] !== '0';
+
+  const status: RelayStatus = {
+    version: PROTOCOL_VERSION,
+    sourceMode,
+    port,
+    startedAt: Date.now(),
+    utddUrl: UTDD_URL,
+    loggingEnabled,
+    towerEmulatorState: 'idle',
+    companionConnected: false,
+    bleAdapterState: null,
+    towerState: createDefaultTowerState(),
+    commandCount: 0,
+    lastCommandAt: null,
+    skullDropCount: null,
+    clients: [],
+    activity: [],
+  };
+
+  // Records a status-line for the dashboard's activity feed. In non-dashboard
+  // mode this is the only thing standing in for the plain console.log/warn
+  // lines the CLI used to print directly — same text, same stream (warn/error
+  // go to stderr), just routed through one place.
+  function note(kind: LogLevel, text: string): void {
+    status.activity.push({ ts: Date.now(), kind, text: text.trim() });
+    if (status.activity.length > MAX_ACTIVITY_ENTRIES) status.activity.shift();
+    if (useDashboard) return;
+    if (kind === 'warn' || kind === 'error') console.warn(text);
+    else console.log(text);
+  }
+
+  note('event', `UltimateDarkTowerRelay v${PROTOCOL_VERSION} (source: ${sourceMode})`);
+
   const logger = new HostLogger(logDir, loggingEnabled);
   // Append-only JSONL log of semantic RelayEvents (PRD §7 / FR-6), separate from
   // the HostLogger's byte/command + human-readable debug log. EventLog assigns its
@@ -144,6 +193,7 @@ async function main(): Promise<void> {
   // so onClientAction can drive it; its semantic events (command-received,
   // skull-dropped, calibration-complete, heartbeat) are persisted to the EventLog.
   const synth = sink ? new NotificationSynthesizer(sink) : null;
+  if (synth) status.skullDropCount = synth.skullDropCount;
   synth?.on('event', (event) => eventLog.append(event));
 
   const relay = new RelayServer({
@@ -156,13 +206,13 @@ async function main(): Promise<void> {
       );
       logger.writeClientEntries(clientId, entries);
     },
-    onClientConnected: (clientId, label, observer) => {
+    onClientConnected: (clientId, label, observerClient) => {
       logger.logEvent(
         'event',
         'host',
-        `Client connected: ${label ?? clientId.slice(0, 8)}${observer ? ' (observer)' : ''}`,
+        `Client connected: ${label ?? clientId.slice(0, 8)}${observerClient ? ' (observer)' : ''}`,
       );
-      eventLog.append(makeConsumerJoinedEvent(clientId, label, observer));
+      eventLog.append(makeConsumerJoinedEvent(clientId, label, observerClient));
     },
     onClientDisconnected: (clientId, label) => {
       logger.logEvent('event', 'host', `Client disconnected: ${label ?? clientId.slice(0, 8)}`);
@@ -186,6 +236,7 @@ async function main(): Promise<void> {
         return;
       }
       const sent = synth.dropSkull();
+      status.skullDropCount = synth.skullDropCount;
       if (!sent)
         logger.logEvent(
           'warn',
@@ -194,15 +245,22 @@ async function main(): Promise<void> {
         );
     },
   });
+  relay.on('client-change', (clients) => {
+    status.clients = clients;
+  });
 
   // Wire tower commands → relay broadcast.
   source.on('command', (data) => {
     const parsed = parser.parse(data);
     if (!parsed.valid) {
-      console.warn('Dropping invalid command: wrong byte length', Array.from(data).length);
+      note('warn', `Dropping invalid command: wrong byte length ${Array.from(data).length}`);
       return;
     }
     observer.onCommandReceived(data);
+    status.towerState = observer.getCurrentState();
+    status.commandCount = observer.getCommandCount();
+    status.lastCommandAt = observer.getLastReceivedAt();
+    if (parsed.description) note('cmd', parsed.description);
     // parsed.description carries decoded snd/ovr annotations (undefined when none).
     logger.logCommand('companion→host', data, null, 'companion', parsed.description);
     const seq = relay.broadcast(data);
@@ -241,17 +299,21 @@ async function main(): Promise<void> {
   }
   source.on('state-change', (state) => {
     relay.setTowerEmulatorState(state);
+    status.towerEmulatorState = state;
     logger.logEvent('event', 'host', `Tower source state: ${state}`);
   });
   source.on('companion-connected', () => {
+    status.companionConnected = true;
     logger.logEvent('event', 'host', 'Companion app connected');
     eventLog.append(makeAppConnectedEvent());
     relay.broadcastResumed();
   });
   source.on('companion-disconnected', () => {
+    status.companionConnected = false;
     logger.logEvent('event', 'host', 'Companion app disconnected');
     eventLog.append(makeAppDisconnectedEvent());
     synth?.reset();
+    if (synth) status.skullDropCount = synth.skullDropCount;
     relay.broadcastPaused('Companion app disconnected from tower source');
   });
   if (source instanceof TowerEmulator) {
@@ -262,17 +324,71 @@ async function main(): Promise<void> {
         `Ghost BLE connection detected (was ${fromState}) — recovering`,
       );
     });
+    // Only TowerEmulator exposes BLE adapter state; mock/real sources have no
+    // adapter to report (status.bleAdapterState stays null for them).
+    status.bleAdapterState = source.getBleAdapterState();
+    source.on('ble-adapter-state', (state) => {
+      status.bleAdapterState = state;
+    });
+  }
+
+  // relay-core writes unstructured console.log/warn/error from ~30 call sites
+  // (TowerEmulator, RealTower, RelayServer, ConnectionManager, ObserverDisplay).
+  // With the dashboard mounted those would print above the live frame and make
+  // a full-screen board crawl down the terminal, so redirect them into the same
+  // activity feed (still forwarded to the JSONL log so they survive there too).
+  // Left untouched in non-dashboard mode — piped/Docker/systemd users still get
+  // today's exact raw console output.
+  let restoreConsole: (() => void) | null = null;
+  if (useDashboard) {
+    const origLog = console.log.bind(console);
+    const origWarn = console.warn.bind(console);
+    const origError = console.error.bind(console);
+    const toLine = (args: unknown[]): string =>
+      args
+        .map((a) =>
+          typeof a === 'string'
+            ? a
+            : a instanceof Error
+              ? (a.stack ?? a.message)
+              : JSON.stringify(a),
+        )
+        .join(' ');
+    console.log = (...args: unknown[]) => {
+      const line = toLine(args);
+      status.activity.push({ ts: Date.now(), kind: 'event', text: line });
+      if (status.activity.length > MAX_ACTIVITY_ENTRIES) status.activity.shift();
+      logger.logEvent('event', 'console', line);
+    };
+    console.warn = (...args: unknown[]) => {
+      const line = toLine(args);
+      status.activity.push({ ts: Date.now(), kind: 'warn', text: line });
+      if (status.activity.length > MAX_ACTIVITY_ENTRIES) status.activity.shift();
+      logger.logEvent('warn', 'console', line);
+    };
+    console.error = (...args: unknown[]) => {
+      const line = toLine(args);
+      status.activity.push({ ts: Date.now(), kind: 'error', text: line });
+      if (status.activity.length > MAX_ACTIVITY_ENTRIES) status.activity.shift();
+      logger.logEvent('error', 'console', line);
+    };
+    restoreConsole = () => {
+      console.log = origLog;
+      console.warn = origWarn;
+      console.error = origError;
+    };
   }
 
   await relay.start();
-  console.log(`Relay server listening on ws://0.0.0.0:${port}`);
-  if (loggingEnabled) console.log(`Event log: ${eventLog.getPath()}`);
+  note('event', `Relay server listening on ws://0.0.0.0:${port}`);
+  if (loggingEnabled) note('event', `Event log: ${eventLog.getPath()}`);
 
   await source.startAdvertising();
   if (bridgeTarget) {
     await bridgeTarget.startAdvertising(); // connects to the real master tower (retries in background)
   }
-  console.log(
+  note(
+    'event',
     sourceMode === 'real'
       ? 'Connecting to real tower — relaying its state to consumers.'
       : sourceMode === 'mock'
@@ -285,11 +401,17 @@ async function main(): Promise<void> {
   // The player's next action shouldn't require finding a doc. UTDD is served over
   // https, but localhost is a "potentially trustworthy" origin and so is exempt
   // from mixed-content blocking — the hosted page can reach this ws:// relay.
-  console.log(`\nNow open  ${UTDD_URL}  and click Connect.`);
-  console.log(`Relay address for the "Official app" panel: ws://localhost:${port}`);
+  note('event', `Now open  ${UTDD_URL}  and click Connect.`);
+  note('event', `Relay address for the "Official app" panel: ws://localhost:${port}`);
 
-  // Graceful shutdown.
+  // Graceful shutdown. Guarded against double-invocation — the dashboard's 'q'/
+  // Ctrl-C path and an external SIGTERM (e.g. a supervisor escalating after
+  // SIGINT) could both reach here.
+  let shuttingDown = false;
   const shutdown = async (): Promise<void> => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    restoreConsole?.();
     console.log('\nShutting down…');
     synth?.destroy();
     await source.stopAdvertising();
@@ -300,16 +422,33 @@ async function main(): Promise<void> {
     process.exit(0);
   };
 
-  process.on('SIGINT', () => void shutdown());
-  process.on('SIGTERM', () => void shutdown());
-
-  console.log(`Relay port: ${port}`);
-}
-
-// Only run as a standalone process — not when imported.
-if (require.main === module) {
-  main().catch((err) => {
-    console.error('Fatal error:', err);
-    process.exit(1);
+  process.on('SIGINT', () => {
+    stopDashboard?.();
+    void shutdown();
   });
+  process.on('SIGTERM', () => {
+    stopDashboard?.();
+    void shutdown();
+  });
+
+  if (useDashboard) {
+    stopDashboard = startDashboard(status, {
+      quit: () => void shutdown(),
+      resend: () => relay.resendLastCommand(),
+      toggleLogging: () => {
+        const enabled = logger.setEnabled(!logger.enabled);
+        eventLog.setEnabled(enabled);
+        relay.broadcastLogConfig(enabled);
+        status.loggingEnabled = enabled;
+      },
+    });
+  } else {
+    console.log(`Relay port: ${port}`);
+  }
 }
+
+main().catch((err) => {
+  stopDashboard?.();
+  console.error('Fatal error:', err);
+  process.exit(1);
+});

--- a/apps/relay-cli/tsconfig.json
+++ b/apps/relay-cli/tsconfig.json
@@ -1,19 +1,22 @@
 {
-  // Published to npm (so `npx ultimatedarktowerrelay-cli` works), and invoked as
-  // `node dist/index.js` with no "type" field, so Node treats it as CommonJS.
-  // Extends the shared tsconfig.node-lib.json for the same CJS/Node16 rationale
-  // as its dependencies.
+  // Published to npm (so `npx ultimatedarktowerrelay-cli` works). package.json
+  // sets "type": "module" (needed for the Ink dashboard, which is ESM-only), so
+  // `module: Node16` here emits real ESM — unlike its CJS-published siblings that
+  // also extend tsconfig.node-lib.json.
   //
   // sourceMap/declarationMap are deliberately OFF: package.json `files` ships
   // `dist` but not `src`, so emitted .map files would point at sources that
   // aren't in the tarball — a broken-sourcemap warning in every consumer's
   // debugger. `declaration` stays on because `composite` requires it.
+  //
+  // jsx: react-jsx is for the Ink dashboard (src/dashboard.tsx) only.
   "extends": "../../tsconfig.node-lib.json",
   "compilerOptions": {
     "declaration": true,
     "outDir": "./dist",
     "rootDir": "./src",
-    "composite": true
+    "composite": true,
+    "jsx": "react-jsx"
   },
   "references": [
     {

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -77,6 +77,9 @@ above.)
   Shortcut for both steps together: `pnpm run dev:relay-cli`. Use `dev` for
   a `tsc --build --watch` loop instead.
 
+  Opens on a live status board when run from a real terminal; set
+  `RELAY_DASHBOARD=0` for plain log lines instead.
+
 - **Relay Electron** (`ultimatedarktowerrelay-electron`) — BLE tower emulator
   desktop app:
 

--- a/docs/relay/SETUP.md
+++ b/docs/relay/SETUP.md
@@ -29,6 +29,13 @@ Environment:
 | `LOGGING`                                                            | on              | set `0` to disable JSONL logging                                                                                                                       |
 | `TOWER_DIS_FIRMWARE_REVISION`                                        | captured value  | DIS firmware revision the app gates on                                                                                                                 |
 | `TOWER_DIS_{MANUFACTURER,MODEL,HARDWARE_REVISION,SOFTWARE_REVISION}` | captured values | other DIS fields                                                                                                                                       |
+| `RELAY_DASHBOARD`                                                    | on              | set `0` to disable the live status board and fall back to plain log lines                                                                              |
+
+The relay CLI opens on a live status board (relay URL, tower/BLE state, connected clients,
+activity feed) when both stdout and stdin are a real terminal. Under a supervisor (systemd,
+Docker `-d`, a piped log) it isn't a terminal, so the board disables itself automatically and
+you get the same plain lines as before — no need to set `RELAY_DASHBOARD=0` yourself in that
+case, though it's there if you want plain output on an interactive terminal too.
 
 ---
 

--- a/docs/relay/TROUBLESHOOTING.md
+++ b/docs/relay/TROUBLESHOOTING.md
@@ -99,6 +99,25 @@ sure your app calls `replay.setTower(tower)` and `client.sendReady(true)` on `on
 
 ---
 
+## The relay CLI's live status board
+
+### The board doesn't appear, or I just want plain log lines
+
+The relay CLI (`apps/relay-cli`) opens on a live status board only when both stdout and stdin are
+a real terminal. Under a supervisor (systemd, Docker `-d`), over SSH without a tty, or with output
+piped/redirected, it isn't one, so the CLI falls back to plain lines automatically — that's
+expected, not a bug. Set `RELAY_DASHBOARD=0` if you want the plain output on an interactive
+terminal too (e.g. to pipe into `tee` or grep it live).
+
+### Which address do I put in the client's connect box?
+
+The board's RELAY panel prints both `ws://localhost:8765` (same machine) and a `ws://<lan-ip>:8765`
+line (LAN address, for a phone or another device) whenever it can detect one. If no LAN line
+appears, the host has no non-internal IPv4 interface up — fall back to `ws://<host-ip>:8765` as
+described above, using whatever your OS reports for that interface.
+
+---
+
 ## Logs & diagnostics
 
 The host writes two JSONL streams to its logs folder: `session-*.jsonl` (commands + debug) and

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -58,6 +58,19 @@ export default tseslint.config(
     },
   },
 
+  // Ink dashboard (relay-cli): rules-of-hooks/exhaustive-deps still apply, but
+  // there's no Vite dev server here, so react-refresh's export-shape rule
+  // doesn't apply the way it does to the Vite-bundled apps above.
+  {
+    files: ['apps/relay-cli/**/*.tsx'],
+    plugins: {
+      'react-hooks': reactHooks,
+    },
+    rules: {
+      ...reactHooks.configs.recommended.rules,
+    },
+  },
+
   // Test files: expose the vitest ambient globals (all packages are on vitest
   // as of the July 2026 stack-alignment pass — no jest left in the workspace).
   {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -425,6 +425,12 @@ importers:
 
   apps/relay-cli:
     dependencies:
+      ink:
+        specifier: ^7.1.1
+        version: 7.1.1(@types/react@19.2.17)(react@19.2.8)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.8
       ultimatedarktower:
         specifier: workspace:^
         version: link:../../packages/core
@@ -441,6 +447,9 @@ importers:
         specifier: 'catalog:'
         version: 8.21.1
     devDependencies:
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.17
       '@types/ws':
         specifier: 'catalog:'
         version: 8.18.1
@@ -825,6 +834,10 @@ importers:
         version: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jsdom@25.0.1)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
 packages:
+
+  '@alcalzone/ansi-tokenize@0.3.0':
+    resolution: {integrity: sha512-p+CMKJ93HFmLkjXKlXiVGlMQEuRb6H0MokBSwUsX+S6BRX8eV5naFZpQJFfJHjRZY0Hmnqy1/r6UWl3x+19zYA==}
+    engines: {node: '>=18'}
 
   '@apidevtools/json-schema-ref-parser@11.9.3':
     resolution: {integrity: sha512-60vepv88RwcJtSHrD6MjIL6Ta3SOYbgfnkHb+ppAVK+o9mXprRtulx7VlRl3lN3bbvysAfCS7WMVfhUYemB0IQ==}
@@ -2192,6 +2205,10 @@ packages:
     resolution: {integrity: sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA==}
     engines: {node: '>=12'}
 
+  ansi-escapes@7.3.0:
+    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
+    engines: {node: '>=18'}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -2260,6 +2277,10 @@ packages:
   author-regex@1.0.0:
     resolution: {integrity: sha512-KbWgR8wOYRAPekEmMXrYYdc7BRyhn2Ftk7KWfMUnQ43hFdojWEFRxhhRUm3/OFEdPa1r0KAvTTg9YQK57xTe0g==}
     engines: {node: '>=0.8'}
+
+  auto-bind@5.0.1:
+    resolution: {integrity: sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -2388,6 +2409,10 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
   chardet@0.7.0:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
 
@@ -2417,6 +2442,10 @@ packages:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
     engines: {node: '>=6'}
 
+  cli-boxes@4.0.1:
+    resolution: {integrity: sha512-5IOn+jcCEHEraYolBPs/sT4BxYCe2nHg374OPiItB1O96KZFseS2gthU4twyYzeDcFew4DaUM/xwc5BQf08JJw==}
+    engines: {node: '>=18.20 <19 || >=20.10'}
+
   cli-cursor@3.1.0:
     resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
     engines: {node: '>=8'}
@@ -2432,6 +2461,10 @@ packages:
   cli-truncate@3.1.0:
     resolution: {integrity: sha512-wfOBkjXteqSnI59oPcJkcPl/ZmwvMMOj340qUIY1SKZCv0B9Cf4D4fAucRkIKQmsIuYK3x1rrgU7MeGRruiuiA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  cli-truncate@6.1.1:
+    resolution: {integrity: sha512-06p9vyLahLa4zkGcgsGxU6iEkSOiuI4fhCH6Emhe2lPAcoUv73n72DnODsnHA+5wwXGnV0n9M9/qOQJSjYhFhw==}
+    engines: {node: '>=22'}
 
   cli-width@4.1.0:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
@@ -2450,6 +2483,10 @@ packages:
   clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
+
+  code-excerpt@4.0.0:
+    resolution: {integrity: sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   color-convert@0.5.3:
     resolution: {integrity: sha512-RwBeO/B/vZR3dfKL1ye/vx8MHZ40ugzpyfeVG5GsiuGnrlMWe2o8wxBbLCpw9CsxV+wHuzYlCiWnybrIA0ling==}
@@ -2508,6 +2545,10 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  convert-to-spaces@2.0.1:
+    resolution: {integrity: sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   cookie-signature@1.0.7:
     resolution: {integrity: sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==}
@@ -2761,6 +2802,10 @@ packages:
     resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  environment@1.1.0:
+    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
+    engines: {node: '>=18'}
+
   err-code@2.0.3:
     resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
 
@@ -2786,6 +2831,9 @@ packages:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
+  es-toolkit@1.50.0:
+    resolution: {integrity: sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==}
+
   es6-error@4.1.1:
     resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
 
@@ -2804,6 +2852,10 @@ packages:
   escape-string-regexp@1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
     engines: {node: '>=0.8.0'}
+
+  escape-string-regexp@2.0.0:
+    resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
+    engines: {node: '>=8'}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -3114,6 +3166,10 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
+    engines: {node: '>=18'}
+
   get-folder-size@2.0.1:
     resolution: {integrity: sha512-+CEb+GDCM7tkOS2wdMKTn9vU7DgnKUTuDlehkNJKNSovdCOVxs14OfKCk4cvSaR3za4gj+OBdl9opPN9xrJ0zA==}
     hasBin: true
@@ -3310,6 +3366,10 @@ packages:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
 
+  indent-string@5.0.0:
+    resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
+    engines: {node: '>=12'}
+
   infer-owner@1.0.4:
     resolution: {integrity: sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==}
 
@@ -3323,6 +3383,19 @@ packages:
   ini@2.0.0:
     resolution: {integrity: sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==}
     engines: {node: '>=10'}
+
+  ink@7.1.1:
+    resolution: {integrity: sha512-Y43xxa1ZSPvpmfLHcN5o+OdP8Rf8ykkNJEuKYOUNZKT8wXVNLFTtEm1nSDMQkfBH+YANF4Xuu0hhZ4ejqAtN2w==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      '@types/react': '>=19.2.0'
+      react: '>=19.2.0'
+      react-devtools-core: '>=6.1.2'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react-devtools-core:
+        optional: true
 
   interpret@3.1.1:
     resolution: {integrity: sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==}
@@ -3360,9 +3433,18 @@ packages:
     resolution: {integrity: sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==}
     engines: {node: '>=12'}
 
+  is-fullwidth-code-point@5.1.0:
+    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
+    engines: {node: '>=18'}
+
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-in-ci@2.0.0:
+    resolution: {integrity: sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   is-interactive@1.0.0:
     resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
@@ -4124,6 +4206,10 @@ packages:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
 
+  patch-console@2.0.0:
+    resolution: {integrity: sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   patch-package@8.0.1:
     resolution: {integrity: sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==}
     engines: {node: '>=14', npm: '>5'}
@@ -4305,6 +4391,12 @@ packages:
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react-reconciler@0.33.0:
+    resolution: {integrity: sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA==}
+    engines: {node: '>=0.10.0'}
+    peerDependencies:
+      react: ^19.2.0
 
   react@19.2.7:
     resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
@@ -4537,6 +4629,10 @@ packages:
     resolution: {integrity: sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==}
     engines: {node: '>=12'}
 
+  slice-ansi@9.0.0:
+    resolution: {integrity: sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA==}
+    engines: {node: '>=22'}
+
   smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
@@ -4585,6 +4681,10 @@ packages:
     resolution: {integrity: sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
+  stack-utils@2.0.6:
+    resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
+    engines: {node: '>=10'}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -4606,6 +4706,10 @@ packages:
   string-width@5.1.2:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
+
+  string-width@8.2.2:
+    resolution: {integrity: sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==}
+    engines: {node: '>=20'}
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
@@ -4653,6 +4757,10 @@ packages:
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
+
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
@@ -4664,6 +4772,10 @@ packages:
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
+
+  terminal-size@4.0.1:
+    resolution: {integrity: sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ==}
+    engines: {node: '>=18'}
 
   terser@5.49.0:
     resolution: {integrity: sha512-SNiDnXyHSrxVcIOtVbULzcTmniUiwcV7Nwdyj1twVubeTmbjoa8p69KKDpfkdoOavuM4/GRm1+ykI8qqnavHoA==}
@@ -4778,6 +4890,10 @@ packages:
   type-fest@1.4.0:
     resolution: {integrity: sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==}
     engines: {node: '>=10'}
+
+  type-fest@5.8.0:
+    resolution: {integrity: sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==}
+    engines: {node: '>=20'}
 
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
@@ -5035,9 +5151,17 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  widest-line@6.0.0:
+    resolution: {integrity: sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA==}
+    engines: {node: '>=20'}
+
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  wrap-ansi@10.0.0:
+    resolution: {integrity: sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==}
+    engines: {node: '>=20'}
 
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
@@ -5131,6 +5255,9 @@ packages:
     resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
     engines: {node: '>=18'}
 
+  yoga-layout@3.2.1:
+    resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
+
   zod-to-json-schema@3.25.2:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
     peerDependencies:
@@ -5182,6 +5309,11 @@ packages:
         optional: true
 
 snapshots:
+
+  '@alcalzone/ansi-tokenize@0.3.0':
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
 
   '@apidevtools/json-schema-ref-parser@11.9.3':
     dependencies:
@@ -7027,6 +7159,10 @@ snapshots:
     dependencies:
       type-fest: 1.4.0
 
+  ansi-escapes@7.3.0:
+    dependencies:
+      environment: 1.1.0
+
   ansi-regex@5.0.1: {}
 
   ansi-regex@6.2.2: {}
@@ -7089,6 +7225,8 @@ snapshots:
   at-least-node@1.0.0: {}
 
   author-regex@1.0.0: {}
+
+  auto-bind@5.0.1: {}
 
   balanced-match@1.0.2: {}
 
@@ -7265,6 +7403,8 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  chalk@5.6.2: {}
+
   chardet@0.7.0: {}
 
   chardet@2.2.0: {}
@@ -7281,6 +7421,8 @@ snapshots:
 
   clean-stack@2.2.0: {}
 
+  cli-boxes@4.0.1: {}
+
   cli-cursor@3.1.0:
     dependencies:
       restore-cursor: 3.1.0
@@ -7295,6 +7437,11 @@ snapshots:
     dependencies:
       slice-ansi: 5.0.0
       string-width: 5.1.2
+
+  cli-truncate@6.1.1:
+    dependencies:
+      slice-ansi: 9.0.0
+      string-width: 8.2.2
 
   cli-width@4.1.0: {}
 
@@ -7316,6 +7463,10 @@ snapshots:
       mimic-response: 1.0.1
 
   clone@1.0.4: {}
+
+  code-excerpt@4.0.0:
+    dependencies:
+      convert-to-spaces: 2.0.1
 
   color-convert@0.5.3:
     optional: true
@@ -7355,6 +7506,8 @@ snapshots:
   content-type@2.0.0: {}
 
   convert-source-map@2.0.0: {}
+
+  convert-to-spaces@2.0.1: {}
 
   cookie-signature@1.0.7: {}
 
@@ -7612,6 +7765,8 @@ snapshots:
 
   env-paths@3.0.0: {}
 
+  environment@1.1.0: {}
+
   err-code@2.0.3: {}
 
   error-ex@1.3.4:
@@ -7634,6 +7789,8 @@ snapshots:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.4
+
+  es-toolkit@1.50.0: {}
 
   es6-error@4.1.1:
     optional: true
@@ -7672,6 +7829,8 @@ snapshots:
   escape-html@1.0.3: {}
 
   escape-string-regexp@1.0.5: {}
+
+  escape-string-regexp@2.0.0: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -8093,6 +8252,8 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
+  get-east-asian-width@1.6.0: {}
+
   get-folder-size@2.0.1:
     dependencies:
       gar: 1.0.4
@@ -8327,6 +8488,8 @@ snapshots:
 
   indent-string@4.0.0: {}
 
+  indent-string@5.0.0: {}
+
   infer-owner@1.0.4: {}
 
   inflight@1.0.6:
@@ -8337,6 +8500,40 @@ snapshots:
   inherits@2.0.4: {}
 
   ini@2.0.0: {}
+
+  ink@7.1.1(@types/react@19.2.17)(react@19.2.8):
+    dependencies:
+      '@alcalzone/ansi-tokenize': 0.3.0
+      ansi-escapes: 7.3.0
+      ansi-styles: 6.2.3
+      auto-bind: 5.0.1
+      chalk: 5.6.2
+      cli-boxes: 4.0.1
+      cli-cursor: 4.0.0
+      cli-truncate: 6.1.1
+      code-excerpt: 4.0.0
+      es-toolkit: 1.50.0
+      indent-string: 5.0.0
+      is-in-ci: 2.0.0
+      patch-console: 2.0.0
+      react: 19.2.8
+      react-reconciler: 0.33.0(react@19.2.8)
+      scheduler: 0.27.0
+      signal-exit: 3.0.7
+      slice-ansi: 9.0.0
+      stack-utils: 2.0.6
+      string-width: 8.2.2
+      terminal-size: 4.0.1
+      type-fest: 5.8.0
+      widest-line: 6.0.0
+      wrap-ansi: 10.0.0
+      ws: 8.21.1
+      yoga-layout: 3.2.1
+    optionalDependencies:
+      '@types/react': 19.2.17
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   interpret@3.1.1: {}
 
@@ -8358,9 +8555,15 @@ snapshots:
 
   is-fullwidth-code-point@4.0.0: {}
 
+  is-fullwidth-code-point@5.1.0:
+    dependencies:
+      get-east-asian-width: 1.6.0
+
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-in-ci@2.0.0: {}
 
   is-interactive@1.0.0: {}
 
@@ -9047,6 +9250,8 @@ snapshots:
 
   parseurl@1.3.3: {}
 
+  patch-console@2.0.0: {}
+
   patch-package@8.0.1:
     dependencies:
       '@yarnpkg/lockfile': 1.1.0
@@ -9198,6 +9403,11 @@ snapshots:
       scheduler: 0.27.0
 
   react-is@17.0.2: {}
+
+  react-reconciler@0.33.0(react@19.2.8):
+    dependencies:
+      react: 19.2.8
+      scheduler: 0.27.0
 
   react@19.2.7: {}
 
@@ -9503,6 +9713,11 @@ snapshots:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 4.0.0
 
+  slice-ansi@9.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
+
   smart-buffer@4.2.0: {}
 
   socks-proxy-agent@7.0.0:
@@ -9555,6 +9770,10 @@ snapshots:
     dependencies:
       minipass: 3.3.6
 
+  stack-utils@2.0.6:
+    dependencies:
+      escape-string-regexp: 2.0.0
+
   stackback@0.0.2: {}
 
   statuses@2.0.2: {}
@@ -9574,6 +9793,11 @@ snapshots:
     dependencies:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
+
+  string-width@8.2.2:
+    dependencies:
+      get-east-asian-width: 1.6.0
       strip-ansi: 7.2.0
 
   string_decoder@1.3.0:
@@ -9616,6 +9840,8 @@ snapshots:
 
   symbol-tree@3.2.4: {}
 
+  tagged-tag@1.0.0: {}
+
   tapable@2.3.3: {}
 
   tar@7.5.22:
@@ -9627,6 +9853,8 @@ snapshots:
       yallist: 5.0.0
 
   term-size@2.2.1: {}
+
+  terminal-size@4.0.1: {}
 
   terser@5.49.0:
     dependencies:
@@ -9733,6 +9961,10 @@ snapshots:
   type-fest@0.21.3: {}
 
   type-fest@1.4.0: {}
+
+  type-fest@5.8.0:
+    dependencies:
+      tagged-tag: 1.0.0
 
   type-is@1.6.18:
     dependencies:
@@ -10013,7 +10245,17 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  widest-line@6.0.0:
+    dependencies:
+      string-width: 8.2.2
+
   word-wrap@1.2.5: {}
+
+  wrap-ansi@10.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 8.2.2
+      strip-ansi: 7.2.0
 
   wrap-ansi@6.2.0:
     dependencies:
@@ -10092,6 +10334,8 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yoctocolors-cjs@2.1.3: {}
+
+  yoga-layout@3.2.1: {}
 
   zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:


### PR DESCRIPTION
## Summary
- Replace the relay CLI's six print-and-go-silent startup lines with a live [Ink](https://github.com/vadimdemedes/ink) dashboard: relay URL (incl. LAN address for phones), tower/BLE state, decoded drum/LED/audio state, connected clients, and a scrolling activity feed.
- Adds a small colored connection-status indicator to the header, plus coloring throughout (tower state, client state, activity severity, counters).
- Keys: `q` quit, `r` resend last command, `l` toggle JSONL logging.
- Package flips to `"type": "module"` (Ink is ESM-only) — same pattern already used by `apps/mcp-server`. Nothing in the workspace imports `ultimatedarktowerrelay-cli`, so this isn't a breaking change for any workspace consumer.
- Dashboard only mounts when both stdout and stdin are a real terminal; `RELAY_DASHBOARD=0` forces the previous plain-line output. Piped/Docker/systemd usage is unaffected.
- Docs updated: `apps/relay-cli/README.md`, `CLAUDE.md`, `docs/relay/SETUP.md`, `TROUBLESHOOTING.md`, `docs/local-development.md`, and the player-facing `connecting-the-official-app.html` walkthrough (which previously told players the relay "stays quiet" on browser connect — now points at the CLIENTS panel instead).
- Changeset included (`ultimatedarktowerrelay-cli`, minor) — `CHANGELOG.md` is Changesets-generated, so it isn't hand-edited here; it'll be produced by the automated Version Packages PR.

## Test plan
- [x] `pnpm run ci` (validate:nodes → lint → format:check → build → typecheck → test) passes clean across all workspaces
- [x] `apps/relay-cli` unit tests for the pure formatting helpers (`format.test.ts`, 9 tests)
- [x] Manually verified under a real pty (`script`): dashboard renders, colors render with `TERM` set, `q` and Ctrl-C both unmount cleanly and exit 0
- [x] Verified non-TTY fallback (piped, `/dev/null` stdin, `RELAY_DASHBOARD=0`) falls back to plain output with no raw-mode crash, including the asymmetric stdout-TTY/stdin-non-TTY edge case
- [x] Verified `l` (toggle logging) and `r` (resend) keys don't crash and toggle state correctly