### PR TITLE
fix(relay-electron): rename rebuild script to rebuild:native

### DIFF
--- a/.changeset/electron-rebuild-script-name.md
+++ b/.changeset/electron-rebuild-script-name.md
@@ -1,0 +1,23 @@
+---
+'ultimatedarktowerrelay-electron': patch
+---
+
+Rename the native-rebuild script `rebuild` → `rebuild:native`, so the documented
+command actually runs it.
+
+`rebuild` is a **pnpm builtin** (`pnpm rebuild`, alias `rb`). Every doc in the
+repo said to run `pnpm --filter ultimatedarktowerrelay-electron rebuild`, which
+dispatched to pnpm's own command and never reached
+`electron-rebuild -f -w @stoprocent/bleno,@stoprocent/noble`. The builtin then
+failed with `ERR_PNPM_MISSING_HOISTED_LOCATIONS`, which reads like a broken
+install but is unrelated — under `nodeLinker: hoisted` it resolves packages by
+exact peer-suffixed depPath, while the hoisted linker records only one
+`hoistedLocations` key per physical directory, so a package with two peer
+variants in one directory can only be found under one of them.
+
+That left the only verification for the native BLE modules unavailable: this app
+has no `build` script, so `pnpm run ci` never exercises the electron toolchain,
+and `pnpm-workspace.yaml` names this command as the way to verify a `tar`/
+electron override.
+
+`rebuild:native` is not a builtin, so it works with or without `run`.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -106,7 +106,7 @@ Most tower-control detail now lives in the packages that own it, as per-package
 For any Dependabot alert/PR work, use the **`dependabot-triage`** skill
 (`.claude/skills/dependabot-triage/`) — it has the full playbook and this repo's
 durable traps (the `minimumReleaseAge` age gate, the `dependabot.yml` ignore
-policy, the electron `rebuild` verification step).
+policy, the electron `rebuild:native` verification step).
 
 ## Before committing
 

--- a/.claude/skills/dependabot-triage/SKILL.md
+++ b/.claude/skills/dependabot-triage/SKILL.md
@@ -115,7 +115,7 @@ pnpm run ci      # validate:nodes → lint → format:check → build → typech
   on your branch = you regressed it; fix it before shipping.
 - **`tar` overrides:** `pnpm run ci` does **not** exercise the electron toolchain
   (it has no `build` script). Verify explicitly:
-  `pnpm --filter ultimatedarktowerrelay-electron rebuild` (§5).
+  `pnpm --filter ultimatedarktowerrelay-electron rebuild:native` (§5).
 
 ## Step 6 — Ship (each step gated by the guardrails)
 
@@ -159,9 +159,12 @@ ignored in `dependabot.yml` — if Dependabot errors on `typescript`, that's why
   is ignored (major bumps taken manually). A major-only _security_ fix therefore
   won't auto-PR — it still shows as a Security-tab alert to handle by hand.
 - **Verify a `tar`/electron override with** `pnpm --filter
-ultimatedarktowerrelay-electron rebuild` — `pnpm run ci` skips it (no `build`
-  script). Bumping the `vite` major? re-check display's CJS `dist` still
-  `require()`s (see `references/repo-gotchas.md`).
+ultimatedarktowerrelay-electron rebuild:native` — `pnpm run ci` skips it (no
+  `build` script). The `:native` suffix is load-bearing: plain `rebuild` is a
+  pnpm builtin that never reaches the script and dies with
+  `ERR_PNPM_MISSING_HOISTED_LOCATIONS` (a red herring — see
+  `references/repo-gotchas.md` §5). Bumping the `vite` major? re-check display's
+  CJS `dist` still `require()`s (same file).
 
 ## Reference
 

--- a/.claude/skills/dependabot-triage/references/repo-gotchas.md
+++ b/.claude/skills/dependabot-triage/references/repo-gotchas.md
@@ -111,12 +111,35 @@ grep -E "<pkg>@<old-version>" pnpm-lock.yaml   # expect no output
 shipped. Forcing `tar` 6→7 risks that toolchain, so verify it:
 
 ```
-pnpm --filter ultimatedarktowerrelay-electron rebuild
+pnpm --filter ultimatedarktowerrelay-electron rebuild:native
 ```
 
 `relay-electron` has **no `build` script**, so `pnpm run ci` does NOT exercise
-this path — you must run `rebuild` (or `electron-forge package`) explicitly. The
-CI `relay-native` matrix job covers it on ubuntu+macOS × Node 22/24.
+this path — you must run `rebuild:native` (or `electron-forge package`)
+explicitly. The CI `relay-native` matrix job covers it on ubuntu+macOS × Node
+22/24.
+
+**The `:native` suffix is load-bearing.** `rebuild` alone is a **pnpm builtin**
+(`pnpm rebuild`, alias `rb`), so `pnpm --filter <pkg> rebuild` runs pnpm's own
+command and never reaches the package script. It then fails for an unrelated
+reason:
+
+```
+[ERR_PNPM_MISSING_HOISTED_LOCATIONS] update-browserslist-db@1.2.3(browserslist@4.28.5)
+is not found in hoistedLocations inside node_modules/.modules.yaml
+```
+
+That error is a **red herring — nothing is missing and nothing needs
+reinstalling.** Under `nodeLinker: hoisted` the builtin looks each package up by
+exact peer-suffixed depPath, but the hoisted linker writes only **one
+`hoistedLocations` key per physical directory**. A package with two peer
+variants sharing one directory therefore has one key, and the other lookup
+throws. Here `update-browserslist-db` resolves against both `browserslist@4.28.5`
+(webpack, via `@electron-forge/cli`) and `4.28.6` (`@babel/helper-compilation-targets`).
+`vite`, `vitest`, `@vitejs/plugin-react` and `@vitest/mocker` collide the same
+way via `@types/node`, so the builtin `pnpm rebuild` is broken repo-wide — and
+nothing in the repo or CI uses it. Don't chase it, and don't `rm -rf
+node_modules` over it.
 
 ## 6. Transient Actions "Set up job / Service Unavailable"
 

--- a/apps/relay-electron/CLAUDE.md
+++ b/apps/relay-electron/CLAUDE.md
@@ -15,8 +15,11 @@ silently ships a broken app — a missing native module **at runtime**, not a bu
 
 ## Native rebuild
 
-Rebuild native modules with `pnpm --filter ultimatedarktowerrelay-electron rebuild`
-(`electron-rebuild -f -w @stoprocent/bleno,@stoprocent/noble`). This is **not** part of
+Rebuild native modules with `pnpm --filter ultimatedarktowerrelay-electron rebuild:native`
+(`electron-rebuild -f -w @stoprocent/bleno,@stoprocent/noble`). The `:native` suffix is
+load-bearing — `rebuild` alone is a **pnpm builtin**, so `pnpm --filter … rebuild` runs
+pnpm's own command and never reaches this script (see the root `pnpm-workspace.yaml`).
+This is **not** part of
 `build` — `build` is deliberately `tsc --noEmit` only (typecheck-only, matching
 `typecheck`), so this app participates in the root `pnpm -r build` fan-out without every
 CI run packaging a full Electron app with native BLE deps. Real packaging/native rebuild

--- a/apps/relay-electron/README.md
+++ b/apps/relay-electron/README.md
@@ -19,7 +19,7 @@ BLE natives (`@stoprocent/bleno`, `@stoprocent/noble`) are prebuilt for Electron
 add/upgrade a native dep, rebuild for Electron with:
 
 ```bash
-pnpm --filter ultimatedarktowerrelay-electron rebuild
+pnpm --filter ultimatedarktowerrelay-electron rebuild:native
 ```
 
 ### Package / distribute

--- a/apps/relay-electron/package.json
+++ b/apps/relay-electron/package.json
@@ -13,7 +13,7 @@
     "package": "electron-forge package",
     "make": "electron-forge make",
     "publish": "electron-forge publish",
-    "rebuild": "electron-rebuild -f -w @stoprocent/bleno,@stoprocent/noble",
+    "rebuild:native": "electron-rebuild -f -w @stoprocent/bleno,@stoprocent/noble",
     "test": "vitest run --passWithNoTests"
   },
   "author": "ChessMess",

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -93,7 +93,7 @@ above.)
   Shortcut: `pnpm run dev:relay-electron`. Needs the native BLE modules
   built, which the root install's `allowBuilds` handles. If the native
   modules complain, rebuild them:
-  `pnpm --filter ultimatedarktowerrelay-electron rebuild`.
+  `pnpm --filter ultimatedarktowerrelay-electron rebuild:native`.
 
 - **MCP Server** (`mcp-server-return-to-dark-tower`) — watch-mode stdio
   server for AI assistants to control the tower:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -54,7 +54,9 @@ catalog:
   #    deps). Forcing 7.5.22 (GHSA-r292-9mhp-454m fixed in 7.5.21) — which already
   #    resolves elsewhere — clears 7 alerts.
   #    Verify the electron native-rebuild path still works: `pnpm --filter
-  #    ultimatedarktowerrelay-electron rebuild` (tar is build-time only, never runtime).
+  #    ultimatedarktowerrelay-electron rebuild:native` (tar is build-time only, never
+  #    runtime). The `:native` suffix matters — `rebuild` alone is a pnpm builtin, and
+  #    under `nodeLinker: hoisted` it dies with ERR_PNPM_MISSING_HOISTED_LOCATIONS.
   #  - tmp: `tmp@0.0.33` is pulled by external-editor (interactive CLI prompts); the
   #    fix ships only in 0.2.6+. Forcing 0.2.7 clears 2 alerts.
   #  - fast-uri: pulled in at 3.1.3 by ajv@8.20.0 (prod dep of mcp-server via


### PR DESCRIPTION
## The bug

`pnpm --filter ultimatedarktowerrelay-electron rebuild` fails with:

```
[ERR_PNPM_MISSING_HOISTED_LOCATIONS] update-browserslist-db@1.2.3(browserslist@4.28.5)
is not found in hoistedLocations inside node_modules/.modules.yaml
```

This is the **only** verification for the native BLE modules — `relay-electron`
has no `build` script, so `pnpm run ci` never exercises the electron toolchain,
and `pnpm-workspace.yaml` names this command as the way to verify a `tar`/electron
override. While it was broken, that whole path was unavailable.

## Root cause — it isn't the hoist map

**`rebuild` is a pnpm builtin** (`pnpm rebuild`, alias `rb`). So
`pnpm --filter <pkg> rebuild` runs *pnpm's own* rebuild and never reaches the
package's `"rebuild": "electron-rebuild -f -w @stoprocent/bleno,@stoprocent/noble"`.

The builtin then fails for an unrelated reason. Under `nodeLinker: hoisted` it
resolves each package by exact peer-suffixed depPath against `hoistedLocations`,
but the hoisted linker writes **one key per physical directory**. `update-browserslist-db@1.2.3`
has two peer variants — `browserslist@4.28.5` (webpack, via `@electron-forge/cli`)
and `4.28.6` (`@babel/helper-compilation-targets`) — sharing one directory, so only
the `4.28.6` key is recorded and the other lookup throws.

`vite`, `vitest`, `@vitejs/plugin-react` and `@vitest/mocker` collide the same way
via `@types/node` 22.20.1-vs-26.1.1, so the builtin `pnpm rebuild` is broken
repo-wide — and nothing in the repo or CI uses it (`ci.yml` uses
`exec electron-forge package`). The error message is a red herring; nothing is
missing and no reinstall helps.

## The fix

Rename the script `rebuild` → `rebuild:native`. Not a builtin name, so it works
with or without `run`, and the collision can't recur. Updates the command in all
7 doc references, and documents the trap in `references/repo-gotchas.md` §5 so
nobody burns time on `ERR_PNPM_MISSING_HOISTED_LOCATIONS` again.

**Not doing:** deduping `@types/node` (22.20.1 / 24.13.3 / 26.1.1 all resolve
in-tree) or `browserslist`. That's lockfile surgery with real blast radius, to
repair a builtin nothing uses.

## Verification

```
$ pnpm --filter ultimatedarktowerrelay-electron rebuild:native
$ electron-rebuild -f -w @stoprocent/bleno,@stoprocent/noble
Searching dependency tree
Building modules: @serialport/bindings-cpp, @stoprocent/bleno,
  @stoprocent/bluetooth-hci-socket, @stoprocent/noble, usb
✔ Rebuild Complete          # exit 0
```

`pnpm run ci` passes (exit 0). The one lint warning
(`packages/core/src/adapters/noble-browser-stub.cjs`) is pre-existing and
untouched here.