### PR TITLE
fix(codex): dedupe react so the app actually mounts

### DIFF
--- a/.changeset/codex-react-dedupe.md
+++ b/.changeset/codex-react-dedupe.md
@@ -1,0 +1,23 @@
+---
+'ultimatedarktowercodex': patch
+---
+
+Fix the blank page in production: dedupe `react`/`react-dom` in the Vite config.
+
+`@udtc/theme` is source-only and declares `react` as a **peer**, so pnpm gives it
+its own copy under `packages/creator-theme/node_modules/react` while the app
+resolves the workspace root copy. Without `resolve.dedupe` both were bundled,
+and `useTheme`'s `useSyncExternalStore` ran against the copy whose dispatcher
+was never set — the app threw
+`Cannot read properties of null (reading 'useSyncExternalStore')` on mount and
+rendered nothing.
+
+Every other React app here already sets this (`creator`, `player`, `digital`);
+the codex was the only one that didn't.
+
+Also adds `src/App.test.tsx`, which mounts the real `<App/>` through the real
+theme store and asserts registry content reaches the DOM. The existing suite
+checked the data and the data was fine, so a blank page passed every test. The
+new suite fails with all five cases when `dedupe` is removed, so it guards the
+actual regression rather than restating it. Test environment moves to `jsdom`
+for it.

--- a/apps/codex/CLAUDE.md
+++ b/apps/codex/CLAUDE.md
@@ -57,5 +57,14 @@ replacement.
 
 ## Tests
 
-`environment: 'node'` — the only suite is a pure data check, so there is no
-`jsdom` devDep. Add one with the first component test.
+Two suites, `environment: 'jsdom'`:
+
+- **`datasets.test.ts`** — the registry drift guard (above), plus key uniqueness,
+  URL-safety, link resolution and readable titles.
+- **`App.test.tsx`** — mounts the real `<App/>` and asserts registry content
+  reaches the DOM. It exists because a blank page once shipped while every data
+  test passed: `resolve.dedupe` was missing from `vite.config.ts`, two React
+  copies got bundled (`@udtc/theme` is source-only with react as a _peer_, so it
+  has its own), and `useTheme`'s `useSyncExternalStore` hit a null dispatcher.
+  **Do not remove `dedupe`** — pull it out and all five render cases fail, which
+  is the point.

--- a/apps/codex/package.json
+++ b/apps/codex/package.json
@@ -28,6 +28,7 @@
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "@vitejs/plugin-react": "catalog:",
+    "jsdom": "catalog:",
     "typescript": "catalog:",
     "vite": "catalog:",
     "vitest": "catalog:"

--- a/apps/codex/src/App.test.tsx
+++ b/apps/codex/src/App.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * Does the app actually mount and render data?
+ *
+ * This exists because it didn't, once. `@udtc/theme` is source-only with react as a *peer*, so
+ * pnpm gives it its own react copy; without `resolve.dedupe` the build shipped two Reacts, and
+ * `useTheme`'s `useSyncExternalStore` ran against the copy whose dispatcher was never set. The
+ * page was blank in production while every registry test passed — they check the data, and the
+ * data was fine.
+ *
+ * So this suite renders the real <App/> through the real theme store and asserts something from
+ * the registry reaches the DOM. It is deliberately shallow: coverage of *what* renders belongs to
+ * datasets.test.ts. What is guarded here is only that rendering happens at all.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import App from './App';
+import { DATASETS, TOTAL_ROWS } from './datasets';
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  window.location.hash = '';
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+/** Mount at a route and return the rendered text. */
+function renderAt(hash: string): string {
+  window.location.hash = hash;
+  act(() => root.render(<App />));
+  return container.textContent ?? '';
+}
+
+describe('App renders', () => {
+  it('mounts the home page with every dataset in the sidebar', () => {
+    const text = renderAt('');
+    // The specific failure this guards: a null dispatcher throws during render and leaves the
+    // container empty, so assert on real content rather than "did not throw".
+    expect(text).toContain('Tower Codex');
+    expect(text).toContain(TOTAL_ROWS.toLocaleString());
+    for (const d of DATASETS) {
+      expect(text, `sidebar is missing ${d.id}`).toContain(d.name);
+    }
+  });
+
+  it('renders a dataset table with its records', () => {
+    const text = renderAt('#/treasures');
+    expect(text).toContain('Treasures');
+    expect(text).toContain('62 records');
+    expect(text).toContain('Lamp of Hope');
+  });
+
+  it('renders a record detail with its cross-links', () => {
+    const text = renderAt('#/foes/oreks');
+    expect(text).toContain('Oreks');
+    expect(text).toContain('See also');
+    expect(text).toContain('Card face');
+  });
+
+  it('renders the review stamp and its source note', () => {
+    const text = renderAt('#/potions-gear/gilded-alembic');
+    expect(text).toContain('needs review');
+    expect(text).toContain('not legible');
+  });
+
+  it('renders global search results', () => {
+    const text = renderAt('#/search?q=arkartus');
+    // The open question this app exists to surface: the name appears in two datasets.
+    expect(text).toContain('Monthly quests');
+    expect(text).toContain('Board locations');
+  });
+});

--- a/apps/codex/vite.config.ts
+++ b/apps/codex/vite.config.ts
@@ -13,6 +13,13 @@ export default defineConfig({
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),
     },
+    // REQUIRED, not tidiness. `@udtc/theme` is source-only with react as a *peer*, so pnpm gives
+    // it its own react under packages/creator-theme/node_modules while the app resolves the root
+    // copy. Without dedupe both get bundled, `useTheme`'s useSyncExternalStore runs against the
+    // copy whose dispatcher was never set, and the app dies on mount with
+    // "Cannot read properties of null (reading 'useSyncExternalStore')" — a blank page.
+    // Every other React app here does the same (creator, player, digital).
+    dedupe: ['react', 'react-dom'],
   },
   server: {
     port: 3006,
@@ -22,8 +29,9 @@ export default defineConfig({
     port: 4006,
   },
   test: {
-    // The only suite is a pure data check over the registry — no DOM, so no jsdom dependency.
-    environment: 'node',
+    // jsdom, because one suite actually mounts the app. A registry that passes every data check
+    // while the app fails to render is exactly the gap that shipped a blank page once.
+    environment: 'jsdom',
     include: ['src/**/*.{test,spec}.{ts,tsx}'],
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: 'catalog:'
         version: 6.0.4(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+      jsdom:
+        specifier: 'catalog:'
+        version: 25.0.1
       typescript:
         specifier: 'catalog:'
         version: 5.9.3


### PR DESCRIPTION
The deployed Codex page is **blank**, throwing on mount:

```
Uncaught TypeError: Cannot read properties of null (reading 'useSyncExternalStore')
```

## Cause

`@udtc/theme` is source-only and declares `react` as a **peer**, so pnpm gives it its own copy while the app resolves the workspace root copy:

| Package | Resolves `react` to |
| --- | --- |
| `apps/codex` | `<root>/node_modules/react` |
| `packages/creator-theme` | `packages/creator-theme/node_modules/react` |

Without `resolve.dedupe` both get bundled. `useTheme`'s `useSyncExternalStore` then runs against the copy whose dispatcher was never set, so render throws before producing any DOM.

**Every other React app here already sets this** — `creator`, `player` and `digital` all list `react`/`react-dom` in `resolve.dedupe`. The codex was the only one that didn't. That's the whole bug.

Confirmed from the sourcemap module graph: **two** react package roots before, **one** after. Bundle drops 348.31 → 344.19 kB.

## Why no test caught it

The suite checked the registry — and the registry was fine. A blank page passed every assertion, because nothing ever rendered.

So this adds `src/App.test.tsx`: mounts the real `<App/>` through the real theme store and asserts registry content reaches the DOM. It's deliberately shallow — *what* renders is `datasets.test.ts`'s job; this guards only that rendering happens at all.

It reproduces the production failure. With `dedupe` removed, all five cases fail with the same null-dispatcher error; with it, they pass. Verified both directions rather than assumed.

Test environment moves to `jsdom`. `jsdom` (`catalog:`) is the only added dep — no assertion library, since `react-dom/client` mounts it directly.

## Verification

`pnpm run ci` passes. Once merged, the Pages deploy will rebuild `/codex/`.