### PR TITLE
fix(display): stop light sequences (and their sound) replaying on unrelated state changes

### DIFF
--- a/.changeset/adapters-clear-led-sequence.md
+++ b/.changeset/adapters-clear-led-sequence.md
@@ -1,0 +1,14 @@
+---
+'@udtc/adapters': patch
+---
+
+Fix: `createDisplayAdapter` no longer re-fires a light sequence on every subsequent op.
+
+`light.named` stamped `current.led_sequence = numId` onto the adapter's long-lived
+`TowerState` and never cleared it — unlike `current.audio`, which was already reset in
+both places. Since `packFullState()` packs byte 18 into every snapshot pushed to the
+relay, the **physical tower** re-ran the light sequence on each later drum rotation,
+sound, or seal op in the same program.
+
+`led_sequence` is now cleared alongside `current.audio`, at the `wait` boundary and at
+the end of `program()`.

--- a/.changeset/sequence-completed-id-latch.md
+++ b/.changeset/sequence-completed-id-latch.md
@@ -1,0 +1,32 @@
+---
+'ultimatedarktowerdisplay': patch
+---
+
+Fix: a light sequence no longer replays every time unrelated state changes.
+
+`state.led_sequence` is a one-shot edge trigger, but it rides inside a full-state
+snapshot that consumers keep re-sending long after the sequence ended.
+`SequenceAnimator.apply()` only deduplicated a same-id re-apply _while the timeline was
+alive_ — `wrapComplete()` zeroes `currentSequenceId` on completion — so any later
+`applyState` still carrying the spent id rebuilt the timeline and played the whole
+sequence again. Every path that re-applies a stored state hit this: rotating a drum,
+clicking an LED (`clearLedOverrides` / `handleLedClick` both re-apply
+`getResolvedState()`), switching renderers, popping out, and the post-GLB-load replay.
+
+`SequenceAnimator` now latches the id of the last sequence that ran to completion and
+will not rebuild it. A state carrying `led_sequence: 0` re-arms it, as do `stop()` and
+`applyTransient()` — so `playSequence()` is never suppressed, and a deliberate
+re-trigger of the same sequence only needs a zero in between. The latched call returns
+`false`, so the renderer resumes normal per-LED replay for the incoming state instead of
+freezing on the sequence's last frame.
+
+Consumers driving from full-state snapshots should still clear `led_sequence` after
+sending it (as `ultimatedarktower` does on every tower response) — the latch is a
+backstop on the receiving side and does not cover the physical tower.
+
+The example's Trigger Sequence button now applies an empty state before firing, so every
+sequence plays from a clean tower and re-triggering the same one works. It also remembers
+a _resting_ copy of each applied state, with both one-shot triggers (`led_sequence` and
+`audio.sample`) zeroed — the sequence's bound sound was replaying on the next drum
+rotation for the same reason the lights were, compounded by the example passing
+`force: true` on every action, which bypasses the audio dedup.

--- a/packages/creator-adapters/src/display.ts
+++ b/packages/creator-adapters/src/display.ts
@@ -155,8 +155,12 @@ export function createDisplayAdapter(opts: {
           const { ticks = 1 } = op as { channel: 'wait'; ticks?: number };
           snapshots.push({ data: packFullState(), delayMs: pendingDelayMs });
           pendingDelayMs = ticks * TICKS_TO_MS;
-          // Clear transient audio so it doesn't re-fire in the next snapshot
+          // Clear transient audio + light sequence so they don't re-fire in the
+          // next snapshot — both are one-shot triggers the tower reads on the
+          // edge, but `current` is long-lived and gets packed into every later
+          // packet.
           current.audio = { sample: 0, loop: false, volume: 0 };
+          current.led_sequence = 0;
           continue;
         }
 
@@ -174,6 +178,7 @@ export function createDisplayAdapter(opts: {
     // Close the final (or only) snapshot
     snapshots.push({ data: packFullState(), delayMs: pendingDelayMs });
     current.audio = { sample: 0, loop: false, volume: 0 };
+    current.led_sequence = 0;
     return { snapshots };
   }
 

--- a/packages/display/docs/API.md
+++ b/packages/display/docs/API.md
@@ -705,7 +705,17 @@ If `bindSequenceToSample` is enabled in the audio config and the sequence has a 
 
 Returns `true` if the sequence started (or was already running), `false` for an unknown id. State-driven drums, individual LEDs, and seal visibility continue to apply normally during transient playback — only `SequenceAnimator.apply(0)` is suppressed. No-op (returns `false`) when the display has no 3D renderer.
 
+`playSequence` is never suppressed by the completed-id latch below — it is an explicit command, so calling it twice with the same id plays the sequence twice.
+
 See [AUDIO](AUDIO.md#one-shot-transient-playback-playsample) for the architectural rationale (same model as `playSample`).
+
+##### `led_sequence` is a one-shot trigger — the completed-id latch — 1.1.1+
+
+`state.led_sequence` rides inside a _full-state snapshot_, but it is an edge trigger: the sequence should fire once, when the id arrives. Consumers that mirror snapshots keep re-sending the same id long after the sequence ended (a drum rotation, an LED click, a renderer switch and a GLB reload all re-apply the stored state), and every one of those used to rebuild the timeline and replay the whole sequence.
+
+`SequenceAnimator` now latches the id of the last sequence that ran to completion and refuses to rebuild it. An `apply(0)` — i.e. any state carrying `led_sequence: 0` — re-arms, so a deliberate re-trigger of the same sequence just needs a zero in between. `stop()` and `applyTransient()` also re-arm.
+
+**If you drive the display from full-state snapshots, clear `led_sequence` after sending it** rather than relying on the latch — that is what `ultimatedarktower` itself does on every tower response. The latch is a backstop for the receiving side, and it does not cover the physical tower, which sees the raw packet.
 
 The bundled default pack ships in the package — no consumer setup is required for audio to work. See [AUDIO](AUDIO.md) for the full guide, including pack authoring, sequence binding, and bundler-compatibility notes.
 

--- a/packages/display/docs/EXAMPLE.md
+++ b/packages/display/docs/EXAMPLE.md
@@ -111,7 +111,7 @@ Lift this pattern any time your app might recreate the display: keep broken-seal
 
 ## Panel: Light Effects
 
-A dropdown lists every `TOWER_LIGHT_SEQUENCES` entry from UDT — about 20 named sequences (angry, defeat, dungeon idle, gloat, seal reveal, victory, drum rotation, etc.). The Trigger button calls `display.applyState(stateWithSequence, true)`. The `force: true` flag bypasses the audio-dedup so the same sample replays on a second click.
+A dropdown lists every `TOWER_LIGHT_SEQUENCES` entry from UDT — about 20 named sequences (angry, defeat, dungeon idle, gloat, seal reveal, victory, drum rotation, etc.). The Trigger button applies an **empty state first**, then `display.applyState(stateWithSequence, true)` — so every sequence plays from a clean tower, and the `led_sequence: 0` in that empty state re-arms the animator's completed-id latch so clicking the same sequence twice in a row replays it (see [API §the completed-id latch](API.md#led_sequence-is-a-one-shot-trigger--the-completed-id-latch--111)). The `force: true` flag bypasses the audio-dedup so the same sample replays on a second click.
 
 The audio side: the example uses `DEFAULT_SEQUENCE_AUDIO_MAP` (exported from the library) to look up the `TOWER_AUDIO_LIBRARY` sample for each sequence. The bundled default sound pack ships with the package, so playback works out of the box. To rebind sequences to different samples, build your own map with `buildSequenceAudioMap({ victory: 'TowerGloat1', ... })` and pass it via `applyAudioConfig({ sequenceMap, bindSequenceToSample: true })`.
 

--- a/packages/display/docs/SEQUENCE_AUTHORING.md
+++ b/packages/display/docs/SEQUENCE_AUTHORING.md
@@ -625,7 +625,7 @@ Note the **track order** for the flurry phase: `discreteSet` (random drop) is re
 ## Pitfalls and FAQ
 
 **Q: I added a JSON file but the player doesn't seem to use it.**
-Check [src/sequences/jsonSequences.ts](../src/sequences/jsonSequences.ts) — your file needs an entry in both the import block and the `JSON_SEQUENCE_DATA` map. If a sequence id has no entry, `SequenceAnimator.apply(id)` returns `false` and the renderer plays nothing for it. The completeness assertion in `parity.test.ts` should catch this in CI.
+Check [src/sequences/jsonSequences.ts](../src/sequences/jsonSequences.ts) — your file needs an entry in both the import block and the `JSON_SEQUENCE_DATA` map. If a sequence id has no entry, `SequenceAnimator.apply(id)` returns `false` and the renderer plays nothing for it. The completeness assertion in `parity.test.ts` should catch this in CI. (`apply()` also returns `false` for an id that already ran to completion — see [API §the completed-id latch](API.md#led_sequence-is-a-one-shot-trigger--the-completed-id-latch--111) — so when debugging a sequence that "does nothing", check whether a `led_sequence: 0` ever arrived to re-arm it.)
 
 **Q: My JSON parses but the parity test fails.**
 The error message names the first divergence (`tick X, LED (Y, Z): TS=A, JSON=B`). Walk through what each side does at that tick and find where they differ. Common causes: track order wrong, wrong RNG draw order in a custom handler, off-by-one on `endTick` (it's exclusive), wrong `from` on a `subtractAll` shadow.

--- a/packages/display/example/presets.ts
+++ b/packages/display/example/presets.ts
@@ -61,8 +61,8 @@ export function createAllOnState(): TowerState {
 
 export const SEQUENCE_AUDIO_MAP: Readonly<Record<number, number>> = DEFAULT_SEQUENCE_AUDIO_MAP;
 
-export function createSequenceState(sequenceId: number, base?: TowerState): TowerState {
-  const state = base ? structuredClone(base) : createDefaultTowerState();
+export function createSequenceState(sequenceId: number): TowerState {
+  const state = createDefaultTowerState();
   state.led_sequence = sequenceId;
   const sample = SEQUENCE_AUDIO_MAP[sequenceId];
   if (sample !== undefined) {

--- a/packages/display/example/stateEditor.ts
+++ b/packages/display/example/stateEditor.ts
@@ -35,7 +35,16 @@ function applyAndShow(
   els: DomElements,
   fromUserGesture = true,
 ): void {
-  setLastState(state);
+  // Remember a *resting* copy. `led_sequence` and `audio.sample` are both
+  // one-shot triggers, so states derived from this one (drum rotate, config
+  // editor, view switch, pop-out) must not carry them forward and re-fire the
+  // light sequence or its sound. Same rule `UltimateDarkTower` applies to every
+  // tower response — see its `updateTowerStateFromResponse`.
+  setLastState(
+    state.led_sequence || state.audio.sample
+      ? { ...state, led_sequence: 0, audio: { ...state.audio, sample: 0 } }
+      : state,
+  );
   if (fromUserGesture) {
     armTowerAudioFromUserGesture(els);
   }
@@ -150,15 +159,11 @@ export function initStateEditor(
         ];
       const label = meta ? formatSequenceName(meta.name) : `sequence 0x${sequenceId.toString(16)}`;
       setStateName(label, els);
-      getDisplay().showIdle();
-      getReadout().showIdle();
-      applyAndShow(
-        createSequenceState(sequenceId, getLastState() ?? undefined),
-        getDisplay,
-        getReadout,
-        setLastState,
-        els,
-      );
+      // Empty state first: every sequence plays from a clean tower. The
+      // `led_sequence: 0` it carries is also what re-arms SequenceAnimator, so
+      // clicking the same sequence twice in a row replays it.
+      applyAndShow(createEmptyState(), getDisplay, getReadout, setLastState, els);
+      applyAndShow(createSequenceState(sequenceId), getDisplay, getReadout, setLastState, els);
     });
   }
 

--- a/packages/display/src/sequences/SequenceAnimator.ts
+++ b/packages/display/src/sequences/SequenceAnimator.ts
@@ -10,8 +10,10 @@ type GSAPTimeline = ReturnType<typeof gsap.timeline>;
 /**
  * Drives the active firmware-style led_sequence on top of the per-LED renderer.
  * One active timeline at a time; identical-id reapplies are no-ops, distinct
- * ids cancel-and-restart. Returns whether a sequence is currently driving the
- * LEDs so callers can suppress their normal per-LED replay.
+ * ids cancel-and-restart, and an id that already ran to completion stays
+ * latched off until an `apply(0)` re-arms it. Returns whether a sequence is
+ * currently driving the LEDs so callers can suppress their normal per-LED
+ * replay.
  *
  * Backed exclusively by the JSON-driven `SequencePlayer`. Sequence data lives
  * in `src/sequences/data/*.json`, parsed at module load into
@@ -29,11 +31,22 @@ export class SequenceAnimator {
    * mid-playback. Cleared automatically when the timeline completes.
    */
   private currentIsTransient = false;
+  /**
+   * Id of the last sequence that ran to completion. `led_sequence` is a
+   * one-shot trigger riding inside a full-state snapshot, and the snapshot
+   * keeps carrying it after the sequence ends — so without this latch every
+   * later `applyState` (drum rotate, LED click, view switch, GLB reload)
+   * would rebuild the timeline and replay it. `apply(0)`, `stop()` and
+   * `applyTransient()` all re-arm.
+   */
+  private lastCompletedId = 0;
 
   constructor(private readonly deps: SequenceAnimatorDeps) {}
 
   apply(sequenceId: number, onComplete: () => void): boolean {
     if (sequenceId === 0) {
+      // A zero between triggers means "fire again next time".
+      this.lastCompletedId = 0;
       // Don't kill a transient-driven sequence with state-mirror resets.
       if (this.currentIsTransient && this.currentTimeline) {
         return true;
@@ -43,6 +56,10 @@ export class SequenceAnimator {
     }
     if (sequenceId === this.currentSequenceId && this.currentTimeline) {
       return true;
+    }
+    // Already played to completion — this is a stale snapshot, not a retrigger.
+    if (sequenceId === this.lastCompletedId) {
+      return false;
     }
     this.stop();
 
@@ -101,6 +118,7 @@ export class SequenceAnimator {
     this.currentTimeline = null;
     this.currentSequenceId = 0;
     this.currentIsTransient = false;
+    this.lastCompletedId = 0;
   }
 
   isActive(sequenceId: number): boolean {
@@ -113,6 +131,7 @@ export class SequenceAnimator {
 
   private wrapComplete(onComplete: () => void): () => void {
     return () => {
+      this.lastCompletedId = this.currentSequenceId;
       this.currentSequenceId = 0;
       this.currentTimeline = null;
       this.currentIsTransient = false;

--- a/packages/display/tests/unit/SequenceAnimator.test.ts
+++ b/packages/display/tests/unit/SequenceAnimator.test.ts
@@ -74,6 +74,49 @@ describe('SequenceAnimator state-driven apply (existing behavior, unchanged)', (
   });
 });
 
+describe('SequenceAnimator completed-id latch', () => {
+  const noop = (): void => {
+    /* */
+  };
+
+  it('a completed sequence does not replay when a stale snapshot re-applies the same id', () => {
+    const { animator } = makeAnimator();
+    animator.apply(SEQ_DEFEAT, noop);
+    gsapMock.__getTimelines().at(-1)!.__fireComplete();
+
+    // Every later applyState (drum rotate, LED click, view switch) still
+    // carries the spent led_sequence — it must not rebuild the timeline.
+    const before = gsapMock.__getTimelines().length;
+    expect(animator.apply(SEQ_DEFEAT, noop)).toBe(false);
+    expect(gsapMock.__getTimelines().length).toBe(before);
+    expect(animator.isActive(SEQ_DEFEAT)).toBe(false);
+  });
+
+  it('apply(0) re-arms, so the same id fires again afterwards', () => {
+    const { animator } = makeAnimator();
+    animator.apply(SEQ_DEFEAT, noop);
+    gsapMock.__getTimelines().at(-1)!.__fireComplete();
+    animator.apply(0, noop);
+
+    const before = gsapMock.__getTimelines().length;
+    expect(animator.apply(SEQ_DEFEAT, noop)).toBe(true);
+    expect(gsapMock.__getTimelines().length).toBe(before + 1);
+    expect(animator.isActive(SEQ_DEFEAT)).toBe(true);
+  });
+
+  it('applyTransient still re-fires an id that just completed', () => {
+    const { animator } = makeAnimator();
+    animator.applyTransient(SEQ_DEFEAT);
+    gsapMock.__getTimelines().at(-1)!.__fireComplete();
+
+    // playSequence() is an explicit command, never latched.
+    const before = gsapMock.__getTimelines().length;
+    expect(animator.applyTransient(SEQ_DEFEAT)).toBe(true);
+    expect(gsapMock.__getTimelines().length).toBe(before + 1);
+    expect(animator.isActive(SEQ_DEFEAT)).toBe(true);
+  });
+});
+
 describe('SequenceAnimator transient mode (new in 0.7.0)', () => {
   it('applyTransient(seqId) starts the sequence and returns true', () => {
     const { animator } = makeAnimator();


### PR DESCRIPTION
## The bug

In the Display example: trigger a light sequence, let it play out, then rotate a drum — the sequence plays again. Same for clicking an LED, switching 2D/3D, popping out, or applying edited JSON.

## Root cause

`led_sequence` and `audio.sample` are **one-shot edge triggers that ride inside a full-state snapshot**. `SequenceAnimator.apply()` only deduplicated a same-id re-apply *while the timeline was alive* — `wrapComplete()` zeroes `currentSequenceId` on completion — so from that instant any later `applyState` still carrying the spent id rebuilt the timeline and replayed the whole sequence.

Every path that re-applies a stored state hit it, not just drum rotate:

| Site | Why it re-applies |
|---|---|
| `TowerDisplay.ts:226` | `clearLedOverrides()` re-applies `getResolvedState()` — this is where the drum-click replay actually originates, one line *before* the drum state lands |
| `TowerDisplay.ts:239` | `handleLedClick()` — the "turn on a light" case |
| `Tower3DView.ts:1602` | re-apply after GLB load |
| `rendererController.ts:175` | renderer switch / pop-out |
| `configEditor.ts:164` | apply edited JSON |
| `creator-adapters/display.ts:171,186` | long-lived `current` snapshot re-sent after every op |

## The fix

**One guard at the choke point** every one of those funnels through, rather than a patch per caller.

- **`SequenceAnimator`** latches the id of the last sequence that ran to completion and won't rebuild it. `apply(0)`, `stop()` and `applyTransient()` all re-arm — so `playSequence()` is never suppressed, and a deliberate re-trigger of the same sequence just needs a zero in between. The latched call returns `false` so the renderer resumes normal per-LED replay for the incoming state instead of freezing on the sequence's last frame.
- **Example**: the Trigger Sequence button applies an empty state before firing (every sequence starts from a clean tower, and that `led_sequence: 0` is what re-arms the latch). `applyAndShow` now remembers a *resting* copy with both one-shot triggers zeroed — the sequence's bound **sound** was replaying for the same reason, compounded by the example passing `force: true` on every action, which exists specifically to bypass the audio dedup.
- **`creator-adapters`**: `light.named` stamped `current.led_sequence` and never cleared it — the only write to that field, while `current.audio` *was* already reset in both places. Since `packFullState()` packs byte 18 into every relayed snapshot, the **physical tower** re-ran the light sequence on each later op. The latch fixes its display side; only the hardware path needed this.

This mirrors what `ultimatedarktower` already does in `updateTowerStateFromResponse`, whose comment names this exact failure mode.

## Behaviour notes

- LEDs are **not** blanked when a sequence ends — they stay where the timeline left them, and the next action renders normally from there. No forced blackout, no drum reset.
- Rotating a drum *while* a sequence sound is playing now stops it rather than restarting it, matching core's model of zeroing `audio.sample` per response.
- Known limitation: a sequence *interrupted* by a different id (never completed) isn't latched. No caller in this repo carries two sequence ids in one snapshot lineage.

## Testing

- `pnpm run ci` green across every workspace.
- 3 new `SequenceAnimator` tests: stale same-id re-apply doesn't rebuild; `apply(0)` re-arms; `applyTransient` still re-fires a just-completed id.
- Manual in `pnpm dev:display`: sequence → finish → rotate drum / click LED / switch 2D↔3D → no replay of lights or audio; same sequence twice in a row still replays.

Two patch changesets included (`ultimatedarktowerdisplay`, `@udtc/adapters`).