### PR TITLE
feat(digital): auto-place starting skulls in the New Game wizard

### DIFF
--- a/apps/digital/src/app/App.css
+++ b/apps/digital/src/app/App.css
@@ -627,6 +627,14 @@ label {
   grid-template-columns: 1fr 1fr;
   gap: 0.5rem;
 }
+.wizard-checkbox {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.4rem;
+}
+.wizard-checkbox input {
+  width: auto;
+}
 .wizard-actions {
   display: flex;
   align-items: center;

--- a/apps/digital/src/features/session/NewGameWizard.tsx
+++ b/apps/digital/src/features/session/NewGameWizard.tsx
@@ -172,6 +172,15 @@ export function NewGameWizard({ onClose }: { onClose: () => void }) {
             </label>
           </div>
 
+          <label className="wizard-checkbox">
+            <input
+              type="checkbox"
+              checked={config.autoPlaceSkulls}
+              onChange={(e) => setConfig((c) => ({ ...c, autoPlaceSkulls: e.target.checked }))}
+            />
+            <span>Auto-place starting skulls (2 on each Sanctuary &amp; Village)</span>
+          </label>
+
           <h3>Heroes</h3>
           {config.heroes.map((h, i) => (
             <div className="wizard-hero" key={i}>

--- a/apps/digital/src/session/factory.ts
+++ b/apps/digital/src/session/factory.ts
@@ -4,7 +4,7 @@
  */
 import { createDefaultTowerState } from 'ultimatedarktower';
 import { BOARD_LOCATIONS } from '@/lib/udtData';
-import { createDefaultBoardState } from 'ultimatedarktowerboard';
+import { createDefaultBoardState, skullTokenId } from 'ultimatedarktowerboard';
 import { HERO_VIRTUE_COUNT } from './playerBoard';
 import {
   GAME_SESSION_SCHEMA_VERSION,
@@ -39,8 +39,12 @@ export function createDefaultConfig(): GameConfig {
     adversary: null,
     foes: { level2: null, level3: null, level4: null },
     mainGoal: '',
+    autoPlaceSkulls: true,
   };
 }
+
+/** Starting skull count on each Sanctuary/Village (official-app setup, mirrored by hand). */
+export const STARTING_SKULLS_PER_SANCTUARY_VILLAGE = 2;
 
 export function createDefaultProgress(): GameProgress {
   return { month: 1, turn: 1, dismissedReminders: [] };
@@ -104,6 +108,16 @@ export function createNewGameSession(config: GameConfig, name?: string): GameSes
         location,
         data: { owner: h.homeKingdom },
       };
+    }
+  }
+  // `!== false` (not a truthy check): a pre-feature save has no `autoPlaceSkulls` key at
+  // all, and `resetSession` rebuilds from that same stored config — undefined should still
+  // default on, matching the wizard's "checked by default" behavior for a fresh game.
+  if (config.autoPlaceSkulls !== false) {
+    for (const l of BOARD_LOCATIONS) {
+      if (l.building === 'Sanctuary' || l.building === 'Village') {
+        board.tokens[skullTokenId(l.name)].n = STARTING_SKULLS_PER_SANCTUARY_VILLAGE;
+      }
     }
   }
   return {

--- a/apps/digital/src/session/session.test.ts
+++ b/apps/digital/src/session/session.test.ts
@@ -44,6 +44,32 @@ describe('createNewGameSession', () => {
     });
     expect(session.tower.state.drum.every((d) => d.calibrated)).toBe(true);
   });
+
+  const SANCTUARIES_AND_VILLAGES = [
+    'Upper Ice Fangs',
+    "Egan's End",
+    'Greater Tombstones',
+    'Duwani',
+    'Arkartus',
+    'Anza',
+    'Sands of Madness',
+    'Southern Wastes',
+  ];
+
+  it('auto-places 2 starting skulls on each Sanctuary/Village by default', () => {
+    const session = createNewGameSession(sampleConfig());
+    for (const location of SANCTUARIES_AND_VILLAGES) {
+      expect(skullsAt(session.board, location)).toBe(2);
+    }
+    expect(skullsAt(session.board, 'Radiant Mountains')).toBe(0); // a Citadel, not seeded
+  });
+
+  it('skips auto-placement when autoPlaceSkulls is false', () => {
+    const session = createNewGameSession({ ...sampleConfig(), autoPlaceSkulls: false });
+    for (const location of SANCTUARIES_AND_VILLAGES) {
+      expect(skullsAt(session.board, location)).toBe(0);
+    }
+  });
 });
 
 describe('serialize / deserialize', () => {

--- a/apps/digital/src/session/types.ts
+++ b/apps/digital/src/session/types.ts
@@ -41,6 +41,8 @@ export interface GameConfig {
   mainGoal: string;
   /** Optional official seed; if present it pre-fills the rest at setup time. */
   seed?: string;
+  /** Auto-place the official app's starting skulls (2 on each Sanctuary/Village) at setup. */
+  autoPlaceSkulls: boolean;
 }
 
 /** Where the game is in the 6-month cadence + UI progress markers. */


### PR DESCRIPTION
## Summary
- The official companion app's first setup instruction is to place 2 skulls on each Sanctuary and each Village (8 locations, 16 skulls) before play starts. Digital's New Game wizard mirrors the rest of official-app setup by hand, so it should mirror this step too.
- Adds a checkbox to the wizard, **checked by default**, that auto-places these starting skulls when a new game is created — no more clicking through the board palette/inspector 16 times.
- New `GameConfig.autoPlaceSkulls` field; `createNewGameSession()` sets `n: 2` on the pre-seeded skull token at each Sanctuary/Village when the flag is on. Read as `!== false` (not a plain truthy check) so a game session saved before this field existed still defaults to "on" if the player later hits Reset Game.

## Test plan
- [x] `pnpm --filter ultimatedarktowerdigital ci` (lint, typecheck, test, build) passes
- [x] New unit tests in `session.test.ts`: default config places 2 skulls at all 4 Sanctuaries + 4 Villages (and 0 elsewhere, e.g. Citadels); `autoPlaceSkulls: false` places none
- [ ] Manual: open the New Game wizard, confirm the checkbox is present and checked by default, start a game, confirm the board inspector shows 2 skulls on each of the 8 Sanctuary/Village locations