### PR TITLE
feat(pages): let a card override its primary button label

### DIFF
--- a/docs/pages/landing.data.mjs
+++ b/docs/pages/landing.data.mjs
@@ -14,6 +14,8 @@
 //   demo     path under the Pages site (./<demo>/), or null if no live demo
 //   demoUrl  full external URL for the primary Launch/Demo button, overriding
 //            `demo` — use for a component hosted outside this Pages site
+//   primaryLabel  override the primary button's text, instead of deriving it from
+//            `category` ('Demo' for a library, 'Launch' for an app)
 //   sourceUrl  override for the Source link, instead of deriving
 //              `<repo>/tree/main/<dir>`
 //   docsUrl  override for the Docs link, instead of deriving from `dir`/docs
@@ -216,8 +218,11 @@ export const components = [
     blurb:
       'Board locations, foes, heroes, monuments, and seed encode/decode — the canonical Return to Dark Tower reference data in strict TypeScript types.',
     category: 'library',
-    // The Codex app is this library's demo — it browses every export.
+    // The Codex app is this library's demo — it browses every export. Same URL as
+    // the Tower Codex card, so it carries the same 'Launch' label rather than the
+    // 'Demo' a library would otherwise get.
     demo: 'codex',
+    primaryLabel: 'Launch',
     glyph: 'banner',
     image: 'game-data.jpg',
     alt: 'The physical Return to Dark Tower board and expansions, with the reference data extracted from it overlaid as a graph',

--- a/scripts/pages/build-landing.mjs
+++ b/scripts/pages/build-landing.mjs
@@ -101,7 +101,7 @@ function renderCard(c, index) {
           <span class="glyph g-${c.glyph}"></span>${ribbon}
         </a>`;
 
-  const primaryLabel = c.category === 'library' ? 'Demo' : 'Launch';
+  const primaryLabel = c.primaryLabel || (c.category === 'library' ? 'Demo' : 'Launch');
   const links = [
     demoUrl &&
       `<a class="primary" href="${esc(demoUrl)}" target="_blank" rel="noopener">${primaryLabel}</a>`,


### PR DESCRIPTION
On the Pages landing page, the **Tower Data** library card and the **Tower
Codex** app card both point their primary button at `./codex/` — but rendered
different labels, because the label came only from `category`:

```js
const primaryLabel = c.category === 'library' ? 'Demo' : 'Launch';
```

Same destination, two labels. The Codex app genuinely *is* game-data's demo
(already noted in a comment on that entry), so it should read "Launch" on both.

## Change

An optional `primaryLabel` field, following the file's existing override
convention — `demoUrl`, `sourceUrl`, `docsUrl`, `alt` and `status` all already
override a derived default:

```js
const primaryLabel = c.primaryLabel || (c.category === 'library' ? 'Demo' : 'Launch');
```

Set on the Tower Data entry, documented in the field-contract comment. The
category rule is untouched, so the other three library cards keep "Demo".

## Verification

`node scripts/pages/build-landing.mjs`, then the rendered label per card:

```
Tower Codex             -> Launch
...
Tower Core              -> Demo
Tower Display           -> Demo
Tower Board             -> Demo
Tower Data              -> Launch     <- changed
```

`pnpm run ci` passes (exit 0).

## Note — `docs/pages/index.html` is stale, deliberately not touched here

That file is tracked but is only a local preview artifact: `deploy-pages.yml:86`
regenerates the served page with
`node scripts/pages/build-landing.mjs "$SITE/index.html"`. The committed copy
predates the Tower Codex app entirely and is behind on ~10 version numbers, so
regenerating it sweeps a lot of unrelated churn into this diff. Left for a
separate refresh.