### PR TITLE
feat(codex): add the Tower Codex — a browsable reference for all game data

### DIFF
--- a/.changeset/codex-game-data-browser.md
+++ b/.changeset/codex-game-data-browser.md
@@ -1,0 +1,26 @@
+---
+'ultimatedarktowercodex': minor
+---
+
+New app: **Tower Codex** — a browsable reference for everything
+`ultimatedarktowerdata` exports.
+
+Twenty-eight datasets, ~1,300 records: the identity rosters, the full card layer
+imported in `55dfad3` (foe/monument/companion cards, treasures, potions and
+gear, corruptions, quest items, quests, spells, nations), all 78 dungeon rooms
+and 32 caravan rooms, the 60 board locations with their adjacency graph and 212
+token spots, the flattened box inventory, the tower's 113 audio cues and light
+sequences, and the seed encoding tables.
+
+Each dataset gets a sortable table and a card view; records cross-link on the
+shared kebab-case ids — a foe reaches its printed card and its tower sound, a
+box component reaches the card that names it, a board location reaches its
+dungeon's room pool. Global search covers every record in one pass.
+
+Rows the source author could not fully observe are stamped `needs review` with
+their source note shown, and the home page reports the data's known gaps
+(6 flagged rows, 14 of 60 locations without an identified dungeon, 4 provisional
+Expeditions heroes) rather than leaving them buried in `open-questions.md`.
+
+A registry test asserts the app covers every export of `ultimatedarktowerdata`,
+so adding data there fails this app's tests until it is registered.

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -66,6 +66,7 @@ jobs:
           vbuild "@udtc/player"                player
           vbuild "ultimatedarktowerdigital"    digital
           vbuild "ultimatedarktowerseed"       seed
+          vbuild "ultimatedarktowercodex"      codex
           vbuild "@dark-tower-sync/client"     sync
           vbuild "ultimatedarktowercontroller" controller
           vbuild "ultimatedarktowergame"       game

--- a/apps/codex/CHANGELOG.md
+++ b/apps/codex/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/apps/codex/CLAUDE.md
+++ b/apps/codex/CLAUDE.md
@@ -1,0 +1,61 @@
+# apps/codex (`ultimatedarktowercodex`) — the game data browser
+
+A read-only React + Vite browser over every export of `ultimatedarktowerdata`.
+Deployed to `/UltimateDarkTower/codex/`; dev server on **3006**.
+
+## The registry is the app
+
+`src/datasets.ts` declares all 28 datasets — rows, key, columns, facets,
+cross-links. Every view is generic over an entry there, so **adding a dataset is
+a data edit, never a component**. Resist adding per-dataset render config:
+`render.tsx`'s `<Fields>` walks `Object.entries()` and already handles strings,
+string arrays, numbers and one level of nesting, which covers every shape the
+package exports. The one exception is the optional `title` (box components label
+themselves with `type`, not `name`).
+
+## `src/datasets.test.ts` fails when game-data grows
+
+Each entry's `exports` array names the game-data exports it covers, and the test
+asserts that union equals the package's whole export surface (minus a named list
+of interactive helpers). **Add an export to `packages/game-data` and this app's
+tests go red until it is registered.** That is deliberate — it is the only thing
+keeping the Codex a complete view. The test also checks every key is unique and
+URL-safe and that every `related()` link resolves.
+
+## Traps
+
+- **Vite does not watch `packages/game-data/dist/`.** It is a symlink to built
+  output, so editing game-data source shows nothing until
+  `pnpm --filter ultimatedarktowerdata build`. `predev`/`pretest` cover a cold
+  start, not a mid-session edit. This bites here more than anywhere else in the
+  repo, because reviewing that data is the whole point of the app.
+- **Never `.sort()` a `dataset.rows` array in place.** game-data's arrays are
+  `readonly` to TypeScript but _not frozen at runtime_, so an in-place sort would
+  reorder the data for every other consumer in the tab. `asRows()` copies the
+  array defensively and `sortRows()` returns a copy; keep it that way.
+- **Composite keys go through `safeKey()`.** `#` would terminate the hash route
+  and `/` would fake a path segment — and real data hits this: box categories
+  include `"Manuals / Sheets"`.
+- **Do not add `optimizeDeps.include` or a CJS alias for `ultimatedarktowerdata`.**
+  It ships an `import` condition pointing at a real ESM bundle. If you see "does
+  not provide an export named …", rebuild game-data — don't edit the vite config.
+  See `packages/game-data/CLAUDE.md`.
+
+## Styling: deliberately not a UDT app
+
+The other apps wear the tower's slate and crimson. This one is a reading room —
+warm paper, botanical green, records as library catalog cards. `index.css` is the
+whole design, and **every colour is a token**; that is what keeps night mode a
+short override rather than a second stylesheet.
+
+`@udtc/theme/theme.css` is **not** imported (it _is_ the tower palette). Only its
+`useTheme` store is reused, for the `udtc-theme` localStorage key and the
+`data-theme` contract that the FOUC script in `index.html` also depends on. Its
+`<ThemeToggle>` is not reused either — it colours itself with inline styles bound
+to `--c-*` tokens, which no stylesheet can override, so `App.tsx` has a small
+replacement.
+
+## Tests
+
+`environment: 'node'` — the only suite is a pure data check, so there is no
+`jsdom` devDep. Add one with the first component test.

--- a/apps/codex/README.md
+++ b/apps/codex/README.md
@@ -1,0 +1,76 @@
+<h1 align="center">Tower Codex</h1>
+
+<p align="center">
+  Browse the whole <em>Return to Dark Tower</em> reference — every printed card face, the board, the rosters, the box contents — searchable and cross-linked.
+</p>
+
+---
+
+## What this is
+
+A read-only browser over
+[`ultimatedarktowerdata`](../../packages/game-data). Twenty-eight datasets, roughly
+1,300 records, presented as a sortable table or a grid of catalog cards, with a
+detail view for every record.
+
+It reads the package directly, so it is never a copy that drifts.
+
+**Live:** https://chessmess.github.io/UltimateDarkTower/codex/
+
+## Why it exists
+
+The card layer — every printed card face, imported from research spreadsheets —
+had no consumer anywhere in the monorepo. Several thousand lines of transcribed
+card text had never been looked at by eye. This app is where you look at it.
+
+It is also honest about the data's gaps. Rows the source author could not fully
+observe carry `needsReview` and a source note; the Codex stamps them and shows
+the note, and the home page counts them alongside the board locations with no
+identified dungeon and the provisional Expeditions heroes.
+
+## Running it
+
+From the repo root:
+
+```bash
+pnpm run dev:codex        # http://localhost:3006
+```
+
+`predev` builds `ultimatedarktowerdata` first, so a fresh clone works without a
+separate library build.
+
+**Editing game data while the dev server runs?** Vite watches this app's source,
+not the symlinked `packages/game-data/dist/`. Rebuild it to see your change:
+
+```bash
+pnpm --filter ultimatedarktowerdata build
+```
+
+## How it is put together
+
+Everything hangs off [`src/datasets.ts`](src/datasets.ts) — a registry declaring,
+per dataset, its rows, key, columns, facets and cross-links. Every view is a
+generic renderer over an entry there, so adding a dataset is a data edit, never a
+component. There is no per-dataset render config: `render.tsx`'s `<Fields>` walks
+`Object.entries()` and handles every shape the package exports.
+
+| File          | What it does                                          |
+| ------------- | ----------------------------------------------------- |
+| `datasets.ts` | The registry. The only real logic.                    |
+| `App.tsx`     | Hash routing, the shelf sidebar, home, global search. |
+| `views.tsx`   | Sortable table, card grid, facet chips.               |
+| `render.tsx`  | The generic record renderer, badges, detail view.     |
+| `search.ts`   | Substring search, faceting, sorting.                  |
+| `index.css`   | The whole visual design.                              |
+
+`src/datasets.test.ts` asserts the registry covers every export of
+`ultimatedarktowerdata`. Add an export there and this app's tests fail until it
+is registered — the Codex cannot silently stop being a complete view.
+
+## Notes
+
+- The **Seed Decoder** link in the sidebar resolves on the deployed site, where
+  both apps sit under the same base path. It 404s in local dev, since that app
+  runs on its own port.
+- Fonts come from Google Fonts (Fraunces, Karla, DM Mono). With them blocked the
+  app still reads correctly — every family has a system fallback stack.

--- a/apps/codex/index.html
+++ b/apps/codex/index.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tower Codex</title>
+    <meta
+      name="description"
+      content="Browse every card, foe, board location and box component in Return to Dark Tower."
+    />
+    <script>
+      // Apply the stored theme before first paint so there is no light flash on a dark reload.
+      // The key must stay in sync with packages/creator-theme/src/useTheme.ts.
+      (function () {
+        var t = localStorage.getItem('udtc-theme');
+        if (t === 'light' || t === 'dark') document.documentElement.setAttribute('data-theme', t);
+      })();
+    </script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght,SOFT,WONK@9..144,400..700,0..100,0..1&family=Karla:wght@400..700&family=DM+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/codex/package.json
+++ b/apps/codex/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "ultimatedarktowercodex",
+  "version": "0.1.0",
+  "description": "Browsable reference for every Return to Dark Tower card, foe, location and box component in ultimatedarktowerdata.",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "predev": "pnpm --filter ultimatedarktowerdata build",
+    "dev": "trap 'exit 0' INT TERM; vite",
+    "dev:codex": "pnpm run dev",
+    "build": "tsc --build && vite build",
+    "preview": "trap 'exit 0' INT TERM; vite preview",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --build",
+    "lint": "eslint .",
+    "pretest": "pnpm --filter ultimatedarktowerdata build",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "ci": "pnpm lint && pnpm typecheck && pnpm test && pnpm build"
+  },
+  "dependencies": {
+    "@udtc/theme": "workspace:*",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "ultimatedarktowerdata": "workspace:^"
+  },
+  "devDependencies": {
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "@vitejs/plugin-react": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:",
+    "vitest": "catalog:"
+  },
+  "engines": {
+    "node": ">=22.13.0"
+  },
+  "author": "ChessMess",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ChessMess/UltimateDarkTower.git",
+    "directory": "apps/codex"
+  }
+}

--- a/apps/codex/src/App.tsx
+++ b/apps/codex/src/App.tsx
@@ -1,0 +1,377 @@
+import { useCallback, useEffect, useMemo, useSyncExternalStore } from 'react';
+import { useTheme, type ThemeMode } from '@udtc/theme';
+import { DATASETS, DATASET_BY_ID, GROUP_ORDER, TOTAL_ROWS, type Dataset } from './datasets';
+import { Detail, Badges } from './render';
+import { DatasetView, type View } from './views';
+import { parseFacets, searchAll, serializeFacets, titleOf, type Facets } from './search';
+
+const REPO = 'https://github.com/ChessMess/UltimateDarkTower';
+
+// ── routing ────────────────────────────────────────────────────────────────────────────────────
+
+/**
+ * The URL is the only source of truth for what's on screen — dataset, record, search text, facets
+ * and view mode all live in the hash. Nothing is mirrored into component state, so there is no
+ * sync effect to get wrong, and every view is deep-linkable.
+ *
+ * Search text and facets are written with `replaceState` so typing doesn't push a history entry per
+ * keystroke. `replaceState` doesn't fire `hashchange`, so this store publishes its own event.
+ */
+const HASH_EVENT = 'codex:navigate';
+
+function subscribeHash(cb: () => void) {
+  window.addEventListener('hashchange', cb);
+  window.addEventListener(HASH_EVENT, cb);
+  return () => {
+    window.removeEventListener('hashchange', cb);
+    window.removeEventListener(HASH_EVENT, cb);
+  };
+}
+
+const getHash = () => window.location.hash;
+
+/** Change the view without adding to history. */
+function replaceHash(next: string) {
+  if (next === window.location.hash) return;
+  history.replaceState(null, '', next || '#/');
+  window.dispatchEvent(new Event(HASH_EVENT));
+}
+
+type Route = { datasetId: string; recordId?: string; query: string; facets: Facets; view?: View };
+
+function parseRoute(hash: string): Route {
+  const [path, search = ''] = hash.replace(/^#\/?/, '').split('?');
+  const [datasetId = '', recordId] = path.split('/');
+  const params = new URLSearchParams(search);
+  const view = params.get('view');
+  return {
+    datasetId: decodeURIComponent(datasetId),
+    recordId: recordId === undefined ? undefined : decodeURIComponent(recordId),
+    query: params.get('q') ?? '',
+    facets: parseFacets(params.getAll('f')),
+    view: view === 'cards' || view === 'table' ? view : undefined,
+  };
+}
+
+function buildHash(
+  datasetId: string,
+  query: string,
+  facets: Facets,
+  view: View,
+  dflt: View,
+): string {
+  const params = new URLSearchParams();
+  if (query) params.set('q', query);
+  for (const f of serializeFacets(facets)) params.append('f', f);
+  if (view !== dflt) params.set('view', view);
+  const qs = params.toString();
+  return `#/${datasetId}${qs ? `?${qs}` : ''}`;
+}
+
+// ── chrome ─────────────────────────────────────────────────────────────────────────────────────
+
+function ThemeToggle() {
+  // @udtc/theme's own <ThemeToggle> colours itself with inline styles bound to the tower palette's
+  // --c-* tokens, which no stylesheet can override. The store is what's worth reusing, not the skin.
+  const [mode, set] = useTheme();
+  const modes: [ThemeMode, string][] = [
+    ['system', 'Auto'],
+    ['light', 'Day'],
+    ['dark', 'Night'],
+  ];
+  return (
+    <div className="theme" role="group" aria-label="Colour theme">
+      {modes.map(([value, text]) => (
+        <button key={value} type="button" aria-pressed={mode === value} onClick={() => set(value)}>
+          {text}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function Sidebar({ activeId }: { activeId: string }) {
+  return (
+    <nav className="shelf" aria-label="Datasets">
+      {GROUP_ORDER.map((group) => {
+        const items = DATASETS.filter((d) => d.group === group);
+        if (items.length === 0) return null;
+        return (
+          <section key={group}>
+            <h2>{group}</h2>
+            <ul>
+              {items.map((d) => (
+                <li key={d.id}>
+                  <a href={`#/${d.id}`} aria-current={d.id === activeId ? 'page' : undefined}>
+                    <span className="shelf-name">{d.name}</span>
+                    <span className="shelf-count">{d.rows.length}</span>
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </section>
+        );
+      })}
+      <p className="shelf-foot">
+        Decoding a game seed? That lives in the{' '}
+        <a href="../seed/" className="out">
+          Seed Decoder
+        </a>
+        .
+      </p>
+    </nav>
+  );
+}
+
+// ── pages ──────────────────────────────────────────────────────────────────────────────────────
+
+/** Counted once from the registry, so these numbers can never drift from the data. */
+function useDataQuality() {
+  return useMemo(() => {
+    const flagged = DATASETS.flatMap((d) =>
+      d.rows.filter((r) => r.needsReview).map((r) => ({ d, r })),
+    );
+    const locations = DATASET_BY_ID.get('board-locations')!;
+    const noDungeon = locations.rows.filter((r) => !r.dungeon).length;
+    const heroes = DATASET_BY_ID.get('heroes')!;
+    const provisional = heroes.rows.filter((r) => r.source === 'expeditions').length;
+    return { flagged, noDungeon, locationTotal: locations.rows.length, provisional };
+  }, []);
+}
+
+function Home() {
+  const q = useDataQuality();
+  return (
+    <section className="home">
+      <header className="home-head">
+        <h2>The Return to Dark Tower reference, all of it.</h2>
+        <p>
+          {TOTAL_ROWS.toLocaleString()} records across {DATASETS.length} datasets — every printed
+          card face, the board, the rosters, the box contents and the tower&rsquo;s own byte tables.
+          Read straight from{' '}
+          <a href={`${REPO}/tree/main/packages/game-data`} className="out">
+            ultimatedarktowerdata
+          </a>
+          , so it is never a copy that drifts.
+        </p>
+      </header>
+
+      <div className="home-groups">
+        {GROUP_ORDER.map((group) => (
+          <section key={group}>
+            <h3>{group}</h3>
+            <ul>
+              {DATASETS.filter((d) => d.group === group).map((d) => (
+                <li key={d.id}>
+                  <a href={`#/${d.id}`}>
+                    {d.name}
+                    <span>{d.rows.length}</span>
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </section>
+        ))}
+      </div>
+
+      <aside className="quality">
+        <h3>Where the data is thin</h3>
+        <p>
+          This reference is honest about its gaps. Some of it was transcribed from play observation,
+          and rows nobody could fully see are flagged rather than guessed at.
+        </p>
+        <ul>
+          <li>
+            <strong>{q.flagged.length}</strong> rows need review
+            <span className="quality-detail">
+              {[...new Set(q.flagged.map((f) => f.d.name))].map((n) => {
+                const d = DATASETS.find((x) => x.name === n)!;
+                return (
+                  <a key={n} href={`#/${d.id}`}>
+                    {n}
+                  </a>
+                );
+              })}
+            </span>
+          </li>
+          <li>
+            <strong>{q.noDungeon}</strong> of {q.locationTotal} board locations have no identified
+            dungeon <a href="#/board-locations">Board locations</a>
+          </li>
+          <li>
+            <strong>{q.provisional}</strong> heroes are provisional Expeditions entries{' '}
+            <a href="#/heroes">Heroes</a>
+          </li>
+        </ul>
+        <p className="quality-foot">
+          <a href={`${REPO}/blob/main/packages/game-data/docs/open-questions.md`} className="out">
+            The full list of open questions
+          </a>
+        </p>
+      </aside>
+    </section>
+  );
+}
+
+function GlobalSearch({ query }: { query: string }) {
+  const hits = useMemo(() => searchAll(query), [query]);
+  const total = hits.reduce((n, h) => n + h.rows.length, 0);
+
+  if (!query.trim()) {
+    return (
+      <section className="results">
+        <p className="empty">Type to search all {TOTAL_ROWS.toLocaleString()} records.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="results">
+      <header className="dataset-head">
+        <h2>&ldquo;{query}&rdquo;</h2>
+        <p className="count">
+          {total} {total === 1 ? 'record' : 'records'} in {hits.length}{' '}
+          {hits.length === 1 ? 'dataset' : 'datasets'}
+        </p>
+      </header>
+      {hits.length === 0 ? <p className="empty">Nothing matches that.</p> : null}
+      {hits.map(({ dataset, rows }) => (
+        <div className="result-group" key={dataset.id}>
+          <h3>
+            <a href={`#/${dataset.id}`}>{dataset.name}</a>
+            <span>{rows.length}</span>
+          </h3>
+          <ul>
+            {rows.slice(0, 12).map((r) => (
+              <li key={dataset.key(r)}>
+                <a href={`#/${dataset.id}/${encodeURIComponent(dataset.key(r))}`}>
+                  {titleOf(dataset, r)}
+                  <Badges dataset={dataset} record={r} />
+                </a>
+              </li>
+            ))}
+            {rows.length > 12 ? (
+              <li className="more">
+                <a href={`#/${dataset.id}?q=${encodeURIComponent(query)}`}>
+                  +{rows.length - 12} more in {dataset.name}
+                </a>
+              </li>
+            ) : null}
+          </ul>
+        </div>
+      ))}
+    </section>
+  );
+}
+
+function NotFound({ dataset, recordId }: { dataset: Dataset; recordId: string }) {
+  return (
+    <section className="dataset">
+      <p className="empty">
+        No record <code>{recordId}</code> in {dataset.name}.{' '}
+        <a href={`#/${dataset.id}`}>Browse all {dataset.rows.length}</a>.
+      </p>
+    </section>
+  );
+}
+
+// ── app ────────────────────────────────────────────────────────────────────────────────────────
+
+export default function App() {
+  const hash = useSyncExternalStore(subscribeHash, getHash, getHash);
+  const route = useMemo(() => parseRoute(hash), [hash]);
+  const dataset = DATASET_BY_ID.get(route.datasetId);
+  const isSearch = route.datasetId === 'search';
+
+  // No mirrored state: query/facets/view are read straight off the route and written back to it.
+  const view: View = route.view ?? dataset?.view ?? 'table';
+  const dflt: View = dataset?.view ?? 'table';
+
+  const navigate = useCallback(
+    (query: string, facets: Facets, v: View) => {
+      if (!dataset) return;
+      replaceHash(buildHash(dataset.id, query, facets, v, dflt));
+    },
+    [dataset, dflt],
+  );
+
+  const toggleFacet = useCallback(
+    (field: string, value: string) => {
+      const next =
+        route.facets[field] === value
+          ? omit(route.facets, field)
+          : { ...route.facets, [field]: value };
+      navigate(route.query, next, view);
+    },
+    [navigate, route.facets, route.query, view],
+  );
+
+  useEffect(() => {
+    document.title = dataset ? `${dataset.name} · Tower Codex` : 'Tower Codex';
+  }, [dataset]);
+
+  let main: React.ReactNode;
+  if (isSearch) {
+    main = <GlobalSearch query={route.query} />;
+  } else if (!dataset) {
+    main = <Home />;
+  } else if (route.recordId !== undefined) {
+    const record = dataset.rows.find((r) => dataset.key(r) === route.recordId);
+    main = record ? (
+      <Detail dataset={dataset} record={record} />
+    ) : (
+      <NotFound dataset={dataset} recordId={route.recordId} />
+    );
+  } else {
+    main = (
+      <DatasetView
+        key={dataset.id}
+        dataset={dataset}
+        query={route.query}
+        facets={route.facets}
+        view={view}
+        onQuery={(q) => navigate(q, route.facets, view)}
+        onToggleFacet={toggleFacet}
+        onView={(v) => navigate(route.query, route.facets, v)}
+      />
+    );
+  }
+
+  return (
+    <>
+      <header className="topbar">
+        <a className="brand" href="#/">
+          <span className="brand-mark" aria-hidden="true" />
+          Tower Codex
+        </a>
+        <form className="global-search" role="search" onSubmit={(e) => e.preventDefault()}>
+          <input
+            type="search"
+            value={isSearch ? route.query : ''}
+            placeholder="Search everything…"
+            aria-label="Search all datasets"
+            onChange={(e) => {
+              const q = e.target.value;
+              const next = q ? `#/search?q=${encodeURIComponent(q)}` : '#/search';
+              // Entering search is a real navigation (Back should return to where you were);
+              // refining it once there is not.
+              if (isSearch) replaceHash(next);
+              else window.location.hash = next;
+            }}
+          />
+        </form>
+        <ThemeToggle />
+      </header>
+
+      <div className="layout">
+        <Sidebar activeId={route.datasetId} />
+        <main>{main}</main>
+      </div>
+    </>
+  );
+}
+
+function omit(f: Facets, key: string): Facets {
+  const { [key]: _drop, ...rest } = f;
+  return rest;
+}

--- a/apps/codex/src/datasets.test.ts
+++ b/apps/codex/src/datasets.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import * as data from 'ultimatedarktowerdata';
+import { DATASETS, DATASET_BY_ID } from './datasets';
+import { cell, titleOf } from './search';
+
+/**
+ * Interactive helpers, not browsable data — apps/seed owns seed decoding, and the board graph
+ * helpers need a two-location picker this app doesn't have.
+ *
+ * charToValue/valueToChar are deliberately NOT here: the seed-alphabet dataset surfaces them
+ * as a table, so they count as covered.
+ */
+const HELPERS = new Set([
+  'neighborsOf',
+  'stepDistance',
+  'shortestPath',
+  'validateSeed',
+  'decodeSeed',
+  'decodeRngSeed',
+  'createSeed',
+  'encodeSeed',
+  'compareSeedsRaw',
+  'dumpSeedChars',
+  'SystemRandom',
+]);
+
+describe('dataset registry', () => {
+  it('covers every ultimatedarktowerdata export', () => {
+    const claimed = new Set(DATASETS.flatMap((d) => d.exports));
+    const uncovered = Object.keys(data).filter((k) => !claimed.has(k) && !HELPERS.has(k));
+    expect(uncovered).toEqual([]);
+  });
+
+  it('claims no export that does not exist', () => {
+    // Catches a rename or removal in game-data that would otherwise leave a dead registry entry.
+    const claimed = new Set(DATASETS.flatMap((d) => d.exports));
+    expect([...claimed].filter((k) => !(k in data))).toEqual([]);
+  });
+
+  it('gives every record a unique, URL-safe key', () => {
+    const problems: string[] = [];
+    for (const d of DATASETS) {
+      const seen = new Set<string>();
+      for (const r of d.rows) {
+        const k = d.key(r);
+        if (!k) problems.push(`${d.id}: empty key`);
+        // '#' would terminate the hash route; '/' would fake a path segment.
+        else if (k.includes('#') || k.includes('/')) problems.push(`${d.id}: unsafe key ${k}`);
+        else if (seen.has(k)) problems.push(`${d.id}: duplicate key ${k}`);
+        seen.add(k);
+      }
+    }
+    expect(problems).toEqual([]);
+  });
+
+  it('resolves every related() link', () => {
+    const ids = new Map(DATASETS.map((d) => [d.id, new Set(d.rows.map(d.key))]));
+    const broken = DATASETS.flatMap((d) =>
+      d.rows.flatMap((r) =>
+        (d.related?.(r) ?? [])
+          .filter(
+            (l) => !ids.has(l.dataset) || (l.id !== undefined && !ids.get(l.dataset)!.has(l.id)),
+          )
+          .map((l) => `${d.id}/${d.key(r)} -> ${l.dataset}/${l.id ?? l.filter}`),
+      ),
+    );
+    expect(broken).toEqual([]);
+  });
+
+  it('has a filter link that actually matches rows', () => {
+    // A `filter` link that matches nothing lands the reader on an empty table with no explanation.
+    // Renaming a field in game-data (dungeonType -> type, say) would do exactly that silently.
+    const empty = new Set<string>();
+    for (const d of DATASETS) {
+      for (const r of d.rows) {
+        for (const l of d.related?.(r) ?? []) {
+          if (!l.filter) continue;
+          const target = DATASET_BY_ID.get(l.dataset)!;
+          const i = l.filter.indexOf(':');
+          const [field, value] = [l.filter.slice(0, i), l.filter.slice(i + 1)];
+          if (!target.rows.some((t) => cell(t, field) === value)) {
+            empty.add(`${d.id} -> ${l.dataset}?f=${l.filter}`);
+          }
+        }
+      }
+    }
+    expect([...empty]).toEqual([]);
+  });
+
+  it('gives every record a readable title', () => {
+    // titleOf() falls back to the record key, which for composite keys is machine text like
+    // "Base Game::Mini Bases::Blue". Any row reaching that fallback needs a `title` on its dataset.
+    const ugly = DATASETS.flatMap((d) =>
+      d.rows
+        .filter((r) => titleOf(d, r).includes('::'))
+        .slice(0, 1)
+        .map((r) => `${d.id}: ${titleOf(d, r)}`),
+    );
+    expect(ugly).toEqual([]);
+  });
+
+  it('has unique dataset ids and non-empty rows', () => {
+    expect(new Set(DATASETS.map((d) => d.id)).size).toBe(DATASETS.length);
+    expect(DATASETS.filter((d) => d.rows.length === 0).map((d) => d.id)).toEqual([]);
+  });
+});

--- a/apps/codex/src/datasets.ts
+++ b/apps/codex/src/datasets.ts
@@ -1,0 +1,602 @@
+/**
+ * The dataset registry — the only real logic in this app.
+ *
+ * Every view (table, card grid, detail) is a generic renderer over an entry here, so adding a
+ * dataset is a data edit, never a component. Deliberately there is NO per-dataset render config:
+ * `render.tsx`'s <Fields> walks Object.entries() and handles strings, string arrays, numbers and
+ * one level of nesting, which covers every shape `ultimatedarktowerdata` exports.
+ *
+ * `exports` on each entry names the game-data exports it covers. `datasets.test.ts` asserts that
+ * union equals the package's full export surface, so a new export there fails this app's tests
+ * until it is registered — the codex can never silently stop being a complete view of the package.
+ */
+import * as D from 'ultimatedarktowerdata';
+
+export type Row = Record<string, unknown>;
+
+/** A cross-reference. `id` targets one record; `filter` (a `field:value` facet) targets a subset. */
+export type Link = { label: string; dataset: string; id?: string; filter?: string };
+
+export type Group =
+  'Rosters' | 'Cards' | 'Dungeons & caravans' | 'Board' | 'Box inventory' | 'Tower' | 'Reference';
+
+export const GROUP_ORDER: readonly Group[] = [
+  'Rosters',
+  'Cards',
+  'Dungeons & caravans',
+  'Board',
+  'Box inventory',
+  'Tower',
+  'Reference',
+];
+
+export type Dataset = {
+  /** URL slug: `#/treasures` */
+  id: string;
+  name: string;
+  group: Group;
+  /** game-data export names this entry covers — the drift guard reads these. */
+  exports: string[];
+  rows: Row[];
+  /** Stable record id for URLs. Must be unique within the dataset. */
+  key: (r: Row) => string;
+  /** Heading for a card/detail. Defaults to the record's `name`, then its key. */
+  title?: (r: Row) => string;
+  /** Table columns, in order. */
+  columns: string[];
+  /** Fields offered as filter chips. */
+  facets?: string[];
+  /** Default view; omit for table. */
+  view?: 'cards';
+  /** One-line provenance or caveat, shown under the header. */
+  note?: string;
+  /** Extra badges beyond the automatic `needsReview` stamp. */
+  flags?: (r: Row) => string[];
+  related?: (r: Row) => Link[];
+};
+
+// ── helpers ────────────────────────────────────────────────────────────────────────────────────
+
+const s = (r: Row, f: string): string => String(r[f] ?? '');
+const byId = (r: Row): string => s(r, 'id');
+const byName = (r: Row): string => s(r, 'name');
+
+/**
+ * Widen a typed game-data array to Row[]. Copies the array (not the records): game-data's arrays
+ * are `readonly` to TypeScript but NOT frozen at runtime, so handing the live reference to a view
+ * that sorts would reorder the data for every other consumer in the tab.
+ */
+const asRows = <T extends object>(a: readonly T[]): Row[] => [...a] as unknown as Row[];
+
+/** Object keyed by name -> rows, with the key folded in as `field`. */
+const rowsOf = (o: Record<string, unknown>, field = 'name'): Row[] =>
+  Object.entries(o).map(([k, v]) =>
+    v && typeof v === 'object' && !Array.isArray(v)
+      ? ({ [field]: k, ...(v as Row) } as Row)
+      : ({ [field]: k, value: v } as Row),
+  );
+
+/** Positional string arrays -> {list, index, value}. */
+const listRows = (lists: Record<string, readonly string[]>): Row[] =>
+  Object.entries(lists).flatMap(([list, vals]) =>
+    vals.map((value, index) => ({ list, index, value })),
+  );
+
+const hex = (n: number): string => '0x' + n.toString(16).toUpperCase().padStart(2, '0');
+
+/**
+ * Join the parts of a composite key so it survives a hash route: '#' would terminate the hash and
+ * '/' would fake a path segment. Real data hits this — box categories include "Manuals / Sheets".
+ */
+const safeKey = (...parts: string[]): string =>
+  parts.filter(Boolean).join('::').replace(/[#/]/g, '-');
+
+// ── cross-reference indexes ────────────────────────────────────────────────────────────────────
+
+/**
+ * One name -> link index across every roster and card dataset. This is what lets a box-inventory
+ * component find its card and an audio cue find its foe without wiring each pair by hand — the
+ * same name-agreement game-data's own nameConsistency test enforces, made navigable.
+ */
+const NAME_INDEX = new Map<string, Link>();
+{
+  const sources: [string, readonly { id: string; name: string }[]][] = [
+    ['foes', D.ALL_FOES],
+    ['heroes', D.HEROES],
+    ['monuments', D.MONUMENTS],
+    ['treasures', D.TREASURES],
+    ['potions-gear', D.POTIONS_AND_GEAR],
+    ['companion-cards', D.COMPANION_CARDS],
+    ['corruptions', D.CORRUPTIONS],
+    ['quest-items', D.QUEST_ITEMS],
+    ['quests', D.QUESTS],
+    ['spells', D.SPELLS],
+    ['monument-cards', D.MONUMENT_CARDS],
+    ['nations', D.NATIONS],
+  ];
+  for (const [dataset, rows] of sources) {
+    for (const r of rows)
+      if (r.name && !NAME_INDEX.has(r.name))
+        NAME_INDEX.set(r.name, { label: r.name, dataset, id: r.id });
+  }
+}
+
+const AUDIO_BY_NAME = new Map(Object.entries(D.TOWER_AUDIO_LIBRARY).map(([k, v]) => [v.name, k]));
+
+const BOARD_NAMES = Object.keys(D.BOARD_LOCATION_BY_NAME);
+
+/** Link back to whichever roster/card dataset owns this name, if any. */
+const nameLink = (r: Row): Link[] => {
+  const l = NAME_INDEX.get(s(r, 'name'));
+  return l ? [l] : [];
+};
+
+// ── derived row sets ───────────────────────────────────────────────────────────────────────────
+
+/** One row per spot rather than per location — 212 placement points, individually filterable. */
+const BOARD_SPOT_ROWS: Row[] = Object.entries(D.BOARD_SPOTS).flatMap(([location, spots]) =>
+  spots.map((sp) => ({
+    location,
+    spot: sp.id,
+    x: Math.round(sp.at.x * 1000) / 1000,
+    y: Math.round(sp.at.y * 1000) / 1000,
+    accepts: [...sp.accepts],
+  })),
+);
+
+const ADJACENCY_ROWS: Row[] = Object.entries(D.BOARD_ADJACENCY).map(([name, neighbors]) => ({
+  name,
+  degree: neighbors.length,
+  neighbors: [...neighbors],
+}));
+
+/** Expansion -> Category -> Component, fully flattened so the whole box is one searchable table. */
+const BOX_COMPONENT_ROWS: Row[] = D.expansions.flatMap((exp) =>
+  exp.categories.flatMap((cat) =>
+    cat.components.map((c) => ({
+      expansion: exp.name,
+      section: cat.section,
+      category: cat.name,
+      ...c,
+    })),
+  ),
+);
+
+const BOX_TOKEN_ROWS: Row[] = [
+  ...D.coffers.flatMap((c) =>
+    c.denominations.map((den) => ({ group: c.resource, name: den.name, count: den.count })),
+  ),
+  ...D.coffers2.tokens.map((t) => ({ group: 'Coffers 2', name: t.name, count: t.count })),
+  ...D.skullsPack.tokens.map((t) => ({ group: 'Skulls pack', name: t.name, count: t.count })),
+];
+
+const SEED_ALPHABET_ROWS: Row[] = Array.from({ length: 34 }, (_, i) => ({
+  value: i,
+  char: D.valueToChar(i),
+}));
+
+// ── the registry ───────────────────────────────────────────────────────────────────────────────
+
+export const DATASETS: Dataset[] = [
+  // ── Rosters ──────────────────────────────────────────────────────────────────────────────────
+  {
+    id: 'heroes',
+    name: 'Heroes',
+    group: 'Rosters',
+    exports: ['HEROES', 'HERO_BY_ID', 'HERO_BY_NAME'],
+    rows: asRows(D.HEROES),
+    key: byId,
+    columns: ['name', 'source', 'bannerAction', 'startLocation'],
+    facets: ['source'],
+    view: 'cards',
+    note: 'Identity and the gameplay sheet in one record. The 4 unreleased Expeditions heroes are identity-only — their cards are not public, so they carry no banner action or virtues rather than a guess.',
+    flags: (r) => (s(r, 'source') === 'expeditions' ? ['provisional'] : []),
+  },
+  {
+    id: 'foes',
+    name: 'Foes & adversaries',
+    group: 'Rosters',
+    exports: ['ALL_FOES', 'FOES', 'ADVERSARY_ROSTER', 'FOE_BY_ID', 'FOE_BY_NAME'],
+    rows: asRows(D.ALL_FOES),
+    key: byId,
+    columns: ['name', 'kind', 'level', 'tier', 'source'],
+    facets: ['kind', 'tier', 'source'],
+    note: 'ALL_FOES is the canonical spelling for every foe/adversary name in the package, enforced by game-data’s nameConsistency test. FOES + ADVERSARY_ROSTER together make this list.',
+    related: (r) => [
+      ...(s(r, 'id') in D.FOE_CARDS_BY_ID
+        ? [{ label: 'Card face', dataset: 'foe-cards', id: s(r, 'id') }]
+        : []),
+      ...(AUDIO_BY_NAME.has(s(r, 'name'))
+        ? [{ label: 'Tower sound', dataset: 'tower-audio', id: AUDIO_BY_NAME.get(s(r, 'name'))! }]
+        : []),
+    ],
+  },
+  {
+    id: 'monuments',
+    name: 'Monuments',
+    group: 'Rosters',
+    exports: ['MONUMENTS', 'MONUMENT_BY_ID'],
+    rows: asRows(D.MONUMENTS),
+    key: byId,
+    columns: ['name', 'source'],
+    facets: ['source'],
+    related: (r) =>
+      s(r, 'id') in D.MONUMENT_CARDS_BY_ID
+        ? [{ label: 'Card face', dataset: 'monument-cards', id: s(r, 'id') }]
+        : [],
+  },
+
+  // ── Cards ────────────────────────────────────────────────────────────────────────────────────
+  {
+    id: 'foe-cards',
+    name: 'Foe cards',
+    group: 'Cards',
+    exports: ['FOE_CARDS', 'FOE_CARDS_BY_ID'],
+    rows: asRows(D.FOE_CARDS),
+    key: byId,
+    columns: ['name', 'level', 'traits', 'event'],
+    facets: ['level'],
+    view: 'cards',
+    note: 'Foes carry whenBattling text and ready/savage/lethal acts; adversaries carry cardText instead.',
+    related: (r) => [{ label: 'Roster entry', dataset: 'foes', id: s(r, 'id') }, ...nameLink(r)],
+  },
+  {
+    id: 'monument-cards',
+    name: 'Monument cards',
+    group: 'Cards',
+    exports: ['MONUMENT_CARDS', 'MONUMENT_CARDS_BY_ID'],
+    rows: asRows(D.MONUMENT_CARDS),
+    key: byId,
+    columns: ['name', 'building', 'reinforce1', 'reinforce2', 'offering'],
+    facets: ['building'],
+    view: 'cards',
+    related: (r) => [{ label: 'Roster entry', dataset: 'monuments', id: s(r, 'id') }],
+  },
+  {
+    id: 'companion-cards',
+    name: 'Companions',
+    group: 'Cards',
+    exports: ['COMPANION_CARDS', 'COMPANION_CARDS_BY_ID'],
+    rows: asRows(D.COMPANION_CARDS),
+    key: byId,
+    columns: ['name', 'title', 'guild', 'quest', 'kingdom', 'ability'],
+    facets: ['kingdom', 'guild'],
+    view: 'cards',
+    note: '22 cards: 10 quest companions and the 12 guild companions.',
+  },
+  {
+    id: 'treasures',
+    name: 'Treasures',
+    group: 'Cards',
+    exports: ['TREASURES', 'TREASURES_BY_ID'],
+    rows: asRows(D.TREASURES),
+    key: byId,
+    columns: ['name', 'source', 'group', 'text'],
+    facets: ['source', 'group'],
+    view: 'cards',
+  },
+  {
+    id: 'potions-gear',
+    name: 'Potions & gear',
+    group: 'Cards',
+    exports: ['POTIONS_AND_GEAR', 'POTIONS_AND_GEAR_BY_ID'],
+    rows: asRows(D.POTIONS_AND_GEAR),
+    key: byId,
+    columns: ['name', 'kind', 'effect', 'count', 'color'],
+    facets: ['kind', 'color'],
+    view: 'cards',
+    note: 'Four rows are unreleased Expeditions gear the source author could not fully observe — they carry a source note rather than a guess.',
+  },
+  {
+    id: 'corruptions',
+    name: 'Corruptions',
+    group: 'Cards',
+    exports: ['CORRUPTIONS', 'CORRUPTIONS_BY_ID'],
+    rows: asRows(D.CORRUPTIONS),
+    key: byId,
+    columns: ['name', 'source', 'description'],
+    facets: ['source'],
+    view: 'cards',
+  },
+  {
+    id: 'quest-items',
+    name: 'Quest items',
+    group: 'Cards',
+    exports: ['QUEST_ITEMS', 'QUEST_ITEMS_BY_ID'],
+    rows: asRows(D.QUEST_ITEMS),
+    key: byId,
+    columns: ['name', 'effect', 'count', 'note'],
+    view: 'cards',
+    note: '17 distinct items across 20 physical cards.',
+  },
+  {
+    id: 'quests',
+    name: 'Monthly quests',
+    group: 'Cards',
+    exports: ['QUESTS', 'QUESTS_BY_ID'],
+    rows: asRows(D.QUESTS),
+    key: byId,
+    columns: ['name', 'virtue', 'kingdom', 'details'],
+    facets: ['kingdom', 'virtue'],
+    view: 'cards',
+    note: 'Four per kingdom. These are boxInventory’s “Heroic Tests” category.',
+    related: (r) =>
+      BOARD_NAMES.filter((n) => s(r, 'details').includes(n)).map((n) => ({
+        label: n,
+        dataset: 'board-locations',
+        id: n,
+      })),
+  },
+  {
+    id: 'spells',
+    name: 'Spells & invocations',
+    group: 'Cards',
+    exports: ['SPELLS', 'SPELLS_BY_ID'],
+    rows: asRows(D.SPELLS),
+    key: byId,
+    columns: ['name', 'kind', 'effect'],
+    facets: ['kind'],
+    view: 'cards',
+    note: 'Six spells and four invocations — the Reverent Astromancer’s deck.',
+  },
+  {
+    id: 'nations',
+    name: 'Nations',
+    group: 'Cards',
+    exports: ['NATIONS', 'NATIONS_BY_ID'],
+    rows: asRows(D.NATIONS),
+    key: byId,
+    columns: ['name', 'kingdom', 'color', 'terrain', 'virtue', 'guild'],
+    facets: ['kingdom'],
+    view: 'cards',
+  },
+
+  // ── Dungeons & caravans ──────────────────────────────────────────────────────────────────────
+  {
+    id: 'dungeon-rooms',
+    name: 'Dungeon rooms',
+    group: 'Dungeons & caravans',
+    exports: [
+      'DUNGEON_ROOMS',
+      'DUNGEON_ROOM_BY_ID',
+      'CAVE_ROOMS',
+      'ENCAMPMENT_ROOMS',
+      'FORTRESS_ROOMS',
+      'RUINS_ROOMS',
+      'SHRINE_ROOMS',
+      'TOMB_ROOMS',
+      'DUNGEON_ADVANTAGE',
+    ],
+    rows: D.DUNGEON_ROOMS.map((r) => ({ ...r, advantage: D.DUNGEON_ADVANTAGE[r.dungeonType] })),
+    key: byId,
+    columns: ['name', 'dungeonType', 'advantage', 'kind', 'initial', 'upgraded'],
+    facets: ['dungeonType', 'kind', 'advantage'],
+    note: '78 rooms — one entrance and twelve rooms for each of the six dungeon types. `advantage` is the advantage that type lets you spend.',
+  },
+  {
+    id: 'caravan-rooms',
+    name: 'Caravan rooms',
+    group: 'Dungeons & caravans',
+    exports: ['CARAVAN_ROOMS', 'CARAVAN_ROOMS_BY_ID'],
+    rows: asRows(D.CARAVAN_ROOMS),
+    key: byId,
+    columns: ['name', 'route', 'kind', 'initial', 'upgraded'],
+    facets: ['route', 'kind'],
+    note: 'Known-incomplete: the set was observed in play, so two rows carry a source note.',
+  },
+
+  // ── Board ────────────────────────────────────────────────────────────────────────────────────
+  {
+    id: 'board-locations',
+    name: 'Board locations',
+    group: 'Board',
+    exports: ['BOARD_LOCATIONS', 'BOARD_LOCATION_BY_NAME', 'BOARD_GROUPINGS'],
+    rows: asRows(D.BOARD_LOCATIONS),
+    key: byName,
+    columns: ['name', 'terrain', 'building', 'kingdom', 'grouping', 'borders', 'dungeon'],
+    facets: ['kingdom', 'terrain', 'building', 'grouping'],
+    note: 'All 60 spaces. A dungeon has been identified for 46 of them.',
+    flags: (r) => (r.dungeon ? [] : ['dungeon unidentified']),
+    related: (r) => {
+      const name = s(r, 'name');
+      const dungeon = r.dungeon as { type: string } | undefined;
+      return [
+        { label: 'Adjacency', dataset: 'board-adjacency', id: name },
+        { label: 'Token spots', dataset: 'board-spots', filter: `location:${name}` },
+        ...(dungeon
+          ? [
+              {
+                label: `${dungeon.type} rooms`,
+                dataset: 'dungeon-rooms',
+                filter: `dungeonType:${dungeon.type}`,
+              },
+            ]
+          : []),
+      ];
+    },
+  },
+  {
+    id: 'board-adjacency',
+    name: 'Adjacency',
+    group: 'Board',
+    exports: ['BOARD_ADJACENCY'],
+    rows: ADJACENCY_ROWS,
+    key: byName,
+    columns: ['name', 'degree', 'neighbors'],
+    note: 'The movement graph. Every neighbour is a link, so this table browses as a graph.',
+    related: (r) => [
+      { label: 'Location', dataset: 'board-locations', id: s(r, 'name') },
+      ...(r.neighbors as string[]).map((n) => ({ label: n, dataset: 'board-locations', id: n })),
+    ],
+  },
+  {
+    id: 'board-spots',
+    name: 'Token spots',
+    group: 'Board',
+    exports: ['BOARD_SPOTS', 'BOARD_IMAGE_INFO'],
+    rows: BOARD_SPOT_ROWS,
+    key: (r) => safeKey(s(r, 'location'), s(r, 'spot')),
+    title: (r) => `${s(r, 'location')} · ${s(r, 'spot')}`,
+    columns: ['location', 'spot', 'x', 'y', 'accepts'],
+    facets: ['spot'],
+    note: `Where each token sits, as fractions of the board image (${D.BOARD_IMAGE_INFO.width}×${D.BOARD_IMAGE_INFO.height}, north heading ${D.BOARD_IMAGE_INFO.northHeadingDegrees}°). Foe spots also accept adversaries; marker spots also accept quests.`,
+    related: (r) => [{ label: 'Location', dataset: 'board-locations', id: s(r, 'location') }],
+  },
+
+  // ── Box inventory ────────────────────────────────────────────────────────────────────────────
+  {
+    id: 'box-components',
+    name: 'Components',
+    group: 'Box inventory',
+    exports: ['expansions', 'EXPANSIONS'],
+    rows: BOX_COMPONENT_ROWS,
+    // 26 of the 347 components carry no `name` at all: 12 (flags, monument minis) label themselves
+    // with `type` and 14 (mini bases) with `color`. Both have to be in the key — and in the title,
+    // or those rows render as their raw composite key.
+    key: (r) =>
+      safeKey(
+        s(r, 'expansion'),
+        s(r, 'category'),
+        s(r, 'name'),
+        s(r, 'type'),
+        s(r, 'color'),
+        s(r, 'level'),
+      ),
+    title: (r) => s(r, 'name') || s(r, 'type') || s(r, 'color'),
+    columns: ['name', 'count', 'expansion', 'section', 'category', 'color', 'type', 'level'],
+    facets: ['expansion', 'section', 'category'],
+    note: 'Everything in every box, flattened. Card names here must match the card datasets verbatim — game-data’s nameConsistency test enforces it, and the Related link is that agreement made visible.',
+    related: nameLink,
+  },
+  {
+    id: 'box-tokens',
+    name: 'Tokens',
+    group: 'Box inventory',
+    exports: ['coffers', 'coffers2', 'skullsPack'],
+    rows: BOX_TOKEN_ROWS,
+    key: (r) => safeKey(s(r, 'group'), s(r, 'name')),
+    columns: ['group', 'name', 'count'],
+    facets: ['group'],
+  },
+  {
+    id: 'box-sleeves',
+    name: 'Sleeves',
+    group: 'Box inventory',
+    exports: ['sleeves'],
+    rows: asRows(D.sleeves),
+    key: byName,
+    columns: ['name', 'purposes'],
+  },
+
+  // ── Tower ────────────────────────────────────────────────────────────────────────────────────
+  {
+    id: 'tower-audio',
+    name: 'Tower audio',
+    group: 'Tower',
+    exports: ['TOWER_AUDIO_LIBRARY'],
+    rows: rowsOf(D.TOWER_AUDIO_LIBRARY as unknown as Record<string, unknown>, 'key').map((r) => ({
+      ...r,
+      hex: hex(r.value as number),
+    })),
+    key: (r) => s(r, 'key'),
+    columns: ['name', 'category', 'value', 'hex'],
+    facets: ['category'],
+    note: '113 cues in 12 categories. `value` is the byte the tower firmware expects; the labels carry no authority, the bytes do.',
+    related: nameLink,
+  },
+  {
+    id: 'light-sequences',
+    name: 'Light sequences',
+    group: 'Tower',
+    exports: ['TOWER_LIGHT_SEQUENCES'],
+    rows: Object.entries(D.TOWER_LIGHT_SEQUENCES).map(([name, value]) => ({
+      name,
+      value,
+      hex: hex(value as number),
+    })),
+    key: byName,
+    columns: ['name', 'value', 'hex'],
+  },
+  {
+    id: 'glyphs',
+    name: 'Glyphs',
+    group: 'Tower',
+    exports: ['GLYPHS'],
+    rows: rowsOf(D.GLYPHS as unknown as Record<string, unknown>, 'key'),
+    key: (r) => s(r, 'key'),
+    columns: ['key', 'name', 'level', 'side'],
+    note: 'The five seal glyphs and where each sits on the tower drums.',
+  },
+
+  // ── Reference ────────────────────────────────────────────────────────────────────────────────
+  {
+    id: 'kingdom-virtues',
+    name: 'Kingdom virtues',
+    group: 'Reference',
+    exports: ['KINGDOM_VIRTUES', 'kingdomVirtues'],
+    rows: Object.entries(D.KINGDOM_VIRTUES).map(([kingdom, v]) => ({ kingdom, ...v })),
+    key: (r) => s(r, 'kingdom'),
+    columns: ['kingdom', 'name', 'ability'],
+    note: 'Taken at setup for your seating kingdom — not hero-specific, which is why they are not on the hero sheet.',
+  },
+  {
+    id: 'vocabularies',
+    name: 'Vocabularies',
+    group: 'Reference',
+    exports: ['ADVANTAGE_TYPES', 'FOE_STATUSES', 'RESERVED_TOKEN_TYPES'],
+    rows: listRows({
+      'Advantage types': D.ADVANTAGE_TYPES,
+      'Foe statuses': D.FOE_STATUSES,
+      'Reserved token types': D.RESERVED_TOKEN_TYPES,
+    }),
+    key: (r) => safeKey(s(r, 'list'), s(r, 'value')),
+    title: (r) => s(r, 'value'),
+    columns: ['list', 'value'],
+    facets: ['list'],
+    note: 'Closed vocabularies used as field values elsewhere. Order is presentational here — unlike Seed constants, the index means nothing.',
+  },
+  {
+    id: 'seed-constants',
+    name: 'Seed constants',
+    group: 'Reference',
+    exports: [
+      'TIER1_FOES',
+      'TIER2_FOES',
+      'TIER3_FOES',
+      'ADVERSARIES',
+      'ALLIES',
+      'DIFFICULTIES',
+      'GAME_SOURCES',
+    ],
+    rows: listRows({
+      'Tier 1 foes': D.TIER1_FOES,
+      'Tier 2 foes': D.TIER2_FOES,
+      'Tier 3 foes': D.TIER3_FOES,
+      Adversaries: D.ADVERSARIES,
+      Allies: D.ALLIES,
+      Difficulties: D.DIFFICULTIES,
+      'Game sources': D.GAME_SOURCES,
+    }),
+    key: (r) => safeKey(s(r, 'list'), s(r, 'index')),
+    title: (r) => s(r, 'value'),
+    columns: ['list', 'index', 'value'],
+    facets: ['list'],
+    note: 'These lists are positional: the index IS the value encoded in a game seed. To decode a whole seed, use the Seed Decoder app.',
+  },
+  {
+    id: 'seed-alphabet',
+    name: 'Seed alphabet',
+    group: 'Reference',
+    exports: ['charToValue', 'valueToChar'],
+    rows: SEED_ALPHABET_ROWS,
+    key: (r) => s(r, 'value'),
+    title: (r) => `${s(r, 'char')} = ${s(r, 'value')}`,
+    columns: ['value', 'char'],
+    note: 'The base-34 alphabet seeds are written in. `0` and `o` are excluded so they can never be confused when read aloud.',
+  },
+];
+
+export const DATASET_BY_ID = new Map(DATASETS.map((d) => [d.id, d]));
+
+/** Total browsable records, for the home page. */
+export const TOTAL_ROWS = DATASETS.reduce((n, d) => n + d.rows.length, 0);

--- a/apps/codex/src/index.css
+++ b/apps/codex/src/index.css
@@ -1,0 +1,1256 @@
+/*
+ * Tower Codex — "Field Guide"
+ *
+ * Every other app in this repo wears the tower's colours: dark slate, crimson, industrial. This one
+ * is a reading room, so it reads like one — warm paper, botanical ink, and records laid out as
+ * library catalog cards. Deliberately NOT @udtc/theme's palette (that stylesheet is not imported);
+ * only its `useTheme` store is reused, which is why the dark overrides below key off [data-theme].
+ *
+ * Every colour is a token. There is no literal hex outside the token blocks, which is what keeps
+ * night mode a short override instead of a second stylesheet.
+ */
+
+/* ── tokens ─────────────────────────────────────────────────────────────────────────────────── */
+
+:root {
+  --paper: #faf6ee;
+  --paper-sunk: #f2ebdd;
+  --card: #fffdf8;
+  --rule: #e6dbc7;
+  --rule-soft: #efe7d8;
+
+  --ink: #2b2723;
+  --ink-2: #5d5346;
+  --ink-faint: #6f6650;
+
+  --leaf: #3f6b50;
+  --leaf-deep: #2f5240;
+  --leaf-soft: #e7efe6;
+  --clay: #bd5f37;
+  --clay-soft: #f7e4d8;
+  --butter: #f6e3b6;
+
+  --shadow: 0 1px 2px rgb(90 74 45 / 8%), 0 6px 16px -8px rgb(90 74 45 / 18%);
+  --shadow-lift: 0 2px 4px rgb(90 74 45 / 10%), 0 14px 28px -12px rgb(90 74 45 / 26%);
+
+  --f-display: 'Fraunces', 'Iowan Old Style', 'Palatino Linotype', Palatino, Georgia, serif;
+  --f-ui: 'Karla', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  --f-mono: 'DM Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+
+  --shelf-w: 17rem;
+  --topbar-h: 3.5rem;
+  --radius: 6px;
+}
+
+:root[data-theme='dark'] {
+  --paper: #211e19;
+  --paper-sunk: #1a1814;
+  --card: #2a2620;
+  --rule: #3d372e;
+  --rule-soft: #322d26;
+
+  --ink: #f0e8d8;
+  --ink-2: #c6bba6;
+  --ink-faint: #978a72;
+
+  --leaf: #82b192;
+  --leaf-deep: #a5cbb1;
+  --leaf-soft: #26332a;
+  --clay: #dd8a5f;
+  --clay-soft: #3a271d;
+  --butter: #5a4a24;
+
+  --shadow: 0 1px 2px rgb(0 0 0 / 30%), 0 6px 16px -8px rgb(0 0 0 / 50%);
+  --shadow-lift: 0 2px 4px rgb(0 0 0 / 35%), 0 14px 28px -12px rgb(0 0 0 / 60%);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme='light']) {
+    --paper: #211e19;
+    --paper-sunk: #1a1814;
+    --card: #2a2620;
+    --rule: #3d372e;
+    --rule-soft: #322d26;
+
+    --ink: #f0e8d8;
+    --ink-2: #c6bba6;
+    --ink-faint: #978a72;
+
+    --leaf: #82b192;
+    --leaf-deep: #a5cbb1;
+    --leaf-soft: #26332a;
+    --clay: #dd8a5f;
+    --clay-soft: #3a271d;
+    --butter: #5a4a24;
+
+    --shadow: 0 1px 2px rgb(0 0 0 / 30%), 0 6px 16px -8px rgb(0 0 0 / 50%);
+    --shadow-lift: 0 2px 4px rgb(0 0 0 / 35%), 0 14px 28px -12px rgb(0 0 0 / 60%);
+  }
+}
+
+/* ── base ───────────────────────────────────────────────────────────────────────────────────── */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--f-ui);
+  font-size: 15px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* Paper tooth: one inline turbulence layer, no asset and no request. */
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  opacity: 0.5;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='180'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='.85' numOctaves='3'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='.07'/%3E%3C/svg%3E");
+}
+
+:root[data-theme='dark'] body::before {
+  opacity: 0.28;
+}
+
+h1,
+h2,
+h3 {
+  margin: 0;
+  font-family: var(--f-display);
+  font-variation-settings:
+    'SOFT' 40,
+    'WONK' 1;
+  font-weight: 600;
+  line-height: 1.15;
+  letter-spacing: -0.01em;
+}
+
+a {
+  color: var(--leaf-deep);
+  text-decoration-color: color-mix(in srgb, var(--leaf) 35%, transparent);
+  text-underline-offset: 2px;
+}
+
+a:hover {
+  text-decoration-color: var(--leaf);
+}
+
+code,
+pre {
+  font-family: var(--f-mono);
+  font-size: 0.85em;
+}
+
+button {
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+}
+
+:where(a, button, input, summary):focus-visible {
+  outline: 2px solid var(--leaf);
+  outline-offset: 2px;
+  border-radius: 3px;
+}
+
+/* Links that leave the app get an arrow rather than an icon font. */
+.out::after {
+  content: ' ↗';
+  font-size: 0.8em;
+  color: var(--ink-faint);
+}
+
+/* ── topbar ─────────────────────────────────────────────────────────────────────────────────── */
+
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  height: var(--topbar-h);
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  padding: 0 1.25rem;
+  background: color-mix(in srgb, var(--paper) 88%, transparent);
+  backdrop-filter: blur(8px);
+  border-bottom: 1px solid var(--rule);
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  font-family: var(--f-display);
+  font-variation-settings:
+    'SOFT' 60,
+    'WONK' 1;
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: var(--ink);
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+/* A pressed leaf, drawn with two opposing corner radii. */
+.brand-mark {
+  width: 1.1rem;
+  height: 1.1rem;
+  flex: none;
+  background: var(--leaf);
+  border-radius: 0 65% 0 65%;
+  transform: rotate(-12deg);
+}
+
+.global-search {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+}
+
+.global-search input {
+  width: min(30rem, 100%);
+  font: inherit;
+  padding: 0.4rem 0.85rem;
+  color: var(--ink);
+  background: var(--card);
+  border: 1px solid var(--rule);
+  border-radius: 999px;
+  transition:
+    border-color 0.15s,
+    box-shadow 0.15s;
+}
+
+.global-search input::placeholder {
+  color: var(--ink-faint);
+}
+
+.global-search input:focus {
+  outline: none;
+  border-color: var(--leaf);
+  box-shadow: 0 0 0 3px var(--leaf-soft);
+}
+
+.theme {
+  display: inline-flex;
+  flex: none;
+  border: 1px solid var(--rule);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.theme button {
+  border: 0;
+  background: transparent;
+  color: var(--ink-faint);
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 0.3rem 0.7rem;
+  transition:
+    background 0.15s,
+    color 0.15s;
+}
+
+.theme button[aria-pressed='true'] {
+  background: var(--leaf);
+  color: var(--paper);
+}
+
+/* ── layout ─────────────────────────────────────────────────────────────────────────────────── */
+
+.layout {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: var(--shelf-w) minmax(0, 1fr);
+  align-items: start;
+}
+
+main {
+  min-width: 0;
+  max-width: 68rem;
+  padding: 2rem 2rem 6rem;
+}
+
+/* ── the shelf (sidebar) ────────────────────────────────────────────────────────────────────── */
+
+.shelf {
+  position: sticky;
+  top: var(--topbar-h);
+  max-height: calc(100vh - var(--topbar-h));
+  overflow-y: auto;
+  padding: 1.5rem 0.75rem 3rem 1.25rem;
+  border-right: 1px solid var(--rule);
+}
+
+.shelf section + section {
+  margin-top: 1.4rem;
+}
+
+.shelf h2 {
+  font-family: var(--f-ui);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  padding: 0 0 0.45rem 0.6rem;
+  border-bottom: 1px solid var(--rule-soft);
+  margin-bottom: 0.35rem;
+}
+
+.shelf ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.shelf a {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.28rem 0.5rem 0.28rem 0.6rem;
+  border-radius: var(--radius);
+  border-left: 3px solid transparent;
+  color: var(--ink-2);
+  text-decoration: none;
+  transition:
+    background 0.14s,
+    color 0.14s,
+    border-color 0.14s;
+}
+
+.shelf a:hover {
+  background: var(--paper-sunk);
+  color: var(--ink);
+}
+
+/* The spine bar — the shelf's one piece of state. */
+.shelf a[aria-current='page'] {
+  background: var(--leaf-soft);
+  border-left-color: var(--leaf);
+  color: var(--leaf-deep);
+  font-weight: 600;
+}
+
+.shelf-count {
+  flex: none;
+  font-family: var(--f-mono);
+  font-size: 0.72rem;
+  color: var(--ink-faint);
+}
+
+.shelf a[aria-current='page'] .shelf-count {
+  color: var(--leaf);
+}
+
+.shelf-foot {
+  margin: 1.75rem 0 0;
+  padding: 0.75rem 0.6rem 0;
+  border-top: 1px solid var(--rule-soft);
+  font-size: 0.78rem;
+  color: var(--ink-faint);
+  line-height: 1.45;
+}
+
+/* ── dataset header ─────────────────────────────────────────────────────────────────────────── */
+
+.dataset-head {
+  margin-bottom: 1.5rem;
+}
+
+.dataset-head h2,
+.home-head h2,
+.detail-title {
+  font-size: clamp(1.6rem, 1.2rem + 1.4vw, 2.3rem);
+  font-variation-settings:
+    'SOFT' 50,
+    'WONK' 1,
+    'opsz' 60;
+}
+
+/* The reference-book divider: one thick rule, one hair below it. */
+.dataset-head h2,
+.detail-title {
+  padding-bottom: 0.45rem;
+  border-bottom: 2px solid var(--leaf);
+  box-shadow: 0 3px 0 -2px var(--rule);
+}
+
+.count {
+  margin: 0.55rem 0 0;
+  font-family: var(--f-mono);
+  font-size: 0.78rem;
+  color: var(--ink-faint);
+}
+
+.count-flagged {
+  color: var(--clay);
+}
+
+.note {
+  margin: 0.6rem 0 0;
+  max-width: 62ch;
+  font-size: 0.88rem;
+  color: var(--ink-2);
+  line-height: 1.6;
+}
+
+/* ── toolbar + facets ───────────────────────────────────────────────────────────────────────── */
+
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.9rem;
+}
+
+.find {
+  flex: 1;
+  min-width: 12rem;
+  font: inherit;
+  color: var(--ink);
+  background: var(--card);
+  padding: 0.4rem 0.8rem;
+  border: 1px solid var(--rule);
+  border-radius: var(--radius);
+}
+
+.find::placeholder {
+  color: var(--ink-faint);
+}
+
+.find:focus {
+  outline: none;
+  border-color: var(--leaf);
+  box-shadow: 0 0 0 3px var(--leaf-soft);
+}
+
+.view-toggle {
+  display: inline-flex;
+  flex: none;
+  border: 1px solid var(--rule);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+
+.view-toggle button {
+  border: 0;
+  background: transparent;
+  color: var(--ink-faint);
+  font-size: 0.75rem;
+  font-weight: 700;
+  padding: 0.35rem 0.8rem;
+  transition:
+    background 0.15s,
+    color 0.15s;
+}
+
+.view-toggle button[aria-pressed='true'] {
+  background: var(--leaf);
+  color: var(--paper);
+}
+
+.facets {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin-bottom: 1.25rem;
+}
+
+.facet {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.facet-name {
+  min-width: 6.5rem;
+  font-family: var(--f-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+
+.chip {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.35rem;
+  padding: 0.16rem 0.6rem;
+  font-size: 0.78rem;
+  color: var(--ink-2);
+  background: var(--card);
+  border: 1px solid var(--rule);
+  border-radius: 999px;
+  transition:
+    transform 0.12s cubic-bezier(0.34, 1.8, 0.64, 1),
+    background 0.14s,
+    border-color 0.14s,
+    color 0.14s;
+}
+
+.chip:hover {
+  border-color: var(--leaf);
+  color: var(--ink);
+}
+
+.chip[aria-pressed='true'] {
+  background: var(--leaf);
+  border-color: var(--leaf);
+  color: var(--paper);
+  transform: scale(1.05);
+}
+
+.chip-count {
+  font-family: var(--f-mono);
+  font-size: 0.68rem;
+  opacity: 0.7;
+}
+
+/* ── table ──────────────────────────────────────────────────────────────────────────────────── */
+
+/*
+ * `overflow-x: auto` makes this the nearest scroll container, so the sticky <thead> below offsets
+ * against THIS box, not the viewport — a viewport-height offset would float the header down over
+ * the rows. So the table owns its own scroll region and the header pins to the top of it. That is
+ * also what makes a pinned header worth having on the 347-row box-components table.
+ */
+.table-wrap {
+  overflow: auto;
+  max-height: calc(100vh - 11rem);
+  background: var(--card);
+  border: 1px solid var(--rule);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.86rem;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  text-align: left;
+  background: var(--paper-sunk);
+  border-bottom: 1px solid var(--rule);
+  padding: 0;
+  white-space: nowrap;
+}
+
+thead th button {
+  width: 100%;
+  border: 0;
+  background: none;
+  text-align: left;
+  padding: 0.5rem 0.85rem;
+  font-family: var(--f-mono);
+  font-size: 0.68rem;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  transition: color 0.14s;
+}
+
+thead th button:hover,
+thead th[aria-sort]:not([aria-sort='none']) button {
+  color: var(--leaf-deep);
+}
+
+.sort-mark {
+  font-size: 0.6em;
+  margin-left: 0.3em;
+}
+
+tbody td {
+  padding: 0.45rem 0.85rem;
+  border-bottom: 1px solid var(--rule-soft);
+  vertical-align: top;
+  color: var(--ink-2);
+}
+
+/* Ruled paper: alternate rows sink rather than stripe in a new colour. */
+tbody tr:nth-child(even) td {
+  background: color-mix(in srgb, var(--paper-sunk) 45%, transparent);
+}
+
+tbody tr:hover td {
+  background: var(--leaf-soft);
+}
+
+tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+tbody td:first-child {
+  font-weight: 600;
+  color: var(--ink);
+  white-space: nowrap;
+}
+
+tbody td.num {
+  font-family: var(--f-mono);
+  font-size: 0.8rem;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── catalog cards ──────────────────────────────────────────────────────────────────────────── */
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(19rem, 1fr));
+  gap: 1rem;
+}
+
+.card {
+  display: block;
+  padding: 0 1rem 0.9rem;
+  background: var(--card);
+  border: 1px solid var(--rule);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  color: inherit;
+  text-decoration: none;
+  transition:
+    transform 0.16s ease,
+    box-shadow 0.16s ease,
+    border-color 0.16s ease;
+}
+
+.card:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-lift);
+  border-color: color-mix(in srgb, var(--leaf) 40%, var(--rule));
+}
+
+/* The ruled header band of a library catalog card. */
+.card-band {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.5rem 0;
+  margin-bottom: 0.6rem;
+  border-bottom: 1px solid var(--rule);
+  font-family: var(--f-mono);
+  font-size: 0.62rem;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+
+.card-band-id {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-transform: none;
+  letter-spacing: 0;
+  opacity: 0.8;
+}
+
+.card h3 {
+  margin-bottom: 0.5rem;
+  font-size: 1.15rem;
+  font-variation-settings:
+    'SOFT' 55,
+    'WONK' 1,
+    'opsz' 30;
+}
+
+/* ── fields ─────────────────────────────────────────────────────────────────────────────────── */
+
+.fields {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.field {
+  display: grid;
+  grid-template-columns: 7.5rem minmax(0, 1fr);
+  gap: 0.75rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px dashed var(--rule-soft);
+}
+
+.field:last-child {
+  border-bottom: 0;
+  padding-bottom: 0;
+}
+
+.field dt {
+  padding-top: 0.15rem;
+  font-family: var(--f-mono);
+  font-size: 0.66rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+
+.field dd {
+  margin: 0;
+  min-width: 0;
+  color: var(--ink-2);
+  font-size: 0.88rem;
+}
+
+.field.more dd {
+  font-family: var(--f-mono);
+  font-size: 0.7rem;
+  color: var(--ink-faint);
+}
+
+.v-text {
+  margin: 0;
+}
+
+.v-tags {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  margin: 0;
+  padding: 0;
+}
+
+.v-tags li {
+  font-family: var(--f-mono);
+  font-size: 0.7rem;
+  padding: 0.08rem 0.45rem;
+  background: var(--paper-sunk);
+  border: 1px solid var(--rule);
+  border-radius: 3px;
+  color: var(--ink-2);
+}
+
+.v-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.v-strong {
+  font-weight: 700;
+  color: var(--ink);
+}
+
+.v-sub {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.v-sub dt {
+  font-family: var(--f-mono);
+  font-size: 0.64rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+
+.v-sub dd {
+  margin: 0 0 0.15rem;
+}
+
+/* ── badges ─────────────────────────────────────────────────────────────────────────────────── */
+
+.badges {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-left: 0.6rem;
+  vertical-align: middle;
+}
+
+/*
+ * The review stamp. Six rows in the package carry `needsReview` — data the source author could not
+ * fully observe. Stamping them makes that unmissable in a way a neutral tag would not.
+ */
+.stamp {
+  font-family: var(--f-mono);
+  font-size: 0.58rem;
+  font-weight: 500;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  color: var(--clay);
+  background: var(--clay-soft);
+  padding: 0.12rem 0.45rem;
+  border: 1px solid var(--clay);
+  border-radius: 2px;
+  box-shadow: inset 0 0 0 1px var(--clay-soft);
+  transform: rotate(-2.5deg);
+}
+
+.flag {
+  font-family: var(--f-mono);
+  font-size: 0.58rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  color: var(--ink-faint);
+  border: 1px dashed var(--rule);
+  border-radius: 2px;
+  padding: 0.12rem 0.45rem;
+}
+
+/* ── detail ─────────────────────────────────────────────────────────────────────────────────── */
+
+.detail {
+  max-width: 52rem;
+}
+
+.crumbs {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.9rem;
+  font-family: var(--f-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+
+.crumbs a {
+  color: var(--ink-faint);
+  text-decoration: none;
+}
+
+.crumbs a:hover {
+  color: var(--leaf-deep);
+}
+
+.detail-id {
+  margin: 0.55rem 0 1.5rem;
+  font-family: var(--f-mono);
+  font-size: 0.75rem;
+  color: var(--ink-faint);
+}
+
+.source-note {
+  margin: 0 0 1.5rem;
+  padding: 0.75rem 1rem;
+  background: var(--clay-soft);
+  border-left: 3px solid var(--clay);
+  border-radius: 0 var(--radius) var(--radius) 0;
+  font-size: 0.86rem;
+  color: var(--ink-2);
+}
+
+.source-note strong {
+  color: var(--clay);
+}
+
+.detail .fields {
+  gap: 0.9rem;
+}
+
+.detail .field {
+  grid-template-columns: 9rem minmax(0, 1fr);
+  padding-bottom: 0.9rem;
+}
+
+.detail .field dd {
+  font-size: 0.95rem;
+}
+
+.related {
+  margin-top: 2rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--rule);
+}
+
+.related-label {
+  font-family: var(--f-mono);
+  font-size: 0.66rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+
+.related ul {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 0.6rem 0 0;
+  padding: 0;
+}
+
+.related a {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.45rem;
+  padding: 0.28rem 0.7rem;
+  background: var(--card);
+  border: 1px solid var(--rule);
+  border-radius: 999px;
+  text-decoration: none;
+  color: var(--ink);
+  font-size: 0.83rem;
+  transition:
+    border-color 0.14s,
+    background 0.14s,
+    transform 0.14s;
+}
+
+.related a:hover {
+  border-color: var(--leaf);
+  background: var(--leaf-soft);
+  transform: translateY(-1px);
+}
+
+.related-in {
+  font-family: var(--f-mono);
+  font-size: 0.64rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+
+.raw {
+  margin-top: 2rem;
+}
+
+.raw summary {
+  font-family: var(--f-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  cursor: pointer;
+}
+
+.raw pre {
+  overflow-x: auto;
+  margin: 0.6rem 0 0;
+  padding: 0.9rem 1rem;
+  background: var(--paper-sunk);
+  border: 1px solid var(--rule);
+  border-radius: var(--radius);
+  color: var(--ink-2);
+  line-height: 1.5;
+}
+
+/* ── home ───────────────────────────────────────────────────────────────────────────────────── */
+
+.home-head {
+  max-width: 46rem;
+  margin-bottom: 2.5rem;
+}
+
+.home-head h2 {
+  max-width: 20ch;
+}
+
+.home-head p {
+  margin: 1rem 0 0;
+  font-size: 1.02rem;
+  line-height: 1.65;
+  color: var(--ink-2);
+}
+
+.home-groups {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(15rem, 1fr));
+  gap: 1.5rem 2rem;
+  margin-bottom: 3rem;
+}
+
+.home-groups h3 {
+  font-family: var(--f-ui);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  padding-bottom: 0.4rem;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 0.5rem;
+}
+
+.home-groups ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.home-groups a {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.22rem 0;
+  color: var(--ink-2);
+  text-decoration: none;
+  border-bottom: 1px dotted transparent;
+}
+
+.home-groups a:hover {
+  color: var(--leaf-deep);
+  border-bottom-color: var(--rule);
+}
+
+.home-groups a span {
+  font-family: var(--f-mono);
+  font-size: 0.72rem;
+  color: var(--ink-faint);
+}
+
+.quality {
+  max-width: 46rem;
+  padding: 1.5rem 1.75rem;
+  background: var(--card);
+  border: 1px solid var(--rule);
+  border-left: 3px solid var(--clay);
+  border-radius: 0 var(--radius) var(--radius) 0;
+  box-shadow: var(--shadow);
+}
+
+.quality h3 {
+  font-size: 1.15rem;
+  font-variation-settings:
+    'SOFT' 55,
+    'WONK' 1;
+}
+
+.quality p {
+  margin: 0.6rem 0 0;
+  font-size: 0.88rem;
+  color: var(--ink-2);
+  line-height: 1.6;
+}
+
+.quality ul {
+  list-style: none;
+  margin: 1rem 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.quality li {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.4rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px dashed var(--rule-soft);
+  font-size: 0.88rem;
+  color: var(--ink-2);
+}
+
+.quality li:last-child {
+  border-bottom: 0;
+}
+
+.quality strong {
+  font-family: var(--f-mono);
+  font-size: 1.05rem;
+  color: var(--clay);
+}
+
+.quality-detail {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.quality a {
+  font-size: 0.78rem;
+}
+
+.quality-foot {
+  margin-top: 1rem;
+  font-size: 0.82rem;
+}
+
+/* ── search results ─────────────────────────────────────────────────────────────────────────── */
+
+.result-group {
+  margin-top: 1.75rem;
+}
+
+.result-group h3 {
+  display: flex;
+  align-items: baseline;
+  gap: 0.6rem;
+  font-family: var(--f-ui);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+  padding-bottom: 0.4rem;
+  border-bottom: 1px solid var(--rule);
+}
+
+.result-group h3 a {
+  color: var(--ink-faint);
+  text-decoration: none;
+}
+
+.result-group h3 a:hover {
+  color: var(--leaf-deep);
+}
+
+.result-group h3 span {
+  font-family: var(--f-mono);
+  font-weight: 400;
+  color: var(--ink-faint);
+}
+
+.result-group ul {
+  list-style: none;
+  margin: 0.5rem 0 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(16rem, 1fr));
+  gap: 0.15rem 1rem;
+}
+
+/* Marker-pen highlight: asymmetric radii read hand-drawn rather than like a <mark> block. */
+.result-group li a {
+  display: block;
+  padding: 0.2rem 0.4rem;
+  color: var(--ink-2);
+  text-decoration: none;
+  background-image: linear-gradient(var(--butter), var(--butter));
+  background-size: 0 100%;
+  background-repeat: no-repeat;
+  border-radius: 12px 4px 10px 3px;
+  transition:
+    background-size 0.2s ease,
+    color 0.15s;
+}
+
+.result-group li a:hover {
+  background-size: 100% 100%;
+  color: var(--ink);
+}
+
+.result-group li.more a {
+  font-family: var(--f-mono);
+  font-size: 0.72rem;
+  color: var(--ink-faint);
+}
+
+.empty {
+  padding: 2.5rem 0;
+  color: var(--ink-faint);
+  font-style: italic;
+}
+
+/* ── motion ─────────────────────────────────────────────────────────────────────────────────── */
+
+@media (prefers-reduced-motion: no-preference) {
+  .reveal {
+    animation: rise 0.32s cubic-bezier(0.22, 1, 0.36, 1) backwards;
+    animation-delay: calc(min(var(--i, 0), 14) * 22ms);
+  }
+
+  @keyframes rise {
+    from {
+      opacity: 0;
+      transform: translateY(7px);
+    }
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
+/* ── scrollbars ─────────────────────────────────────────────────────────────────────────────── */
+
+/* @udtc/theme ships these, but its stylesheet is not imported here — restated in codex tokens. */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--rule) transparent;
+}
+
+*::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+*::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+*::-webkit-scrollbar-thumb {
+  background-color: var(--rule);
+  border: 2px solid transparent;
+  border-radius: 6px;
+  background-clip: padding-box;
+}
+
+*::-webkit-scrollbar-thumb:hover {
+  background-color: var(--ink-faint);
+}
+
+/* ── narrow ─────────────────────────────────────────────────────────────────────────────────── */
+
+@media (max-width: 62rem) {
+  .layout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .shelf {
+    position: static;
+    max-height: none;
+    overflow: visible;
+    border-right: 0;
+    border-bottom: 1px solid var(--rule);
+    padding: 1rem 1.25rem;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(13rem, 1fr));
+    gap: 0 1.5rem;
+    align-items: start;
+  }
+
+  .shelf section + section {
+    margin-top: 0;
+  }
+
+  .shelf-foot {
+    grid-column: 1 / -1;
+  }
+
+  main {
+    padding: 1.5rem 1.25rem 4rem;
+  }
+
+  .field,
+  .detail .field {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 0.15rem;
+  }
+}

--- a/apps/codex/src/main.tsx
+++ b/apps/codex/src/main.tsx
@@ -1,0 +1,13 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+// Deliberately NOT importing '@udtc/theme/theme.css': that stylesheet is the tower apps' slate
+// palette, and the codex is a reading room. It reuses @udtc/theme's `useTheme` store (same
+// localStorage key, same data-theme contract) and defines its own tokens against it.
+import './index.css';
+import App from './App';
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/apps/codex/src/render.tsx
+++ b/apps/codex/src/render.tsx
@@ -1,0 +1,214 @@
+/**
+ * The generic record renderer. One <Fields> walks Object.entries() and handles every shape
+ * `ultimatedarktowerdata` exports — strings, string arrays, numbers, and one level of nested
+ * object (FOE_CARDS.acts, TREASURES.advantage, BOARD_LOCATIONS.dungeon, hero virtue lists).
+ * That is why the registry carries no per-dataset render config.
+ */
+import type { Dataset, Link, Row } from './datasets';
+import { DATASET_BY_ID } from './datasets';
+import { href, titleOf } from './search';
+
+/** Fields that are chrome, not content — already shown as the title or the card's header band. */
+const SUPPRESSED = new Set(['name', 'id', 'key', 'needsReview', 'sourceNote']);
+
+const LABELS: Record<string, string> = {
+  whenBattling: 'When battling',
+  cardText: 'Card text',
+  eventText: 'Event text',
+  eventTextAlternate: 'Event text (alternate)',
+  dungeonType: 'Dungeon',
+  startLocation: 'Starts at',
+  bannerAction: 'Banner action',
+  defaultVirtues: 'Starting virtues',
+  unlockableVirtues: 'Unlockable virtues',
+  reinforce1: 'Reinforce',
+  reinforce2: 'Reinforce (alt)',
+};
+
+/** `dungeonType` -> "Dungeon"; otherwise camelCase -> "Camel case". */
+function label(field: string): string {
+  if (LABELS[field]) return LABELS[field];
+  const spaced = field.replace(/([a-z0-9])([A-Z])/g, '$1 $2');
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
+function isEmpty(v: unknown): boolean {
+  return v === undefined || v === null || v === '' || (Array.isArray(v) && v.length === 0);
+}
+
+/** One value, rendered by shape. */
+function Value({ value }: { value: unknown }) {
+  if (Array.isArray(value)) {
+    // An array of objects (hero virtues) reads as a definition list; strings read as a list.
+    if (value.length > 0 && typeof value[0] === 'object' && value[0] !== null) {
+      return (
+        <ul className="v-list">
+          {(value as Row[]).map((o, i) => (
+            <li key={i}>
+              {Object.values(o)
+                .filter((x) => !isEmpty(x))
+                .map((x, j) => (
+                  <span key={j} className={j === 0 ? 'v-strong' : undefined}>
+                    {String(x)}
+                    {j === 0 ? ' — ' : ''}
+                  </span>
+                ))}
+            </li>
+          ))}
+        </ul>
+      );
+    }
+    return (
+      <ul className="v-tags">
+        {(value as unknown[]).map((v, i) => (
+          <li key={i}>{String(v)}</li>
+        ))}
+      </ul>
+    );
+  }
+
+  if (value !== null && typeof value === 'object') {
+    return (
+      <dl className="v-sub">
+        {Object.entries(value as Row)
+          .filter(([, v]) => !isEmpty(v))
+          .map(([k, v]) => (
+            <div key={k}>
+              <dt>{label(k)}</dt>
+              <dd>{String(v)}</dd>
+            </div>
+          ))}
+      </dl>
+    );
+  }
+
+  return <p className="v-text">{String(value)}</p>;
+}
+
+export function Fields({ record, limit }: { record: Row; limit?: number }) {
+  const entries = Object.entries(record).filter(([k, v]) => !SUPPRESSED.has(k) && !isEmpty(v));
+  const shown = limit ? entries.slice(0, limit) : entries;
+  if (shown.length === 0) return null;
+  return (
+    <dl className="fields">
+      {shown.map(([k, v]) => (
+        <div className="field" key={k}>
+          <dt>{label(k)}</dt>
+          <dd>
+            <Value value={v} />
+          </dd>
+        </div>
+      ))}
+      {limit && entries.length > shown.length ? (
+        <div className="field more">
+          <dt />
+          <dd>+{entries.length - shown.length} more</dd>
+        </div>
+      ) : null}
+    </dl>
+  );
+}
+
+/**
+ * Badges. `needsReview` renders as a rubber stamp because that is what it means: a row the source
+ * author could not fully observe. Six rows in the package carry it, and they should be unmissable.
+ */
+export function Badges({ dataset, record }: { dataset: Dataset; record: Row }) {
+  const flags = dataset.flags?.(record) ?? [];
+  if (!record.needsReview && flags.length === 0) return null;
+  return (
+    <span className="badges">
+      {record.needsReview ? (
+        <span className="stamp" title={String(record.sourceNote ?? '')}>
+          needs review
+        </span>
+      ) : null}
+      {flags.map((f) => (
+        <span className="flag" key={f}>
+          {f}
+        </span>
+      ))}
+    </span>
+  );
+}
+
+export function Related({ links }: { links: Link[] }) {
+  if (links.length === 0) return null;
+  return (
+    <div className="related">
+      <span className="related-label">See also</span>
+      <ul>
+        {links.map((l, i) => (
+          <li key={i}>
+            <a href={href(l)}>
+              {l.label}
+              <span className="related-in">{DATASET_BY_ID.get(l.dataset)?.name ?? l.dataset}</span>
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+/** A catalog card: ruled header band, title, then the record's fields. */
+export function RecordCard({
+  dataset,
+  record,
+  index,
+}: {
+  dataset: Dataset;
+  record: Row;
+  index: number;
+}) {
+  return (
+    <a
+      className="card reveal"
+      style={{ '--i': index } as React.CSSProperties}
+      href={`#/${dataset.id}/${encodeURIComponent(dataset.key(record))}`}
+    >
+      <span className="card-band">
+        <span className="card-band-set">{dataset.name}</span>
+        <span className="card-band-id">{dataset.key(record)}</span>
+      </span>
+      <h3>
+        {titleOf(dataset, record)}
+        <Badges dataset={dataset} record={record} />
+      </h3>
+      <Fields record={record} limit={5} />
+    </a>
+  );
+}
+
+export function Detail({ dataset, record }: { dataset: Dataset; record: Row }) {
+  const links = dataset.related?.(record) ?? [];
+  return (
+    <article className="detail">
+      <nav className="crumbs">
+        <a href="#/">Codex</a>
+        <span aria-hidden="true">/</span>
+        <a href={`#/${dataset.id}`}>{dataset.name}</a>
+      </nav>
+
+      <h2 className="detail-title">
+        {titleOf(dataset, record)}
+        <Badges dataset={dataset} record={record} />
+      </h2>
+      <p className="detail-id">{dataset.key(record)}</p>
+
+      {record.sourceNote ? (
+        <aside className="source-note">
+          <strong>Not fully observed.</strong> {String(record.sourceNote)}
+        </aside>
+      ) : null}
+
+      <Fields record={record} />
+      <Related links={links} />
+
+      <details className="raw">
+        <summary>Raw record</summary>
+        <pre>{JSON.stringify(record, null, 2)}</pre>
+      </details>
+    </article>
+  );
+}

--- a/apps/codex/src/search.ts
+++ b/apps/codex/src/search.ts
@@ -1,0 +1,107 @@
+/**
+ * Search and faceting. ~1,300 records total, so a plain substring scan over each row's serialized
+ * text is sub-millisecond — no index to build, no debounce to tune, nothing to invalidate.
+ */
+import { DATASETS, type Dataset, type Link, type Row } from './datasets';
+
+/** Hash URL for a cross-reference: a record when it has an id, otherwise a pre-filtered list. */
+export function href(l: Link): string {
+  const base = `#/${l.dataset}`;
+  if (l.id !== undefined) return `${base}/${encodeURIComponent(l.id)}`;
+  if (l.filter) return `${base}?f=${encodeURIComponent(l.filter)}`;
+  return base;
+}
+
+/** Serialized haystack per row, built once and reused for every keystroke. */
+const HAYSTACK = new WeakMap<Row, string>();
+
+function haystack(r: Row): string {
+  let h = HAYSTACK.get(r);
+  if (h === undefined) {
+    h = JSON.stringify(r).toLowerCase();
+    HAYSTACK.set(r, h);
+  }
+  return h;
+}
+
+export function matches(r: Row, q: string): boolean {
+  return !q || haystack(r).includes(q.toLowerCase());
+}
+
+/** A facet selection, serialized in the URL as `field:value`. */
+export type Facets = Record<string, string>;
+
+export function parseFacets(pairs: string[]): Facets {
+  const out: Facets = {};
+  for (const p of pairs) {
+    const i = p.indexOf(':');
+    if (i > 0) out[p.slice(0, i)] = p.slice(i + 1);
+  }
+  return out;
+}
+
+export function serializeFacets(f: Facets): string[] {
+  return Object.entries(f).map(([k, v]) => `${k}:${v}`);
+}
+
+/** Cell value as a plain string, matching how the table renders it. */
+export function cell(r: Row, field: string): string {
+  const v = r[field];
+  if (v === undefined || v === null || v === '') return '';
+  if (Array.isArray(v)) return v.join(', ');
+  if (typeof v === 'object') return Object.values(v as Row).join(' · ');
+  return String(v);
+}
+
+export function filterRows(rows: readonly Row[], q: string, facets: Facets): Row[] {
+  const active = Object.entries(facets);
+  return rows.filter((r) => active.every(([f, v]) => cell(r, f) === v) && matches(r, q));
+}
+
+/** Distinct values of a facet field, with counts, ordered by frequency then alphabetically. */
+export function facetValues(
+  rows: readonly Row[],
+  field: string,
+): { value: string; count: number }[] {
+  const counts = new Map<string, number>();
+  for (const r of rows) {
+    const v = cell(r, field);
+    if (v) counts.set(v, (counts.get(v) ?? 0) + 1);
+  }
+  return [...counts]
+    .map(([value, count]) => ({ value, count }))
+    .sort((a, b) => b.count - a.count || a.value.localeCompare(b.value));
+}
+
+export type SearchHit = { dataset: Dataset; rows: Row[] };
+
+/** Every dataset that has a match, in registry order. */
+export function searchAll(q: string): SearchHit[] {
+  if (!q.trim()) return [];
+  return DATASETS.map((dataset) => ({
+    dataset,
+    rows: dataset.rows.filter((r) => matches(r, q)),
+  })).filter((h) => h.rows.length > 0);
+}
+
+/** The record's display heading. */
+export function titleOf(d: Dataset, r: Row): string {
+  return d.title?.(r) || cell(r, 'name') || d.key(r);
+}
+
+/**
+ * Sort a copy — never in place. game-data's arrays are readonly to TypeScript but not frozen at
+ * runtime, so sorting the live array would reorder the data for every other consumer in the tab.
+ */
+export function sortRows(rows: readonly Row[], field: string, dir: 1 | -1): Row[] {
+  return [...rows].sort((a, b) => {
+    const av = a[field];
+    const bv = b[field];
+    if (typeof av === 'number' && typeof bv === 'number') return (av - bv) * dir;
+    const as = cell(a, field);
+    const bs = cell(b, field);
+    // Empty cells sort last in both directions — a blank is absence, not a low value.
+    if (!as !== !bs) return as ? -1 : 1;
+    return as.localeCompare(bs, undefined, { numeric: true }) * dir;
+  });
+}

--- a/apps/codex/src/views.tsx
+++ b/apps/codex/src/views.tsx
@@ -1,0 +1,197 @@
+/**
+ * Dataset views: a sortable table for scanning, a card grid for reading printed card text.
+ * Both are generic over the registry — nothing here knows what a treasure or a foe is.
+ */
+import { useMemo, useState } from 'react';
+import type { Dataset, Row } from './datasets';
+import { RecordCard } from './render';
+import { cell, facetValues, filterRows, sortRows, titleOf, type Facets } from './search';
+
+export type View = 'table' | 'cards';
+
+function FacetChips({
+  dataset,
+  rows,
+  facets,
+  onToggle,
+}: {
+  dataset: Dataset;
+  rows: readonly Row[];
+  facets: Facets;
+  onToggle: (field: string, value: string) => void;
+}) {
+  const groups = useMemo(() => {
+    const declared = dataset.facets ?? [];
+    // A cross-link can filter on a field this dataset doesn't facet on — a board location links to
+    // its token spots as `?f=location:Broken Lands`, and `location` is not a chip (60 values). Show
+    // just the active value in that case, so the filter is visible and can be cleared. Without this
+    // the header reads "3 of 212" with nothing on screen explaining why.
+    const fields = [...new Set([...declared, ...Object.keys(facets)])];
+    return fields.map((field) => {
+      const values = facetValues(rows, field);
+      return {
+        field,
+        values: declared.includes(field) ? values : values.filter((v) => v.value === facets[field]),
+      };
+    });
+  }, [dataset, rows, facets]);
+
+  // One chip is only worth showing if it is the active filter; otherwise it narrows nothing.
+  const shown = groups.filter((g) => g.values.length > 1 || facets[g.field]);
+  if (shown.length === 0) return null;
+
+  return (
+    <div className="facets">
+      {shown.map(({ field, values }) => (
+        <div className="facet" key={field}>
+          <span className="facet-name">{field}</span>
+          {values.map(({ value, count }) => (
+            <button
+              key={value}
+              type="button"
+              className="chip"
+              aria-pressed={facets[field] === value}
+              onClick={() => onToggle(field, value)}
+            >
+              {value}
+              <span className="chip-count">{count}</span>
+            </button>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function DataTable({ dataset, rows }: { dataset: Dataset; rows: Row[] }) {
+  const [sort, setSort] = useState<{ col: string; dir: 1 | -1 } | null>(null);
+  const sorted = useMemo(() => (sort ? sortRows(rows, sort.col, sort.dir) : rows), [rows, sort]);
+
+  const toggle = (col: string) =>
+    setSort((s) => (s?.col === col ? { col, dir: s.dir === 1 ? -1 : 1 } : { col, dir: 1 }));
+
+  return (
+    <div className="table-wrap">
+      <table>
+        <thead>
+          <tr>
+            {dataset.columns.map((c) => (
+              <th
+                key={c}
+                aria-sort={sort?.col === c ? (sort.dir === 1 ? 'ascending' : 'descending') : 'none'}
+              >
+                <button type="button" onClick={() => toggle(c)}>
+                  {c}
+                  <span className="sort-mark" aria-hidden="true">
+                    {sort?.col === c ? (sort.dir === 1 ? '▲' : '▼') : ''}
+                  </span>
+                </button>
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {sorted.map((r) => {
+            const k = dataset.key(r);
+            return (
+              <tr key={k}>
+                {dataset.columns.map((c, i) => (
+                  <td key={c} className={typeof r[c] === 'number' ? 'num' : undefined}>
+                    {i === 0 ? (
+                      // The first cell is the link, but it still shows ITS OWN column's value —
+                      // using the record title here made "Kingdom" read "Champion of the East".
+                      // titleOf is only the fallback for rows whose first column is empty
+                      // (box components labelled by `type` rather than `name`).
+                      <a href={`#/${dataset.id}/${encodeURIComponent(k)}`}>
+                        {cell(r, c) || titleOf(dataset, r)}
+                      </a>
+                    ) : (
+                      cell(r, c)
+                    )}
+                  </td>
+                ))}
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+      {sorted.length === 0 ? <p className="empty">Nothing matches that.</p> : null}
+    </div>
+  );
+}
+
+function CardGrid({ dataset, rows }: { dataset: Dataset; rows: Row[] }) {
+  if (rows.length === 0) return <p className="empty">Nothing matches that.</p>;
+  return (
+    <div className="card-grid">
+      {rows.map((r, i) => (
+        <RecordCard key={dataset.key(r)} dataset={dataset} record={r} index={i} />
+      ))}
+    </div>
+  );
+}
+
+export function DatasetView({
+  dataset,
+  query,
+  facets,
+  view,
+  onQuery,
+  onToggleFacet,
+  onView,
+}: {
+  dataset: Dataset;
+  query: string;
+  facets: Facets;
+  view: View;
+  onQuery: (q: string) => void;
+  onToggleFacet: (field: string, value: string) => void;
+  onView: (v: View) => void;
+}) {
+  const rows = useMemo(() => filterRows(dataset.rows, query, facets), [dataset, query, facets]);
+  const flagged = useMemo(() => dataset.rows.filter((r) => r.needsReview).length, [dataset]);
+  // Chip counts come from the search-filtered rows but ignore the facets themselves, so each count
+  // is what clicking that chip actually yields. Counting all rows would promise more than it gives.
+  const facetRows = useMemo(() => filterRows(dataset.rows, query, {}), [dataset, query]);
+
+  return (
+    <section className="dataset">
+      <header className="dataset-head">
+        <h2>{dataset.name}</h2>
+        <p className="count">
+          {rows.length === dataset.rows.length
+            ? `${dataset.rows.length} records`
+            : `${rows.length} of ${dataset.rows.length}`}
+          {flagged > 0 ? <span className="count-flagged"> · {flagged} need review</span> : null}
+        </p>
+        {dataset.note ? <p className="note">{dataset.note}</p> : null}
+      </header>
+
+      <div className="toolbar">
+        <input
+          type="search"
+          className="find"
+          placeholder={`Search ${dataset.name.toLowerCase()}…`}
+          value={query}
+          onChange={(e) => onQuery(e.target.value)}
+          aria-label={`Search ${dataset.name}`}
+        />
+        <div className="view-toggle" role="group" aria-label="View">
+          {(['table', 'cards'] as const).map((v) => (
+            <button key={v} type="button" aria-pressed={view === v} onClick={() => onView(v)}>
+              {v === 'table' ? 'Table' : 'Cards'}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <FacetChips dataset={dataset} rows={facetRows} facets={facets} onToggle={onToggleFacet} />
+
+      {view === 'cards' ? (
+        <CardGrid dataset={dataset} rows={rows} />
+      ) : (
+        <DataTable dataset={dataset} rows={rows} />
+      )}
+    </section>
+  );
+}

--- a/apps/codex/tsconfig.app.json
+++ b/apps/codex/tsconfig.app.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "noEmit": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo"
+  },
+  "include": ["src"]
+}

--- a/apps/codex/tsconfig.json
+++ b/apps/codex/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "files": [],
+  "references": [{ "path": "./tsconfig.app.json" }, { "path": "./tsconfig.node.json" }]
+}

--- a/apps/codex/tsconfig.node.json
+++ b/apps/codex/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo"
+  },
+  "include": ["vite.config.ts"]
+}

--- a/apps/codex/vite.config.ts
+++ b/apps/codex/vite.config.ts
@@ -1,0 +1,29 @@
+/// <reference types="vitest/config" />
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { fileURLToPath, URL } from 'node:url';
+
+// No optimizeDeps/alias entry for `ultimatedarktowerdata`: since v2 it ships an `import` export
+// condition pointing at a real ESM bundle (dist/esm/index.mjs), so Vite resolves named exports
+// directly. Re-adding the old CJS workarounds here is a regression — see packages/game-data/CLAUDE.md.
+export default defineConfig({
+  base: '/', // Pages base is set via --base in deploy-pages.yml
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
+  server: {
+    port: 3006,
+    open: true,
+  },
+  preview: {
+    port: 4006,
+  },
+  test: {
+    // The only suite is a pure data check over the registry — no DOM, so no jsdom dependency.
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+  },
+});

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -38,6 +38,7 @@ fails with `ERR_PNPM_NO_SCRIPT` from an unrelated package without `-w`.
 | **Player** (`@udtc/player`)                  | `pnpm --filter @udtc/player dev`                | `pnpm run dev:player`     | http://localhost:5174              |
 | **Digital** — solo digital play              | `pnpm --filter ultimatedarktowerdigital dev`    | `pnpm run dev:digital`    | http://localhost:5173 †            |
 | **Seed** — seed decoder SPA                  | `pnpm --filter ultimatedarktowerseed dev`       | `pnpm run dev:seed`       | http://localhost:3002 (auto-opens) |
+| **Codex** — game data browser                | `pnpm --filter ultimatedarktowercodex dev`      | `pnpm run dev:codex`      | http://localhost:3006 (auto-opens) |
 | **Sync** (`@dark-tower-sync/client`)         | `pnpm --filter @dark-tower-sync/client dev`     | `pnpm run dev:sync`       | http://localhost:3000 (auto-opens) |
 | **Controller** — tower control + 3D emulator | `pnpm --filter ultimatedarktowercontroller dev` | `pnpm run dev:controller` | http://localhost:3005 (auto-opens) |
 | **Game** — The Tower's Challenge             | `pnpm --filter ultimatedarktowergame dev`       | `pnpm run dev:game`       | http://localhost:3004 (auto-opens) |
@@ -50,8 +51,10 @@ the initial `pnpm install`; run `pnpm --filter "./packages/*" build` first if yo
 skipped it.
 
 Creator and Player auto-build `@udtc/engine` first (their `predev` hook), so
-those two are self-contained. Digital, Seed, and Sync rely on the core (and, for
-Sync, the relay) `dist/` produced by the initial `pnpm install`.
+those two are self-contained. Codex does the same for `ultimatedarktowerdata` —
+reviewing that data is the point of the app, so a stale `dist/` there would make
+it quietly lie. Digital, Seed, and Sync rely on the core (and, for Sync, the
+relay) `dist/` produced by the initial `pnpm install`.
 
 ## Library demos (display / board)
 

--- a/docs/pages/landing.data.mjs
+++ b/docs/pages/landing.data.mjs
@@ -105,6 +105,16 @@ export const components = [
     image: 'seed.jpg',
   },
   {
+    dir: 'apps/codex',
+    title: 'Tower Codex',
+    blurb:
+      'Browse the whole Return to Dark Tower reference — every printed card face, the board, the rosters, the box contents — searchable and cross-linked.',
+    category: 'app',
+    demo: 'codex',
+    glyph: 'quest',
+    image: null,
+  },
+  {
     dir: 'apps/sync',
     title: 'Dark Tower Sync',
     blurb: 'Browser client for the relay — mirror relayed commands onto your physical tower.',
@@ -206,7 +216,8 @@ export const components = [
     blurb:
       'Board locations, foes, heroes, monuments, and seed encode/decode — the canonical Return to Dark Tower reference data in strict TypeScript types.',
     category: 'library',
-    demo: null,
+    // The Codex app is this library's demo — it browses every export.
+    demo: 'codex',
     glyph: 'banner',
     image: 'game-data.jpg',
     alt: 'The physical Return to Dark Tower board and expansions, with the reference data extracted from it overlaid as a graph',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -43,6 +43,7 @@ export default tseslint.config(
   // React surfaces: the creator/player/digital apps and package example sites.
   {
     files: [
+      'apps/codex/**/*.{ts,tsx}',
       'apps/creator/**/*.{ts,tsx}',
       'apps/player/**/*.{ts,tsx}',
       'apps/digital/**/*.{ts,tsx}',

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "build": "pnpm -r build",
     "test": "pnpm -r test",
     "typecheck": "pnpm -r typecheck",
+    "dev:codex": "pnpm --filter ultimatedarktowercodex dev",
     "dev:creator": "pnpm --filter @udtc/creator dev",
     "dev:player": "pnpm --filter @udtc/player dev",
     "dev:digital": "pnpm --filter ultimatedarktowerdigital dev",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,40 @@ importers:
         specifier: ^8.65.0
         version: 8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
 
+  apps/codex:
+    dependencies:
+      '@udtc/theme':
+        specifier: workspace:*
+        version: link:../../packages/creator-theme
+      react:
+        specifier: 'catalog:'
+        version: 19.2.8
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.8(react@19.2.8)
+      ultimatedarktowerdata:
+        specifier: workspace:^
+        version: link:../../packages/game-data
+    devDependencies:
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: 'catalog:'
+        version: 6.0.4(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vite:
+        specifier: 'catalog:'
+        version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jsdom@25.0.1)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+
   apps/controller:
     dependencies:
       '@dimforge/rapier3d-compat':
@@ -4086,10 +4120,6 @@ packages:
   object-keys@1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
-
-  obug@2.1.3:
-    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
-    engines: {node: '>=12.20.0'}
 
   obug@2.1.4:
     resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
@@ -9133,8 +9163,6 @@ snapshots:
 
   object-keys@1.1.1: {}
 
-  obug@2.1.3: {}
-
   obug@2.1.4: {}
 
   on-finished@2.4.1:
@@ -10110,7 +10138,7 @@ snapshots:
       es-module-lexer: 2.3.0
       expect-type: 1.4.0
       magic-string: 0.30.21
-      obug: 2.1.3
+      obug: 2.1.4
       pathe: 2.0.3
       picomatch: 4.0.5
       std-env: 4.2.0
@@ -10139,7 +10167,7 @@ snapshots:
       es-module-lexer: 2.3.0
       expect-type: 1.4.0
       magic-string: 0.30.21
-      obug: 2.1.3
+      obug: 2.1.4
       pathe: 2.0.3
       picomatch: 4.0.5
       std-env: 4.2.0


### PR DESCRIPTION
> **Stacked on #75.** Base is `feat/game-data-hero-record-merge`, so the diff here is just the app. Merge #75 first and this retargets to `main` cleanly.

## What

A read-only React + Vite app over every export of `ultimatedarktowerdata` — **28 datasets, ~1,300 records**. Deployed to `/UltimateDarkTower/codex/`, port 3006 in dev (`pnpm run dev:codex`).

## Why

The card layer imported in `55dfad3` had **no consumer anywhere in the monorepo** — several thousand lines of transcribed card text nobody had looked at by eye. This is where you look at it. It reads the package directly, so it is never a copy that drifts.

It's also honest about the data's gaps, which is half the point. Rows the source author could not fully observe are stamped `needs review` with their source note shown, and the home page reports the known gaps — 6 flagged rows, 14 of 60 locations without an identified dungeon, 4 provisional Expeditions heroes — rather than leaving them buried in `docs/open-questions.md`.

Building it is what surfaced the duplicate hero record fixed in #75.

## Design

Everything hangs off **one registry** (`src/datasets.ts`) declaring per dataset its rows, key, columns, facets and cross-links. Every view is a generic renderer over an entry there, so **adding a dataset is a data edit, never a component**. There is deliberately no per-dataset render config — `render.tsx`'s `<Fields>` walks `Object.entries()` and handles every shape the package exports.

Records cross-link on the shared kebab-case ids: a foe reaches its printed card and its tower sound, a box component reaches the card that names it, a board location reaches its dungeon's room pool. One `NAME_INDEX` powers all of it rather than wiring each pair by hand.

No router, no table library, no state library, no CSS framework. The URL is the single source of truth for dataset, record, search, facets and view mode, so every filtered view is deep-linkable.

## The drift guard

`src/datasets.test.ts` asserts the registry covers **every export** of `ultimatedarktowerdata`. Add data there and this app's tests go red until it's registered — the codex cannot silently stop being a complete view. It also checks every key is unique and URL-safe, every cross-link resolves, and every record has a readable title.

Those guards earned their keep — they caught four real bugs during the build:

| Bug | How it would have shown |
| --- | --- |
| Hero sheets had empty keys | Every row linked to the same broken URL |
| `/` in box-category keys (`"Manuals / Sheets"`) | Faked a path segment, breaking the hash route |
| 26 components labelled by `type`/`color`, not `name` | Collided into 2 keys; rendered as raw composite keys |
| A filter link with no visible chip | "3 of 212" with nothing on screen explaining why |

## Look and feel

Deliberately **not** the tower's slate and crimson — it's a reference library, so it reads like one: warm paper, botanical ink, records as catalog cards, Fraunces/Karla/DM Mono. `@udtc/theme`'s stylesheet is **not** imported (that *is* the tower palette); only its `useTheme` store is reused, for the shared `udtc-theme` localStorage key and `data-theme` contract.

Contrast was checked rather than eyeballed — the first palette failed WCAG AA on `--ink-faint` (3.24:1 light, 4.28:1 dark) for text carrying real content; re-derived to 5.28 / 4.90.

## Registration

`deploy-pages.yml`, the Pages landing data (which also points the game-data library card at this app as its demo), `docs/local-development.md`, the root `dev:codex` alias, and eslint's React surfaces.

## Verification

`pnpm run ci` passes. Worth a look at Treasures in card view, `#/foes/oreks` (Related should reach both the card face and the tower sound), Potions & gear for the review stamps, and the Day/Night toggle.