### PR TITLE
feat(digital): drop a physics skull in the 3D tower

### DIFF
--- a/.changeset/digital-auto-place-starting-skulls.md
+++ b/.changeset/digital-auto-place-starting-skulls.md
@@ -1,0 +1,10 @@
+---
+'ultimatedarktowerdigital': minor
+---
+
+The New Game wizard now has a checkbox (checked by default) that auto-places
+the official app's first setup instruction — 2 skulls on each Sanctuary and
+Village — instead of requiring 16 manual clicks through the board
+palette/inspector.
+
+Backfilled changeset — this shipped in #70 without one.

--- a/.changeset/digital-companion-app-bridge.md
+++ b/.changeset/digital-companion-app-bridge.md
@@ -1,0 +1,16 @@
+---
+'ultimatedarktowerdigital': minor
+---
+
+Add the relay bridge (PRD-05): `BridgeTowerSource` wraps `ManualTowerSource`
+and consumes a relay host's decoded command stream, so Restoration Games'
+official companion app can drive the tower while UTDD renders it. Skull drops
+are reported back for the host to synthesize. Disconnected, every call falls
+through to the manual source and UTDD behaves exactly as before. The first
+Connect from the deployed build is expected to fail once — Chrome's Local
+Network Access permission gates a public origin reaching loopback and aborts
+the very request that raises the prompt, so `connect()` retries once, waiting
+on the permission rather than guessing a delay.
+
+Backfilled changeset — this shipped without one; only its `relay-shared`/
+`relay-client` ESM-sidecar dependency got a changeset at the time.

--- a/.changeset/digital-foe-threat-per-level.md
+++ b/.changeset/digital-foe-threat-per-level.md
@@ -1,0 +1,14 @@
+---
+'ultimatedarktowerdigital': minor
+---
+
+Foe threat status is now set per level (2-4), not per placed foe instance,
+matching how Return to Dark Tower actually applies it — every placed foe of a
+level advances together. The placement palette and inspector share one status
+control per level, stored in `BoardState.meta.levelStatus` so it persists
+whether or not anything of that level is currently placed (e.g. to reflect the
+official app's own status announcements) and cascades to every placed foe of
+that level on change. Level rows show the game's actual configured foe name
+(e.g. "Brigands") once setup has assigned one, instead of a bare "Level N".
+
+Backfilled changeset — this shipped in #68 without one.

--- a/.changeset/digital-skull-physics-drop.md
+++ b/.changeset/digital-skull-physics-drop.md
@@ -1,0 +1,13 @@
+---
+'ultimatedarktowerdigital': minor
+---
+
+Drop skull now also spawns a physics-driven skull in the 3D tower
+(`ultimatedarktowerdisplay/physics`), the same simulation the display
+package's own demo uses, instead of only bumping the counter and (when
+bridged) notifying the relay. The skull count driving it comes from the
+tower source's own counter, not `TowerState.beam.count`, so it stays correct
+whether or not the official companion app is connected. Skulls already
+dropped replay into the 3D scene whenever it (re)attaches — enabling the 3D
+tower, popping the board out to a separate window, or loading a saved
+session.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -84,6 +84,18 @@ Publication is driven **purely by each package's `private` flag** —
 `.changeset/config.json` has an empty `ignore` list. So `private: false` opts a
 package in automatically (`apps/mcp-server` is the only app that does).
 
+**`private: true` packages still get changesets — they just don't publish to
+npm.** The empty `ignore` list means `pnpm changeset:version` bumps _every_
+workspace package with a pending changeset, private or not, and writes its
+`CHANGELOG.md` entry; only the separate `npm publish` step skips `private:
+true`. So a `private` app (`apps/digital`, `apps/controller`, `apps/game`, …)
+still needs a changeset for its own user-facing changes — that's the only way
+its `CHANGELOG.md` records anything beyond dependency-bump ripples. Confirmed
+gap: three `apps/digital`-only features (foe threat status per-level, #68;
+auto-place starting skulls, #70; the PRD-05 companion-app bridge) shipped with
+no changeset and left no trace in its changelog — see
+`.changeset/digital-skull-physics-drop.md` and its neighbors for the backfill.
+
 #### A failed publish reports the wrong error — read this before debugging one
 
 **Changesets masks npm's rejection with a TypeError.** When `npm publish` fails,
@@ -223,5 +235,7 @@ ultimatedarktowerrelay-electron rebuild` — `pnpm run ci` skips it (no `build`
 ## Before committing
 
 Run `pnpm run ci` from the root. Add a changeset (`pnpm changeset`) for any
-change to a published package. This project drives hardware — cover edge cases
-and prefer the mock adapter for automated tests.
+user-facing change to **any** workspace package — private apps included (see
+[Releasing](#releasing-changesets)); "published" only decides whether the
+change also reaches npm, not whether it gets a changeset. This project drives
+hardware — cover edge cases and prefer the mock adapter for automated tests.

--- a/apps/digital/CLAUDE.md
+++ b/apps/digital/CLAUDE.md
@@ -29,6 +29,10 @@ Three traps worth remembering:
 - **Don't derive the skull count from `TowerState.beam.count` while connected.** Every command the
   app writes carries its own beam count (bytes 15-16), so remote state clobbers it on the next
   command. `BridgeTowerSource` keeps its own counter; `BridgeTowerSource.test.ts` guards this.
+  `TowerBoardStage`'s skull-physics sync (`src/lib/skullSync.ts`) reads
+  `towerSource.getSkullDropCount()` for the same reason — never wire the physics lib's own
+  `skull.autoDropOnSkullCountIncrease` (which watches `beam.count`) here, it won't fire while
+  bridged and can fire spuriously off remote state.
 - **`ultimatedarktowerrelay-client` / `-shared` resolve via their `import` condition**, added in
   the PRD-05 pass — both were CJS-only and `relay-shared`'s barrel emits `__exportStar`. They are
   deliberately **not** in `vite.config.ts`'s `optimizeDeps.include`; the export condition is
@@ -56,10 +60,22 @@ this app, including the React rules — `eslint.config.js` scopes them to
 
 Standard Vite scripts; `build` = `tsc -b && vite build`; `test` = `vitest run` (tests colocated
 under `src/`). `vite.config.ts`'s `optimizeDeps.include` pre-bundles the linked
-`ultimatedarktowerdisplay`/`ultimatedarktowerboard` workspace libs so their `file:` links
+`ultimatedarktowerdisplay`/`ultimatedarktowerboard` workspace libs (plus the
+`ultimatedarktowerdisplay/physics` subpath, for skull physics) so their `file:` links
 resolve cleanly in dev. `ultimatedarktower` is deliberately _not_ listed there: since core
 v7.0.0 it ships a `browser` export condition (`dist/browser/index.mjs`, no `createRequire`/
 noble banner) that Vite resolves directly.
+
+## Skull physics: re-attach by `Tower3DView` identity, not once
+
+`TowerBoardStage` drops a real physics skull (`ultimatedarktowerdisplay/physics`'s
+`attachSkullPhysics`) into the 3D scene on every tower-source skull drop, mirroring the
+display demo. The attach is **not** a one-shot done in `onTowerToggle` — the board stage's
+always-visible Pop Out button rebuilds the whole `Tower3DView` behind the scenes
+(`BoardStageView`'s `create3D`/`dispose3D`), which detaches every previously-registered scene
+plugin. `ensurePhysics()` in `TowerBoardStage.tsx` re-attaches lazily, keyed on view identity,
+on the next tower paint — don't cache the `SkullPhysicsHandle` across a pop-out/pop-in without
+that identity check, it'll go silently dead.
 
 ## `localStorage` in tests needs `src/test/setup.ts`
 

--- a/apps/digital/src/lib/TowerBoardStage.tsx
+++ b/apps/digital/src/lib/TowerBoardStage.tsx
@@ -13,10 +13,17 @@
 import { useEffect, useRef } from 'react';
 import { BoardStageView } from 'ultimatedarktowerboard/stage';
 import type { TowerState } from 'ultimatedarktower';
+import type { Tower3DView } from 'ultimatedarktowerdisplay';
+import type { PhysicsConfig, SkullPhysicsHandle } from 'ultimatedarktowerdisplay/physics';
 import { ManualBoardSource } from '@/sources/ManualBoardSource';
 import { useGameStore } from '@/state/gameStore';
+import { syncSkulls } from './skullSync';
 
 const BASE = import.meta.env.BASE_URL; // ends with '/'
+
+const PHYSICS_CONFIG = {
+  skull: { modelUrl: `${BASE}assets/tokens/markers/skull.glb`, colliderShape: 'hull' },
+} as const satisfies PhysicsConfig;
 
 export interface TowerBoardStageProps {
   /** Called once the stage instance exists (e.g. to drive the tower view in PRD-01). */
@@ -34,6 +41,44 @@ export function TowerBoardStage({ onReady, className }: TowerBoardStageProps) {
 
     const towerSource = useGameStore.getState().towerSource;
 
+    // Skull physics is attached lazily, keyed on whichever `Tower3DView` is
+    // currently live. Pop Out / Pop In rebuilds the 3D view behind the scenes
+    // (see BoardStageView's create3D/dispose3D), which detaches any
+    // previously-attached scene plugin — so this re-attaches by view identity
+    // on the next tower paint rather than attaching once and going stale.
+    let physics: SkullPhysicsHandle | null = null;
+    let physicsView: Tower3DView | null = null;
+    let prevSkulls = 0;
+    let attaching = false;
+
+    const ensurePhysics = async (): Promise<void> => {
+      const view = stageRef.current?.tower3D?.view3D ?? null;
+      if (!view) {
+        physics?.dispose();
+        physics = null;
+        physicsView = null;
+        return;
+      }
+      if (view === physicsView || attaching) return;
+      attaching = true;
+      try {
+        // Dynamic: a static import would pull Display + the physics module into
+        // the main bundle and defeat the lazy 3D chunk BoardStageView exists to
+        // preserve. (Rapier itself is dynamic-imported inside PhysicsManager
+        // .init() either way.)
+        const { attachSkullPhysics } = await import('ultimatedarktowerdisplay/physics');
+        const live = stageRef.current?.tower3D?.view3D ?? null; // may have changed mid-await
+        if (!live) return;
+        physics?.dispose();
+        physics = attachSkullPhysics(live, PHYSICS_CONFIG);
+        physicsView = live;
+        prevSkulls = 0; // fresh scene — replay every skull dropped so far
+        prevSkulls = syncSkulls(physics, prevSkulls, towerSource.getSkullDropCount());
+      } finally {
+        attaching = false;
+      }
+    };
+
     const stage = new BoardStageView({
       container,
       assetBaseUrl: `${BASE}assets/tokens/`,
@@ -42,10 +87,12 @@ export function TowerBoardStage({ onReady, className }: TowerBoardStageProps) {
       editingUI: false,
       // The 3D tower loads lazily; once it's on, paint the current state into it.
       onTowerToggle: (enabled) => {
-        if (!enabled) return;
-        const view = stageRef.current?.tower3D;
-        view?.applyState(towerSource.getState(), true);
-        view?.applySeals(towerSource.getBrokenSeals());
+        if (enabled) {
+          const view = stageRef.current?.tower3D;
+          view?.applyState(towerSource.getState(), true);
+          view?.applySeals(towerSource.getBrokenSeals());
+        }
+        void ensurePhysics();
       },
     });
     stageRef.current = stage;
@@ -56,6 +103,11 @@ export function TowerBoardStage({ onReady, className }: TowerBoardStageProps) {
       if (!view) return;
       view.applyState(state);
       view.applySeals(towerSource.getBrokenSeals());
+
+      void ensurePhysics(); // no-op once bound to this view; self-heals after a pop-out
+      if (physics && physicsView === view.view3D) {
+        prevSkulls = syncSkulls(physics, prevSkulls, towerSource.getSkullDropCount());
+      }
     };
 
     const boardSource = new ManualBoardSource(stage.controller);
@@ -69,6 +121,7 @@ export function TowerBoardStage({ onReady, className }: TowerBoardStageProps) {
     return () => {
       towerUnsub();
       useGameStore.getState().unregisterBoard();
+      physics?.dispose();
       stage.dispose();
       stageRef.current = null;
     };

--- a/apps/digital/src/lib/skullSync.test.ts
+++ b/apps/digital/src/lib/skullSync.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest';
+import { syncSkulls } from './skullSync';
+
+function fakeHandle() {
+  return { dropSkull: vi.fn(), clearSkulls: vi.fn() };
+}
+
+describe('syncSkulls', () => {
+  it('drops one skull per increment', () => {
+    const handle = fakeHandle();
+    const prev = syncSkulls(handle, 0, 3);
+    expect(prev).toBe(3);
+    expect(handle.dropSkull).toHaveBeenCalledTimes(3);
+    expect(handle.clearSkulls).not.toHaveBeenCalled();
+  });
+
+  it('drops only the delta on a further increment', () => {
+    const handle = fakeHandle();
+    const prev = syncSkulls(handle, 3, 4);
+    expect(prev).toBe(4);
+    expect(handle.dropSkull).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears and drops nothing when the count resets to zero', () => {
+    const handle = fakeHandle();
+    const prev = syncSkulls(handle, 4, 0);
+    expect(prev).toBe(0);
+    expect(handle.clearSkulls).toHaveBeenCalledTimes(1);
+    expect(handle.dropSkull).not.toHaveBeenCalled();
+  });
+
+  it('clears and replays from zero when the count decreases but is nonzero', () => {
+    const handle = fakeHandle();
+    const prev = syncSkulls(handle, 4, 2);
+    expect(prev).toBe(2);
+    expect(handle.clearSkulls).toHaveBeenCalledTimes(1);
+    expect(handle.dropSkull).toHaveBeenCalledTimes(2);
+  });
+
+  it('does nothing when the count is unchanged', () => {
+    const handle = fakeHandle();
+    const prev = syncSkulls(handle, 3, 3);
+    expect(prev).toBe(3);
+    expect(handle.dropSkull).not.toHaveBeenCalled();
+    expect(handle.clearSkulls).not.toHaveBeenCalled();
+  });
+});

--- a/apps/digital/src/lib/skullSync.ts
+++ b/apps/digital/src/lib/skullSync.ts
@@ -1,0 +1,18 @@
+import type { SkullPhysicsHandle } from 'ultimatedarktowerdisplay/physics';
+
+/**
+ * Reconcile the 3D scene's skulls to `next` drops. Returns the new "previous"
+ * count. A decrease (new game / session reset) clears and replays from zero.
+ */
+export function syncSkulls(
+  handle: Pick<SkullPhysicsHandle, 'dropSkull' | 'clearSkulls'>,
+  prev: number,
+  next: number,
+): number {
+  if (next < prev) {
+    handle.clearSkulls();
+    prev = 0;
+  }
+  for (let i = prev; i < next; i++) handle.dropSkull();
+  return next;
+}

--- a/apps/digital/vite.config.ts
+++ b/apps/digital/vite.config.ts
@@ -27,7 +27,11 @@ export default defineConfig({
     // no longer needs listing here: since v7.0.0 it ships a `browser` export condition
     // (dist/browser/index.mjs) with no `createRequire`/noble banner, so Vite resolves a
     // browser-safe entry directly.
-    include: ['ultimatedarktowerdisplay', 'ultimatedarktowerboard'],
+    include: [
+      'ultimatedarktowerdisplay',
+      'ultimatedarktowerdisplay/physics',
+      'ultimatedarktowerboard',
+    ],
   },
   test: {
     environment: 'jsdom',


### PR DESCRIPTION
## Summary
- Clicking **Drop skull** now also spawns a real Rapier physics skull in digital's 3D tower (`ultimatedarktowerdisplay/physics`'s `attachSkullPhysics`), mirroring what the display package's demo does — in addition to the existing counter bump and relay `dropSkull` message, both unchanged.
- The attach is lazy and keyed on `Tower3DView` identity rather than a one-shot: the board stage's always-visible **Pop Out** button rebuilds the 3D view behind the scenes and detaches any previously-registered scene plugin, so a naive one-shot attach would go silently dead after a pop-out/pop-in. `ensurePhysics()` re-attaches on the next tower paint instead.
- Skull count is driven off `towerSource.getSkullDropCount()`, not `TowerState.beam.count` — the physics lib's own `skull.autoDropOnSkullCountIncrease` watches `beam.count`, which `BridgeTowerSource` deliberately leaves untouched while connected (every app command carries its own beam count), so that hook would never fire while bridged.
- No BLE command exists to drop a skull into the *physical* tower — the hardware only reports drops. This is the 3D-simulation equivalent, same as the display demo.

## Changes
- `apps/digital/src/lib/skullSync.ts` (new) — delta→drops reconciler (`dropSkull()`/`clearSkulls()`), unit tested without WebGL.
- `apps/digital/src/lib/TowerBoardStage.tsx` — dynamic-imports the physics subpath, attaches/re-attaches by view identity, syncs skull count on every tower-state emit, disposes on unmount.
- `apps/digital/vite.config.ts` — added `ultimatedarktowerdisplay/physics` to `optimizeDeps.include`.
- `apps/digital/CLAUDE.md` — documented the `beam.count` trap's second consumer and the re-attach-by-identity requirement.
- `apps/digital/src/lib/skullSync.test.ts` (new) — 5 cases: increment, delta, reset-to-zero, decrease-then-replay, no-op.

No changeset: `apps/digital` is `private: true` and isn't part of the release flow.

## Test plan
- [x] `pnpm --filter ultimatedarktowerdigital test` — 107/107 passing (incl. new `skullSync` cases)
- [x] `pnpm --filter ultimatedarktowerdigital typecheck` / `lint` / `build` — clean; build output confirms `physics.esm` + `rapier` land in their own lazy chunks, not the main bundle
- [x] Root `pnpm lint` / `pnpm format:check` — clean (one pre-existing, unrelated warning)
- [x] Manually verified in the browser: 3D tower on, Drop skull → skull falls and settles; repeat clicks add more; Pop Out → Pop In → drop still works and replays prior skulls