### PR TITLE
docs(game-data): correct the v3.0.0 migration changelog

### DIFF
--- a/.changeset/hero-record-merge.md
+++ b/.changeset/hero-record-merge.md
@@ -7,7 +7,7 @@ entries now carry the gameplay sheet — `bannerAction`, `defaultVirtues`,
 `unlockableVirtues` — alongside board identity, and the foe/adversary/companion
 copies are gone in favour of the rosters that already covered them.
 
-Through v2 the same 14 heroes existed twice: identity in `heroes.ts` keyed by a
+Through v2, 10 of the 14 heroes existed twice: identity in `heroes.ts` keyed by a
 stable `id`, and the gameplay sheet in `gameContent.HEROES` keyed by display name
 with no `id` at all. Nothing could join the two halves except by matching on a
 name string, and the two could drift apart silently. The split was never a
@@ -40,6 +40,12 @@ So the merge keeps the `id`-keyed roster and folds the sheet into it.
 
 `hero.expansion` (`'Base Game' | 'Alliances' | 'Covenant'`) is gone; it agreed
 with `hero.source` on all 10 rows, so `source` is the single vocabulary now.
+
+**Adversaries no longer have their own type.** `gameContent.Adversary` collapses
+into `Foe` — `ADVERSARY_ROSTER` is a `readonly Foe[]`, and `ALL_FOES` is
+`[...FOES, ...ADVERSARY_ROSTER]`. Annotate with `Foe` wherever you used
+`Adversary`; the fields you were reading are all still there, plus `id`, `tier`
+and `source`.
 
 ```diff
 -import { gameContent } from 'ultimatedarktowerdata';

--- a/packages/game-data/CLAUDE.md
+++ b/packages/game-data/CLAUDE.md
@@ -10,7 +10,7 @@ inventory, card text) + seed encode/decode. Split out of `ultimatedarktower` in 
 - **Rosters** (`foes.ts`, `heroes.ts`, `monuments.ts`, `board/gameBoard.ts`) — who exists,
   keyed by stable kebab-case `id`. Canonical for names.
   - **`heroes.ts` also carries the hero gameplay sheet** (`bannerAction`, `defaultVirtues`,
-    `unlockableVirtues`) as of v3. Through v2 the same 14 heroes existed twice — identity here
+    `unlockableVirtues`) as of v3. Through v2, 10 of the 14 heroes existed twice — identity here
     and the sheet in `gameContent.HEROES`, keyed by name with no `id`, joinable only on a
     display string. The split was a workaround for the `Hero`/`HEROES` collision, not a
     modelling call, and the sheet half had zero consumers. **Do not re-add a second hero

--- a/packages/game-data/src/boxInventory.ts
+++ b/packages/game-data/src/boxInventory.ts
@@ -1,5 +1,6 @@
 // Return to Dark Tower — box inventory (physical component counts).
-// "What's in the box" data for UDT apps. Gameplay content lives in gameContent.ts.
+// "What's in the box" data for UDT apps. Gameplay content lives in the flat
+// rosters (heroes.ts, foes.ts, companionCards.ts, …).
 // Source: "RTDT Expansion Info v2.xlsx" (categories with < 2 entries were skipped).
 
 /** Top-level grouping a category sits under on a component sheet. */

--- a/packages/game-data/src/companionCards.ts
+++ b/packages/game-data/src/companionCards.ts
@@ -2,8 +2,9 @@
  * companionCards.ts — the printed card face for all 22 companions.
  *
  * 10 base-game quest companions (recruited by completing their quest) and 12 guild
- * companions, three per guild. `gameContent.COMPANIONS` holds the same 10 quest
- * companions as name+title only; this is the full card.
+ * companions, three per guild. Through v2, `gameContent.COMPANIONS` held the same
+ * 10 quest companions as name+title only; this is the full card, and the quest ten
+ * are the rows carrying a `quest`.
  */
 
 import type { BoardKingdom } from './board/gameBoard';

--- a/packages/game-data/src/heroes.ts
+++ b/packages/game-data/src/heroes.ts
@@ -5,7 +5,7 @@
  * seed-encoded. 14 heroes: 4 base, 2 Alliances, 4 Covenant, 4 Expeditions (Expeditions is
  * unreleased; its heroes are publicly confirmed but provisional until the box ships).
  *
- * This is the ONE hero record. Until v3 the same 14 heroes existed twice — identity here
+ * This is the ONE hero record. Until v3, 10 of the 14 existed twice — identity here
  * (keyed by `id`) and the gameplay sheet in `gameContent.HEROES` (keyed by name, no id at
  * all), so nothing could join them without matching on a display string. The split was a
  * workaround for a `Hero`/`HEROES` name collision, not a modelling decision, and the sheet


### PR DESCRIPTION
Found while reviewing what PR #58 would publish. `ultimatedarktowerdata` 2.2.0 →
**3.0.0** is a genuine major that removes the whole `gameContent` namespace, so
`.changeset/hero-record-merge.md` becomes the published CHANGELOG — and
`packages/game-data` ships `CHANGELOG.md` in its `files` list, so this text is
the migration doc external consumers actually receive.

## 1. The hero count was wrong

> Through v2 the same **14** heroes existed twice

`heroes.ts` has 14 rows, but only **10** carry `bannerAction`, and the removed
`gameContent.ts` held 10 hero sheets. The same document already says "all **10**
hero sheets transferred byte-identical" and "**four** heroes genuinely have no
sheet" (the unreleased Expeditions heroes).

A reader hitting "14 existed twice" and then "four have no sheet" concludes data
was dropped in the merge. Nothing was. Corrected to "10 of the 14".

## 2. `Adversary` → `Foe` was an unremarked type collapse

The migration table maps three types onto two in a single cell:

| Removed | Use instead |
| --- | --- |
| `gameContent.Foe` / `.Adversary` / `.Companion` | `Foe` / `CompanionCard` |

Nothing says adversaries are now modelled as `Foe` — `ADVERSARY_ROSTER` is a
`readonly Foe[]` and `ALL_FOES` is `[...FOES, ...ADVERSARY_ROSTER]`. A consumer
with `let a: gameContent.Adversary` can't guess `Foe` from that row. Added a
short paragraph after the table.

## 3. Two stale source comments from the same removal

- `boxInventory.ts` — "Gameplay content lives in gameContent.ts" (that file is
  deleted).
- `companionCards.ts` — "`gameContent.COMPANIONS` **holds** the same 10 quest
  companions", present tense.

## What I verified but did not change

Every replacement name in the migration table resolves against the real v3
export surface (`HERO_BY_NAME`, `HERO_BY_ID`, `HEROES`, `FOES`,
`ADVERSARY_ROSTER`, `COMPANION_CARDS`, `KINGDOM_VIRTUES`, `kingdomVirtues`,
`KingdomDirection`, `Virtue`, `Hero`, `Foe`, `CompanionCard`, `ContentSource`) —
no dangling references. `gameContent` was a named export of `.`, never a
subpath, so the `import { gameContent }` diff has the right shape. Nothing in
the repo still imports it, and `virtues.test.ts` asserts it stays gone.

## Verification

`pnpm run ci` passes (exit 0). `pnpm --filter ultimatedarktowerdata test` — 326
passed / 13 files. `pnpm changeset status` still resolves `ultimatedarktowerdata`
to **major**.

Merging this regenerates the "Version Packages" PR (#58) with the corrected text.