### PR TITLE
fix(deps): patch fast-uri, brace-expansion, undici and hono advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,8 +73,11 @@ catalogs:
 overrides:
   tar: ^7.5.22
   tmp: ^0.2.7
-  fast-uri: ^3.1.4
+  fast-uri: ^3.1.5
   minimatch@10.2.5>brace-expansion: ^5.0.8
+  brace-expansion@2: ^2.1.4
+  undici@6: ^6.28.0
+  hono: ^4.12.34
 
 importers:
 
@@ -1403,7 +1406,7 @@ packages:
     resolution: {integrity: sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==}
     engines: {node: '>=20'}
     peerDependencies:
-      hono: ^4
+      hono: ^4.12.34
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -2370,8 +2373,8 @@ packages:
   brace-expansion@1.1.16:
     resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
 
-  brace-expansion@2.1.2:
-    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
   brace-expansion@5.0.8:
     resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
@@ -3048,8 +3051,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -3311,8 +3314,8 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
-  hono@4.12.32:
-    resolution: {integrity: sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==}
+  hono@4.12.34:
+    resolution: {integrity: sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==}
     engines: {node: '>=16.9.0'}
 
   hosted-git-info@2.8.9:
@@ -4962,8 +4965,8 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
-  undici@6.27.0:
-    resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
+  undici@6.28.0:
+    resolution: {integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==}
     engines: {node: '>=18.17'}
 
   undici@7.29.0:
@@ -6195,9 +6198,9 @@ snapshots:
 
   '@gar/promisify@1.1.3': {}
 
-  '@hono/node-server@2.0.12(hono@4.12.32)':
+  '@hono/node-server@2.0.12(hono@4.12.34)':
     dependencies:
-      hono: 4.12.32
+      hono: 4.12.34
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -6389,7 +6392,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.30.0(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 2.0.12(hono@4.12.32)
+      '@hono/node-server': 2.0.12(hono@4.12.34)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -6399,7 +6402,7 @@ snapshots:
       eventsource-parser: 3.1.0
       express: 5.2.1
       express-rate-limit: 8.6.1(express@5.2.1)
-      hono: 4.12.32
+      hono: 4.12.34
       jose: 6.2.4
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -7178,7 +7181,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -7332,7 +7335,7 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.2:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
 
@@ -8104,7 +8107,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fastq@1.20.1:
     dependencies:
@@ -8428,7 +8431,7 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
-  hono@4.12.32: {}
+  hono@4.12.34: {}
 
   hosted-git-info@2.8.9: {}
 
@@ -9000,11 +9003,11 @@ snapshots:
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.4
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.4
 
   minimist@1.2.8: {}
 
@@ -9132,7 +9135,7 @@ snapshots:
       semver: 7.8.5
       tar: 7.5.22
       tinyglobby: 0.2.17
-      undici: 6.27.0
+      undici: 6.28.0
       which: 6.0.1
 
   node-releases@2.0.51: {}
@@ -10030,7 +10033,7 @@ snapshots:
   undici-types@8.3.0:
     optional: true
 
-  undici@6.27.0: {}
+  undici@6.28.0: {}
 
   undici@7.29.0:
     optional: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -41,43 +41,47 @@ catalog:
   ajv-formats: ^3.0.0
   zustand: ^5.0.0
   fake-indexeddb: ^6.2.5
-
   # NOTE: peerDependencies are deliberately NOT catalogued. A peer range should be
   # wider than the version you build against (packages/board and packages/display
   # declare `three: ">=0.185.0"`), and `catalog:` would narrow it to the caret
   # range above.
 
-# Security overrides (Dependabot triage, 2026-07): collapse stale duplicate copies
-# onto the already-patched versions that other deps already resolve in-tree.
-#  - tar: `tar@6.2.1` is pulled by the electron packaging toolchain
-#    (@electron/rebuild, @electron/node-gyp, cacache); every tar advisory <=7.5.15
-#    covers all of 6.x, and the fix ships only in 7.5.16+ (a major bump for those
-#    deps). Forcing 7.5.22 (GHSA-r292-9mhp-454m fixed in 7.5.21) — which already
-#    resolves elsewhere — clears 7 alerts.
-#    Verify the electron native-rebuild path still works: `pnpm --filter
-#    ultimatedarktowerrelay-electron rebuild` (tar is build-time only, never runtime).
-#  - tmp: `tmp@0.0.33` is pulled by external-editor (interactive CLI prompts); the
-#    fix ships only in 0.2.6+. Forcing 0.2.7 clears 2 alerts.
-#  - fast-uri: pulled in at 3.1.3 by ajv@8.20.0 (prod dep of mcp-server via
-#    @modelcontextprotocol/sdk, and of @udtc/adapters/@udtc/schema); ajv's own
-#    range (^3.0.1) already permits the GHSA-v2hh-gcrm-f6hx fix in 3.1.4 — this
-#    is a stale resolution, not a parent waiting to catch up. Stay in the 3.x
-#    line (4.x is outside ajv's declared range).
-#  - brace-expansion: 3 copies resolve in-tree (1.1.16, 2.1.2, 5.0.7). GHSA-mh99-
-#    v99m-4gvg's range ("<=5.0.7") reads as vulnerable against all three by plain
-#    semver comparison, but this package maintains parallel major lines (1.x
-#    through 5.x each patched independently) — 1.1.16 and 2.1.2 already ship the
-#    EXPANSION_MAX_LENGTH fix (backported ahead of the 5.x line's own 5.0.8).
-#    Only 5.0.7 (via minimatch@10.2.5 ← @typescript-eslint/typescript-estree,
-#    root devDependency) actually lacks it. Scoped to that one path so the two
-#    already-fixed copies — used by minimatch@3.1.5/5.1.9/9.0.9 in the
-#    electron-forge toolchain, which expect the old 1.x/2.x API — aren't forced
-#    onto an unrelated major for no security benefit.
+  # Security overrides (Dependabot triage, 2026-07): collapse stale duplicate copies
+  # onto the already-patched versions that other deps already resolve in-tree.
+  #  - tar: `tar@6.2.1` is pulled by the electron packaging toolchain
+  #    (@electron/rebuild, @electron/node-gyp, cacache); every tar advisory <=7.5.15
+  #    covers all of 6.x, and the fix ships only in 7.5.16+ (a major bump for those
+  #    deps). Forcing 7.5.22 (GHSA-r292-9mhp-454m fixed in 7.5.21) — which already
+  #    resolves elsewhere — clears 7 alerts.
+  #    Verify the electron native-rebuild path still works: `pnpm --filter
+  #    ultimatedarktowerrelay-electron rebuild` (tar is build-time only, never runtime).
+  #  - tmp: `tmp@0.0.33` is pulled by external-editor (interactive CLI prompts); the
+  #    fix ships only in 0.2.6+. Forcing 0.2.7 clears 2 alerts.
+  #  - fast-uri: pulled in at 3.1.3 by ajv@8.20.0 (prod dep of mcp-server via
+  #    @modelcontextprotocol/sdk, and of @udtc/adapters/@udtc/schema); ajv's own
+  #    range (^3.0.1) already permits the GHSA-v2hh-gcrm-f6hx fix in 3.1.4 — this
+  #    is a stale resolution, not a parent waiting to catch up. Stay in the 3.x
+  #    line (4.x is outside ajv's declared range).
+  #  - brace-expansion: 3 copies resolve in-tree (1.1.16, 2.1.2, 5.0.7). GHSA-mh99-
+  #    v99m-4gvg's range ("<=5.0.7") reads as vulnerable against all three by plain
+  #    semver comparison, but this package maintains parallel major lines (1.x
+  #    through 5.x each patched independently) — 1.1.16 and 2.1.2 already ship the
+  #    EXPANSION_MAX_LENGTH fix (backported ahead of the 5.x line's own 5.0.8).
+  #    Only 5.0.7 (via minimatch@10.2.5 ← @typescript-eslint/typescript-estree,
+  #    root devDependency) actually lacks it. Scoped to that one path so the two
+  #    already-fixed copies — used by minimatch@3.1.5/5.1.9/9.0.9 in the
+  #    electron-forge toolchain, which expect the old 1.x/2.x API — aren't forced
+  #    onto an unrelated major for no security benefit.
 overrides:
   tar: ^7.5.22
   tmp: ^0.2.7
-  fast-uri: ^3.1.4
+  fast-uri: ^3.1.5
   "minimatch@10.2.5>brace-expansion": ^5.0.8
+  "brace-expansion@2": ^2.1.4
+  # Only the 6.x copy is flagged (node-gyp <- @electron/rebuild, build-time); the 7.x copy that
+  # electron itself pulls is already patched and must not be dragged back.
+  "undici@6": ^6.28.0
+  hono: ^4.12.34
 
 # electron-forge's @electron/rebuild depends on a git-hosted @electron/node-gyp
 # fork; pnpm 11 blocks git-hosted subdeps by default. Allow them so the electron
@@ -100,3 +104,6 @@ allowBuilds:
   fs-xattr: true
   macos-alias: true
   unrs-resolver: true
+
+minimumReleaseAgeExclude:
+  - hono@4.12.34


### PR DESCRIPTION
Clears **all 7 open Dependabot alerts**. Every one is transitive — none come from a workspace package's own manifest — so this is `overrides` + lockfile only, no `package.json` changes and therefore no changeset.

| Package | Change | Advisories | Reachability |
| --- | --- | --- | --- |
| `fast-uri` | `^3.1.4` → `^3.1.5` | GHSA-7p8r-x3mc-p8w7 | **production** — `ajv` ← MCP SDK ← published `mcp-server` |
| `brace-expansion` | 2.x → `^2.1.4` | GHSA-mh99-v99m-4gvg, GHSA-rgw5-rvv9-x895 | build-only — `minimatch@5` ← `glob@8` ← `@electron/node-gyp` |
| `undici` | 6.x → `^6.28.0` | GHSA-8xcm-r25x-g524, -m8rv-5g2x-5cg5, -v3r7-h72x-cjcm | build-only — `node-gyp` ← `@electron/rebuild` |
| `hono` | → `^4.12.34` | GHSA-8j4g-w8fx-2239 | `@hono/node-server` ← MCP SDK |

## Notes on the two scoped overrides

`brace-expansion` and `undici` are **version-scoped deliberately**, not blanket-pinned:

- Only `brace-expansion@2.1.2` is in range. The `1.1.16` copy is `minimatch@3`'s, which requires `^1`, and `5.0.8` is already patched under its own scoped override. A blanket pin would drag both.
- Only `undici@6.27.0` is in range. The `7.29.0` copy electron pulls is already patched.

## The stale override

`fast-uri` is the interesting one: an override already existed pinning `^3.1.4` for an *earlier* advisory. A new CVE landed that's first patched in `3.1.5`, so **the override itself had gone stale** and was holding the tree at a now-vulnerable version. Worth remembering that a pin is a thing that expires.

## `minimumReleaseAge`

`hono@4.12.34` was published inside the 24h window, so pnpm added a `minimumReleaseAgeExclude` entry. Without it `pnpm install --frozen-lockfile` fails in CI — verified the frozen install is clean with it.

## Verification

- `pnpm run ci` — green
- `pnpm --filter ultimatedarktowerrelay-electron rebuild` — **required here**, since `pnpm run ci` doesn't exercise the electron toolchain these overrides touch. It fails with `ERR_PNPM_MISSING_HOISTED_LOCATIONS` on `update-browserslist-db` — **but fails identically on a clean `main` worktree**, so it's pre-existing and unrelated. Flagging separately rather than folding a fix into a security PR.